### PR TITLE
feat(workshop): HackSprint1 kit + gap pack (GH source / PR sink / Decision Gate)

### DIFF
--- a/README-RU.md
+++ b/README-RU.md
@@ -1,0 +1,113 @@
+# Whilly Orchestrator (RU)
+
+[![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Workshop kit](https://img.shields.io/badge/workshop-HackSprint1-blue.svg)](docs/workshop/INDEX.md)
+
+Python-реализация **техники Ralph Wiggum** — непрерывного цикла, в котором AI-агент (Claude CLI) забирает задачи с board'а и выполняет их одну за другой, пока не закончатся или не сработает budget/timeout. Ralph TUI-дашборд, параллельные агенты в tmux + git worktree, decomposer, TRIZ analyzer и PRD wizard в комплекте.
+
+> "I'm helping!" — Ralph Wiggum
+
+📘 [Full English README](README.md) · 🎓 [Workshop kit (HackSprint1)](docs/workshop/INDEX.md)
+
+## Что делает
+
+Whilly крутит loop: взять pending-задачу → передать LLM-агенту → проверить → коммит → следующая. Работает, пока board не пуст, бюджет не исчерпан или вы не остановили. Параллельный режим запускает несколько агентов в tmux pane'ах или git worktree'ах.
+
+Техника впервые описана в [посте Ghuntley о Ralph Wiggum](https://ghuntley.com/ralph/), стала популярна в Claude Code сообществе. Whilly — batteries-included оркестратор с дашбордом и task lifecycle вокруг этого цикла.
+
+## Возможности
+
+- **Непрерывный agent loop** — pending-задачи из JSON, прогон через Claude CLI, retry на transient errors.
+- **Rich TUI dashboard** — живой прогресс, токены, cost, статусы; hotkeys для pause/reset/skip.
+- **Параллельный запуск** — tmux pane'ы или git worktree'ы, до N одновременно с budget/deadlock guards.
+- **Task decomposer** — LLM-разбивка слишком крупных задач на подзадачи.
+- **PRD wizard** — интерактивная генерация PRD, потом auto-derive task'ов.
+- **TRIZ analyzer** — выявление противоречий и инвентивных принципов для неоднозначных задач.
+- **State store** — состояние задач переживает рестарт, per-task per-iteration логи.
+
+## Установка
+
+```bash
+pip install whilly-orchestrator
+```
+
+Или из исходников:
+
+```bash
+git clone https://github.com/mshegolev/whilly-orchestrator
+cd whilly-orchestrator
+pip install -e .
+```
+
+Требуется [Claude CLI](https://docs.claude.com/en/docs/claude-code) в `PATH` (или `CLAUDE_BIN`).
+
+## Quick start
+
+1. Создай `tasks.json`:
+
+```json
+{
+  "project": "health-endpoint",
+  "tasks": [
+    {
+      "id": "TASK-001",
+      "phase": "Phase 1",
+      "category": "functional",
+      "priority": "high",
+      "description": "Добавь /health endpoint, возвращающий {\"status\":\"ok\"}",
+      "status": "pending",
+      "dependencies": [],
+      "key_files": ["app/server.py"],
+      "acceptance_criteria": ["GET /health возвращает 200 с {\"status\":\"ok\"}"],
+      "test_steps": ["curl -s localhost:8000/health"]
+    }
+  ]
+}
+```
+
+2. Запусти Whilly (2 параллельных агента, бюджет $5):
+
+```bash
+WHILLY_MAX_PARALLEL=2 WHILLY_BUDGET_USD=5 whilly tasks.json
+```
+
+3. Смотри dashboard. `q` — выйти, `d` — детали task, `l` — лог агента, `t` — список задач, `h` — помощь.
+
+## Workshop kit (HackSprint1)
+
+Whilly идёт с **workshop kit для HackSprint1** — hands-on на 90 минут от `pip install` до работающего self-hosting bootstrap demo:
+
+- **Track A (`tasks.json`)** — без GitHub auth, ~30 минут.
+- **Track B (GitHub Issues)** — полный e2e с созданием PR, ~60 минут.
+
+Содержит BRD, PRD, 12 ADR'ов, sample plans, roadmap. См. [docs/workshop/INDEX.md](docs/workshop/INDEX.md) — полное руководство. RU/EN.
+
+## Конфигурация
+
+Большинство параметров — env vars с префиксом `WHILLY_`:
+
+| Variable | Default | Назначение |
+|---|---|---|
+| `WHILLY_MODEL` | `claude-opus-4-6[1m]` | id Claude модели |
+| `WHILLY_MAX_PARALLEL` | `3` | одновременных агентов (1 = последовательно) |
+| `WHILLY_BUDGET_USD` | `0` | hard cap; 80% — warning, 100% — стоп |
+| `WHILLY_TIMEOUT` | `0` | wall-clock cap в секундах |
+| `WHILLY_USE_TMUX` | `1` | tmux для параллельных агентов |
+| `WHILLY_WORKTREE` | `0` | git worktree per task (нужен `MAX_PARALLEL>1`) |
+| `WHILLY_HEADLESS` | auto | CI mode — JSON на stdout |
+
+## Troubleshooting
+
+| Проблема | Решение |
+|---|---|
+| `gh auth status` возвращает 401 | `unset GITHUB_TOKEN`, потом `gh auth login` |
+| `claude: command not found` | Установи Claude CLI или укажи путь через `CLAUDE_BIN` |
+| Dashboard ломается на узком терминале | `WHILLY_HEADLESS=1 whilly tasks.json` |
+| Бюджет упал в 0 раньше времени | `WHILLY_BUDGET_USD=N` (N>0) |
+| `tmux ls` пуст после dispatch | tmux не установлен или `WHILLY_USE_TMUX=0` — whilly fallback'ит на subprocess |
+| Агент в loop'е без `done` | проверь маркер `<promise>COMPLETE</promise>` в результате |
+
+## Лицензия
+
+MIT — см. [LICENSE](LICENSE).

--- a/docs/workshop/BRD-Whilly.md
+++ b/docs/workshop/BRD-Whilly.md
@@ -1,0 +1,319 @@
+---
+title: HackSprint1 — Agents Orchestrator — BRD
+type: brd
+created: 2026-04-18
+updated: 2026-04-20
+status: v2 · team-locked after kickoff
+audience: bilingual (RU primary, EN summary)
+related:
+  - PRD-Whilly.md
+  - READINESS-REPORT.md
+  - ROADMAP.md
+  - adr/README.md
+---
+
+# HackSprint1 — Agents Orchestrator — BRD
+
+> **Назначение:** объяснить команде HackSprint1 — что мы делаем за этот спринт, на какие правила сдаёмся, какие минимальные требования закрываем, какие опциональные блоки приоритетны, какие риски и кто кураторы. PRD (как именно строим) — отдельный документ.
+>
+> **EN:** Hackathon-grade BRD for the HackSprint1 sprint. Minimum requirements, optional blocks priority, curator stakeholders, voting prize. Not a corporate BRD.
+
+> ⚠️ Контекст этого BRD — **не корпоративный продукт**, а 10-дневный спринт по правилам клуба. Метрики, бюджет и dеливерэблы соответствуют формату хакатона, а не enterprise-cycle.
+
+---
+
+## 1. Executive Summary
+
+Команда (2-4 человека, опционально соло) реализует **Agents Orchestrator** — систему «задача → AI-агент пишет код → PR → retry при ошибке → демо», которая закрывает все 5 минимальных требований клуба HackSprint1 и максимально отрабатывает 2-3 опциональных блока.
+
+- **Старт:** 18 апреля 2026 (регистрация 17 апреля).
+- **Дедлайн демо-видео:** 4 мая 2026, 10:00 MSK.
+- **Голосование:** 8 мая 2026 (приз — 3 месяца подписки победителю).
+- **Длительность:** ~10 рабочих дней + буфер на видео.
+- **Цель:** зачёт по правилам клуба + произвести впечатление на голосовании.
+
+**Унесём с собой:** компетенция по orchestration AI-агентов, рабочий прототип, демо-видео для CV/портфолио, общий чат команды с накопленным контекстом.
+
+---
+
+## 2. Business Context
+
+> Эта секция — для внутренней мотивации команды. Не входит в контракт спринта.
+
+### Почему сейчас
+
+1. **2025-2026 — год agent orchestration.** Codex, Claude Code, Cursor Composer, Devin, Replit Agent — все рынки переходят к "агенты закрывают задачи".
+2. **Стоимость токенов упала в 10-20×** за два года.
+3. **Vendor lock-in** становится реальной болью. Свой open-source orchestrator — страховка.
+4. **Hackathon-формат** даёт permission поэкспериментировать с инструментом, который иначе не возьмут в работу.
+
+---
+
+## 3. Стейкхолдеры
+
+| Роль | Кто | Что хочет |
+|---|---|---|
+| **Команда спринта** | 2-4 человека (или соло) | сдать проект по правилам, не сгореть, унести демо в портфолио |
+| **Кураторы клуба** | Геннадий Евстратов · Степан Гончаров · Михаил Мужаровский | видеть прогресс на check-in'ах, помочь с демо-форматом, зачесть проект |
+| **Зрители голосования** | community клуба | впечатлиться демо-видео, проголосовать |
+
+Никаких Engineering Lead / Security Review / CFO / Junior'ов — этих ролей в хакатоне нет. Подписи и approvals не требуются.
+
+---
+
+## 4. Goals
+
+### Primary
+
+| # | Goal | Outcome |
+|---|---|---|
+| **G1** | Knowledge Foundation | каждый участник может на собесе/в чате объяснить архитектуру orchestrator'а |
+| **G2** | Working MVP | end-to-end закрыт хотя бы 1 реальный issue в реальном репо без ручного вмешательства |
+| **G3** | Scalability Path | команда понимает что нужно для production (что в MVP-scope, что нет) |
+
+### Secondary
+
+| # | Goal | Outcome |
+|---|---|---|
+| **G4** | Portfolio | каждый участник может добавить "Built agent orchestrator (HackSprint1, 2026)" в CV / LinkedIn / портфолио проектов |
+| **G5** | Vendor independence | архитектура позволяет заменить Claude на другой backend без переписывания core |
+| **G6** | Voting impression | произвести впечатление на голосовании 8 мая (приз — 3 мес подписки) |
+
+### Non-goals
+
+- Production-grade deployment (K8s, observability, on-call).
+- Multi-tenant / SaaS для внешних клиентов.
+- Автоматический merge в main (всегда human review).
+- Поддержка >2 типов задач в MVP (выберем 1 на kickoff, см. D6).
+- HackSprint2/3/4 как заранее запланированный roadmap (этих спринтов не существует — мы их не планируем).
+
+---
+
+## 5. Success Criteria (KPIs) и зачётный gate
+
+### Зачётный gate (правила клуба)
+
+> Проект **зачтён**, если выполнены **все 5 минимальных требований**:
+>
+> 1. Задача поступает из источника (GH Issues / Linear / ручной список).
+> 2. Агент пишет код для задачи.
+> 3. Агент создаёт PR.
+> 4. **Retry-петля при ошибке** (агент не падает на первой неудаче — пытается ещё раз).
+> 5. Запуск на **реальном репо** (sandbox/собственное), не на mock'е.
+>
+> + демо-видео записано и приложено до 10:00 MSK 4 мая.
+
+### Метрики
+
+| # | Метрика | Target | Тип | Как измеряем |
+|---|---|---|---|---|
+| **K1** | End-to-end demo | 1 issue полностью закрыт агентом (issue → PR → passing CI) | gate | live demo / видео |
+| **K3** | Cost per issue | ≤ $0.50 среднее на задачи выбранного типа | informational | JSONL `agent.done` events |
+| **K4** | Success rate | ≥ 40% (MVP) на конкретном типе задач (см. D6) | informational | % issues closed без ручной правки |
+| **K5** | Team learning | каждый участник может ответить на 10 ключевых вопросов архитектуры | gate-soft | опрос после спринта |
+| **K7** | Optional blocks | реализовано 2-3 из 8 опциональных блоков | informational | self-report + linkable code |
+| **K8** | Demo video | записано и загружено до дедлайна (4 мая 10:00 MSK) | gate | URL приложен к submit |
+
+KPI K2 (lead-time на boilerplate с 1ч до 15мин) и K6 (next-feature за следующий спринт) сознательно убраны: review-time автоматизацией не сокращается, и следующего планового спринта не существует.
+
+---
+
+## 6. Что мы унесём с собой
+
+> Без ROI-таблиц и employer-branding. Хакатон — это про опыт, не про экономику команды.
+
+| Что | Кто получает | Когда |
+|---|---|---|
+| Компетенция Ralph-loop / agent orchestration | каждый участник | в процессе |
+| Рабочий прототип (репо + README) | команда / личное портфолио | к 4 мая |
+| Демо-видео ~3 мин | каждый участник | к 4 мая |
+| Дополнительные релевантные строки в CV / LinkedIn | каждый | бонус навсегда |
+| 3 месяца подписки (приз победителю) | топ голосования | 8 мая |
+
+---
+
+## 7. Scope (бизнес-уровень)
+
+### In scope (MVP — 5 минимальных требований)
+
+1. **Один источник задач** (GitHub Issues — выбран по минимуму интеграций).
+2. **Один AI backend** (TBD на kickoff — D3).
+3. **Один тип задач** (выбираем на kickoff — D6).
+4. **Retry-петля** при ошибке агента (exponential backoff, max N попыток).
+5. **Запуск на реальном репо** (sandbox под HackSprint1).
+6. **PR creation** обязателен (никаких direct push в main).
+
+### Optional blocks — приоритет
+
+| Приоритет | Блок | Почему |
+|---|---|---|
+| **High** | Observability (JSONL + cost tracking) | дёшево, эффектно для демо |
+| **High** | Quality gates (линтер + тесты в CI/локально) | повышает success rate |
+| **High** | Agentic code review (агент-ревьюер до merge) | wow-эффект для голосования |
+| **Mid** | Параллельные реализации (несколько агентов на одной задаче, выбор лучшего) | технически интересно, дорого по токенам |
+| **Mid** | Выбор стратегии по типу задачи (router для разных prompt strategies) | требует больше кода |
+| **Low / skip** | Декомпозиция крупных задач | помогает на больших задачах, у нас MVP scope маленький |
+| **Low / skip** | Merge conflicts resolution | редкий edge case |
+| **Low / skip** | Долгосрочная память агента | вне нашего scope |
+
+**Цель: реализовать 2-3 high-priority блока**.
+
+### Out of scope (явно)
+
+- Auto-merge PR без человека.
+- Мульти-репо.
+- Distributed queue (Redis/NATS).
+- Web UI / SaaS.
+- HackSprint2/3 — никаких запланированных продолжений.
+
+---
+
+## 8. Constraints
+
+| Тип | Ограничение |
+|---|---|
+| **Время** | 10 рабочих дней (18 апреля — 1 мая) + буфер до 4 мая для видео |
+| **Команда** | 2-4 человека (соло возможно, но scope тогда сокращается до MVP без optional блоков) |
+| **Бюджет AI** | ~$300 личных средств на токены (compensation от клуба отсутствует — бюджет личный, не компенсируется). Рекомендуется hard-cap WHILLY_BUDGET_USD=300 на весь спринт |
+| **Стек** | **Python**. Subprocess `claude -p` vs `claude-agent-sdk` — решается на kickoff (см. D7) |
+| **Security** | агент **никогда** не пушит в main напрямую, только PR; sandbox-репо изолирован; secrets через `.env` + gitignore |
+| **Tooling** | `gh` CLI у каждого участника, git CLI, общий sandbox-репо, общий чат команды |
+| **Human gate** | каждый PR требует ручного merge (нет auto-merge) |
+| **Время суток** | вечерами/выходными — реалистичный режим для хакатона; не "только в рабочие часы" |
+
+---
+
+## 9. Assumptions
+
+- У команды есть доступ к **воркспейсу со спринтом** (Telegram чат клуба + чат команды).
+- **Кураторы доступны для вопросов** через Telegram (response time — часы, не минуты).
+- У каждого участника есть Anthropic / OpenAI API key (личный или corp-key, на личном бюджете).
+- У каждого установлены `gh` CLI и git CLI.
+- Есть **тестовый sandbox-репо** на GitHub, где можно безопасно экспериментировать.
+- Интернет доступен (для API).
+- Минимум 1 check-in с куратором запланирован на день 4-5 спринта.
+
+---
+
+## 10. Risks
+
+| # | Риск | Likelihood | Impact | Mitigation |
+|---|---|---|---|---|
+| **R1** | Команда не успеет MVP за 10 дней | Средняя | Высокий | Scope aggressive cut: 1 источник, 1 backend, 1 тип задач. Жёсткий приоритет минимальных требований над optional блоками. |
+| **R2** | Агент жжёт токены сверх личного бюджета | Высокая | Средний | Hard cap `WHILLY_BUDGET_USD=300` (или меньше per-задаче). Декомпозируем дорогие задачи или режем их. |
+| **R3** | Агент ломает sandbox-репо | Средняя | Низкий (sandbox же) | Только worktree + PR, никогда direct push в main. |
+| **R4** | **Утечка секретов в промпт → leak в API / в issue body / в PR description** | Высокая | **Высокий** | trufflehog/gitleaks pre-prompt scan покрывает только часть вектора. Дополнительно: ручной review issues перед label `whilly:ready`, никаких real env vars в sandbox-репо. **Обсудить отдельно на kickoff.** |
+| **R5** | Команда не договорится о scope на kickoff | Средняя | Средний | BRD + PRD + 1-час facilitated kickoff с чёткой повесткой (D3, D6, D7). |
+| **R6** | API rate limits (Anthropic/OpenAI) | Низкая | Низкий | Backoff (уже встроен в whilly), fallback на 2-й backend если есть время реализовать. |
+| **R7** | Результат MVP не впечатляет на голосовании | Средняя | Средний | Демо готовится с **дня 5**, черновое видео ко дню 8, чистовое — за 2 дня до дедлайна. |
+| **R8** | После спринта никто не дорабатывает | Высокая | Низкий | Это нормально для хакатона. Зафиксируем lessons learned, уйдём с портфолио. |
+| **R9** | **Демо-видео не записано / записано плохо** | Средняя | **Высокий** (проект не зачтётся) | Скелет демки со дня 5, прогон с куратором день 8-9, чистовая запись за 2 дня до дедлайна. Pre-recorded backup всегда лучше live demo. |
+| **R10** | PR review bottleneck на sandbox-репо (агент нагенерит больше чем успеваем смотреть) | Средняя | Средний | Decision Gate (отказ от мусорных issues), draft PR mode, ограничить max in-flight PRs. |
+| **R11** | **Prompt injection через issue body** | Средняя | Высокий | Ограничить агенту `--allowedTools` (запретить exec на критичных системах), sandbox-репо изолирован, не подключаем к нему secrets. |
+
+---
+
+## 11. Decision Log
+
+| # | Вопрос | Решение | Дата |
+|---|---|---|---|
+| **D1** | Язык реализации | Python (не Go/bash) — команде ближе | 2026-04-18 |
+| **D2** | Референс-проекты + материалы кураторов | grkr (минимальная модель), yolo-runner (как цель), 3 сессии кураторов в клубе (см. Notebook) | 2026-04-18 |
+| **D3** | AI backend на MVP | TBD на kickoff (Claude vs Codex) | — |
+| **D4** | Источник задач | GitHub Issues (минимум интеграций — `gh` CLI уже у всех) | 2026-04-18 |
+| **D5** | Изоляция | git worktree (взято у grkr) | 2026-04-18 |
+| **D6** | **Какой тип задачи берём первым** (определяет K4) | TBD на kickoff. Кандидаты: README-badge, healthcheck endpoint, dependency bump, README typo fix, test scaffold | — |
+| **D7** | **Subprocess `claude -p` vs `claude-agent-sdk`** | TBD на kickoff. Subprocess проще и наследует пользовательскую конфигурацию; SDK даёт более тонкий контроль | — |
+
+> D3, D6, D7 — обязательно решены до конца Day 1 (kickoff).
+
+---
+
+## 12. Timeline (10 рабочих дней)
+
+> Старт регистрации: 17 апреля. Старт работы: 18 апреля. Hard deadline submit: **4 мая 10:00 MSK**. Голосование: 8 мая.
+
+| Day | Дата | Цель | Deliverable |
+|---|---|---|---|
+| **1** | Sat 18 апр | Kickoff | Roles assigned, scope locked, D3 / D6 / D7 решены, sandbox-репо создан |
+| **2-3** | Sun 19 — Mon 20 апр | MVP-скелет | Runner + worktree + publisher (PR creator) — компилируется и запускается на sample |
+| **4** | Tue 21 апр | Первое e2e | Прогон на 1 реальной задаче в sandbox: issue → агент → PR (retry может быть mock) |
+| **5** | Wed 22 апр | Retry-петля + check-in куратора | Real retry on failure, минимальное требование #4 закрыто. Show curator → feedback. |
+| **6-7** | Thu 23 — Fri 24 апр | 1-2 опциональных блока (high priority) | Observability + Quality gates — JSONL логи и линтер/тесты в pipeline |
+| **8** | Sat 25 апр | 3-й опциональный блок / стабилизация | Agentic code review ИЛИ buffer для багфиксов |
+| **9** | Sun 26 апр | Черновик демо-видео | Записать draft, показать куратору, собрать feedback |
+| **10** | Mon 27 апр | Чистовое видео + README + submit-prep | Финальная запись, README репо обновлён, готов к submit |
+| **buffer** | 28 апр — 4 мая | Polishing, rollback фиксы | Никаких новых фич — только стабилизация |
+| **Submit** | Mon 4 мая 10:00 MSK | **Hard deadline** | Видео + repo URL присланы кураторам |
+| **Voting** | Thu 8 мая | Голосование | Result announcement |
+
+> ⚠️ Сегодня **20 апреля** = Day 3. Если читаете этот BRD позже — пересчитайте позицию относительно дедлайна 4 мая.
+
+> 💡 **Check-in с куратором (Day 4-5)** — самый недооценённый ресурс. 30 минут разговора стоит часов догадок. **Запланировать обязательно.**
+
+---
+
+## 13. Что бы доделали сами, если бы продолжили
+
+> Это не roadmap клуба — это наши собственные идеи на «если когда-нибудь захотим вернуться».
+
+- Multi-backend (Claude + Codex + Gemini) с fallback'ом.
+- DAG зависимостей между задачами.
+- Production deploy (K8s + dashboard + team-wide rollout).
+- Multi-repo адаптеры (Linear / Jira / GitLab Issues).
+- Self-healing с другим промптом при повторяющейся ошибке.
+- MCP-server интерфейс (whilly tools published as MCP).
+
+Если кто-то из команды захочет — это подходящие follow-up issues для backlog.
+
+---
+
+## 14. Approval
+
+> Approval-блок не требуется. HackSprint1 — community-format, без формальных подписей.
+
+Единственный «approval-эквивалент»: **зачтено / не зачтено** кураторами после submit'а 4 мая.
+
+---
+
+## 15. Глоссарий
+
+- **Ralph Wiggum loop** — техника непрерывного цикла, где AI-агент берёт задачу за задачей. Названа по фразе "I'm helping!" из Симпсонов. См. [Ghuntley's post](https://ghuntley.com/ralph/).
+- **Agent / AI agent** — LLM с доступом к tools (file system, git, subprocess), способная выполнять многошаговые задачи.
+- **Orchestrator** — программа, управляющая циклом «источник задач → агент → проверка → commit/PR».
+- **Worktree** — git-механизм, позволяющий иметь несколько рабочих копий одного репо.
+- **Decision Gate** — точка перед имплементацией, где агент решает «берусь / отказываюсь» (экономия токенов).
+- **MCP (Model Context Protocol)** — стандарт от Anthropic для подключения внешних tools к AI-агентам.
+- **JSONL event log** — построчный JSON-лог событий (1 объект на строку), удобно парсить.
+- **Agent SDK** — `claude-agent-sdk` (Python пакет от Anthropic), даёт programmatic agent loop без CLI.
+- **stream-json** — потоковый формат вывода Claude CLI (`--output-format stream-json`), позволяет читать события агента в реальном времени.
+- **Quality gate** — автоматическая проверка (линтер, тесты, security scan), без прохождения которой PR не считается ready.
+- **Retry-loop** — встроенная в orchestrator петля «попробовать → fail → подождать → попробовать снова с exp.backoff». Минимальное требование клуба №4.
+- **gh CLI** — официальный GitHub CLI tool. Используется и для чтения issues, и для создания PR.
+- **Sandbox-репо** — отдельный публичный/приватный GitHub репозиторий, выделенный под эксперименты HackSprint1. Не production.
+
+---
+
+## Приложения
+
+### A. Связанные документы
+
+- [PRD-Whilly.md](PRD-Whilly.md) — что и как строим (технически).
+- [READINESS-REPORT.md](READINESS-REPORT.md) — gap analysis whilly vs HackSprint1 scope.
+- [ROADMAP.md](ROADMAP.md) — декомпозиция задач.
+- [adr/](adr/) — Architecture Decision Records (12 записей).
+- [TUTORIAL.md](TUTORIAL.md) — пошаговое руководство.
+
+### B. Внешние материалы
+
+- [stepango/grkr](https://github.com/stepango/grkr) — bash-референс.
+- [egv/yolo-runner](https://github.com/egv/yolo-runner) — Go-референс.
+- [Anthropic — Building Effective Agents](https://www.anthropic.com/research/building-effective-agents) — обязательная статья.
+- [NotebookLM с материалами](https://notebooklm.google.com/notebook/d4c73023-591e-4583-b26f-864be367749f) — спрашивай на русском.
+- 3 сессии кураторов клуба (записи доступны в Telegram-чате).
+- Telegram-чат клуба: общие объявления, кураторы.
+- Telegram кураторы: [@jewpacabra](https://t.me/jewpacabra), [@stepango](https://t.me/stepango), [@miky_muz](https://t.me/miky_muz).
+
+---
+
+**Status:** v2 · 2026-04-20 · team-locked after kickoff. Будет финализирован после check-in'а с куратором (Day 4-5).

--- a/docs/workshop/INDEX.md
+++ b/docs/workshop/INDEX.md
@@ -1,0 +1,68 @@
+# Whilly Workshop Kit — Index / Индекс
+
+> **EN:** Self-paced and instructor-led workshop kit for the **Ralph Wiggum loop**: drive Claude Code agents around a task board until the work is done. Built on top of `whilly-orchestrator`.
+>
+> **RU:** Воркшоп-кит для **Ralph Wiggum loop**: непрерывный цикл «задача → агент → ревью → следующая». Базируется на `whilly-orchestrator`.
+
+---
+
+## Reading order / Порядок чтения
+
+| # | Doc | Read when / Когда читать |
+|---|---|---|
+| 1 | [TUTORIAL.md](TUTORIAL.md) | Hands-on first run / Первый запуск, hands-on (~60 min) |
+| 2 | [BRD-Whilly.md](BRD-Whilly.md) | Why we built it, KPIs / Зачем, бизнес-цели, KPI |
+| 3 | [PRD-Whilly.md](PRD-Whilly.md) | What we built, contracts / Архитектура, контракты, scope |
+| 4 | [READINESS-REPORT.md](READINESS-REPORT.md) | Workshop fitness check / Готовность к воркшопу |
+| 5 | [ROADMAP.md](ROADMAP.md) | What's next / Дорожная карта расширений |
+| 6 | [adr/](adr/) | Why these decisions / Почему такие архитектурные решения |
+
+---
+
+## Quick links / Быстрые ссылки
+
+- **Source code:** [`/whilly/`](../../whilly/) — orchestrator package
+- **CLI reference:** [`Whilly-Usage.md`](../Whilly-Usage.md)
+- **Task schema:** [`Whilly-Interfaces-and-Tasks.md`](../Whilly-Interfaces-and-Tasks.md)
+- **Sample tasks:** [`examples/workshop/tasks.json`](../../examples/workshop/tasks.json)
+- **Demo issues:** open issues with label `whilly:ready` in this repo
+
+---
+
+## What you can build in one workshop day / Что соберёте за один день воркшопа
+
+```
+┌─────────────────────────────────────────────────────┐
+│                ONE-DAY WORKSHOP TARGET              │
+└─────────────────────────────────────────────────────┘
+
+  Hour 1:   Install + first run on tasks.json
+            (Ralph loop for 1 task, dashboard appears)
+
+  Hour 2-3: Add GitHub Issues source — agent picks
+            real open issue from your repo
+
+  Hour 4:   Add PR sink — agent opens a PR you can review
+
+  Hour 5:   Add Decision Gate — agent refuses unclear
+            issues with `needs-clarification`
+
+  Hour 6:   Self-hosting bootstrap — point whilly at
+            its own repo, watch it close 1 issue end-to-end
+
+  ─── "I'm helping!" ──────────────────────────────────
+```
+
+---
+
+## Audience / Аудитория
+
+- **Engineers** who never built an agent loop and want a 1-day on-ramp.
+- **Tech leads** evaluating Ralph-style automation against Devin/Cursor/Codex.
+- **Workshop facilitators** who need a working reference + lecture material.
+
+No prior agent experience required. Python 3.10+, git, `gh` CLI, Anthropic API key.
+
+---
+
+**Status:** v1 · 2026-04-20 · maintained alongside the codebase.

--- a/docs/workshop/PRD-Whilly.md
+++ b/docs/workshop/PRD-Whilly.md
@@ -1,0 +1,380 @@
+---
+title: Whilly Orchestrator — Product Requirements Document
+type: prd
+created: 2026-04-20
+status: v1
+audience: bilingual (RU primary, EN summary)
+related:
+  - BRD-Whilly.md
+  - READINESS-REPORT.md
+  - ROADMAP.md
+  - adr/README.md
+---
+
+# Whilly Orchestrator — PRD
+
+> **Назначение:** что и **как** строим. Архитектурные контракты, функциональные требования, scope текущего gap pack, acceptance criteria. BRD (зачем) — отдельный документ.
+>
+> **Purpose (EN):** what and how we build. Architectural contracts, functional requirements, current gap pack scope, acceptance criteria.
+
+---
+
+## TL;DR
+
+**RU.** Whilly — Python пакет с CLI `whilly`, реализующий **continuous Ralph loop**. Источник задач (`tasks.json` или GitHub Issues) → batch planner → параллельные агенты в tmux/git worktree → JSONL events + Rich TUI → опциональный sink (PR / Slack). Текущий gap pack добавляет **GitHub Issues source**, **PR creation sink** и **Decision Gate**, чтобы поддержать workshop demo «whilly закрывает свои же issues».
+
+**EN.** Whilly is a Python package + `whilly` CLI implementing a **continuous Ralph loop**. Source of tasks (`tasks.json` or GitHub Issues) → batch planner → parallel agents in tmux/git worktrees → JSONL events + Rich TUI → optional sink (PR / Slack). The current gap pack adds **GitHub Issues source**, **PR creation sink**, and **Decision Gate** to enable the workshop self-hosting demo.
+
+---
+
+## 1. System overview
+
+### 1.1 High-level architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                         WHILLY ORCHESTRATOR                          │
+└─────────────────────────────────────────────────────────────────────┘
+                                  │
+        ┌─────────────────────────┼─────────────────────────┐
+        ▼                         ▼                         ▼
+   ┌─────────┐              ┌──────────┐             ┌──────────┐
+   │ Source  │              │   Loop   │             │   Sink   │
+   │ adapter │ ──tasks.json─▶│ (cli.py  │──result─▶│ adapter  │
+   │         │              │ run_plan)│             │ (PR/log) │
+   └─────────┘              └──────────┘             └──────────┘
+        │                         │                         │
+        │                         │                         │
+   ┌────┴────┐         ┌──────────┴──────────┐         ┌────┴────┐
+   │GH Issues│         │ TaskManager (state) │         │gh PR    │
+   │tasks.json         │ Reporter (logs)     │         │comment  │
+   │Linear*  │         │ Dashboard (TUI)     │         │webhook* │
+   └─────────┘         │ StateStore (resume) │         └─────────┘
+                       └──────────┬──────────┘
+                                  │
+                       ┌──────────┴──────────┐
+                       │  Batch planner      │
+                       │  (orchestrator.py)  │
+                       └──────────┬──────────┘
+                                  │
+                       ┌──────────┴──────────┐
+                       │  Decision Gate*     │   ← NEW (gap pack)
+                       │  proceed / refuse   │
+                       └──────────┬──────────┘
+                                  │
+              ┌───────────────────┼───────────────────┐
+              ▼                   ▼                   ▼
+        ┌──────────┐        ┌──────────┐        ┌──────────┐
+        │ Tmux     │        │ Worktree │        │ Subproc  │
+        │ runner   │   +    │ runner   │   or   │ runner   │
+        └────┬─────┘        └────┬─────┘        └────┬─────┘
+             │                   │                   │
+             └───────────────────┼───────────────────┘
+                                 ▼
+                        ┌──────────────┐
+                        │ Claude CLI   │
+                        │ (agent)      │
+                        └──────────────┘
+                                 │
+                                 ▼
+                        ┌──────────────┐
+                        │AgentResult   │
+                        │usage,is_done │
+                        └──────────────┘
+
+  *  = planned / future
+```
+
+### 1.2 Module map
+
+| Module | Responsibility | LOC | Status |
+|---|---|---|---|
+| `cli.py` | Entry point, `run_plan()` главный loop, prompt builders | 1592 | ✅ existing |
+| `orchestrator.py` | Batch planning (file-based + LLM-based) | 174 | ✅ existing |
+| `agent_runner.py` | Claude CLI subprocess, JSON output parsing, `AgentResult` | 225 | ✅ existing |
+| `tmux_runner.py` | tmux session lifecycle для параллельных агентов | 137 | ✅ existing |
+| `worktree_runner.py` | git worktree per task / per plan | 382 | ✅ existing |
+| `task_manager.py` | `Task`, `Plan`, `TaskManager` (state, atomic JSON) | 174 | ✅ existing |
+| `state_store.py` | `.whilly_state.json`, `--resume` | 128 | ✅ existing |
+| `dashboard.py` | Rich Live TUI, hotkeys | 1232 | ✅ existing |
+| `reporter.py` | Per-iteration JSON, summary MD | 207 | ✅ existing |
+| `decomposer.py` | LLM split oversized tasks | 108 | ✅ existing |
+| `prd_wizard.py`, `prd_generator.py`, `prd_launcher.py` | PRD pipeline | 895 | ✅ existing |
+| `triz_analyzer.py` | TRIZ contradiction analysis | 390 | ✅ existing |
+| `verifier.py` | Acceptance criteria verifier | 152 | ✅ existing |
+| `notifications.py` | Budget/deadlock/auth alerts | 52 | ✅ existing |
+| `history.py` | Cross-run analytics | 165 | ✅ existing |
+| `web_status.py` | HTTP read-only status endpoint | 171 | ✅ existing |
+| `config.py` | `WhillyConfig.from_env()` | 49 | ✅ existing |
+| **`sources/github_issues.py`** | **GH Issues → tasks.json adapter** | ~150 | 🆕 gap pack |
+| **`sinks/github_pr.py`** | **task done → `gh pr create`** | ~120 | 🆕 gap pack |
+| **`decision_gate.py`** | **proceed / refuse short LLM gate** | ~100 | 🆕 gap pack |
+
+### 1.3 Data contracts
+
+#### 1.3.1 `Task` dataclass (existing)
+
+```python
+@dataclass
+class Task:
+    id: str                                  # "TASK-001" or "GH-42"
+    phase: str                               # "Phase 1"
+    category: str                            # "functional" / "test" / etc
+    priority: str                            # critical | high | medium | low
+    description: str
+    status: str                              # pending | in_progress | done | failed | skipped
+    dependencies: list[str] = []
+    key_files: list[str] = []
+    acceptance_criteria: list[str] = []
+    test_steps: list[str] = []
+    prd_requirement: str = ""
+```
+
+**GH Issues adapter** конвертирует issue → Task:
+- `id = f"GH-{issue.number}"`
+- `phase = "GH-Issues"`
+- `category = "github-issue"`
+- `priority` ← issue label `priority:high|medium|low|critical` (default = `medium`)
+- `description` = первые ~500 символов issue body
+- `key_files` ← парсятся из issue body (markdown bullet list под `**Files:**`)
+- `acceptance_criteria` ← парсятся под `**Acceptance:**`
+- `prd_requirement` = issue URL (для traceability)
+
+#### 1.3.2 `AgentResult` (existing)
+
+```python
+@dataclass
+class AgentResult:
+    result_text: str = ""
+    usage: AgentUsage = AgentUsage()
+    exit_code: int = 0
+    duration_s: float = 0.0
+    is_complete: bool = False                # True если "<promise>COMPLETE</promise>" в тексте
+```
+
+#### 1.3.3 Plan JSON schema (existing)
+
+```jsonc
+{
+  "project": "string",                       // optional
+  "prd_file": "string",                      // optional
+  "created_at": "ISO timestamp",             // optional
+  "agent_instructions": {                    // optional, hints for agent
+    "before": ["..."],
+    "after": ["..."]
+  },
+  "source": {                                // 🆕 NEW (gap pack), optional
+    "type": "github_issues",
+    "repo": "owner/repo",
+    "label": "whilly:ready",
+    "since": "2026-04-20T00:00:00Z"
+  },
+  "tasks": [
+    { /* Task */ }
+  ]
+}
+```
+
+#### 1.3.4 JSONL events (existing + new)
+
+Existing events (in `whilly_logs/whilly_events.jsonl`):
+
+```json
+{"ts":"...","event":"plan.start","plan":"tasks.json","total":12}
+{"ts":"...","event":"iteration.start","iter":1,"ready":3}
+{"ts":"...","event":"task.start","task_id":"TASK-001","worker":"tmux:whilly-TASK-001"}
+{"ts":"...","event":"task.done","task_id":"TASK-001","cost_usd":0.42,"duration_s":180}
+{"ts":"...","event":"budget.warning","spent":4.0,"cap":5.0}
+{"ts":"...","event":"plan.end","done":12,"failed":0,"skipped":0}
+```
+
+**New events (gap pack):**
+
+```json
+{"ts":"...","event":"source.fetch","source":"github_issues","repo":"mshegolev/whilly-orchestrator","new":5,"updated":1}
+{"ts":"...","event":"decision_gate","task_id":"GH-42","decision":"proceed","reason":"clear spec"}
+{"ts":"...","event":"decision_gate","task_id":"GH-43","decision":"refuse","reason":"missing acceptance criteria"}
+{"ts":"...","event":"sink.pr.created","task_id":"GH-42","pr_url":"https://github.com/owner/repo/pull/128","branch":"whilly/GH-42"}
+{"ts":"...","event":"sink.pr.failed","task_id":"GH-42","reason":"gh CLI not authenticated"}
+```
+
+---
+
+## 2. Functional requirements
+
+### 2.1 Core (existing, must not regress)
+
+- **FR-1 Continuous loop.** `run_plan(plan_path)` берёт ready tasks, запускает агентов, ждёт результаты, обновляет state, повторяет — пока pending != 0 ИЛИ не сработал budget/deadlock/timeout guard.
+- **FR-2 Atomic state.** `TaskManager.save()` пишет через temp + `os.replace` (POSIX atomic).
+- **FR-3 Resume.** `--resume` восстанавливает state из `.whilly_state.json` после kill/crash.
+- **FR-4 Headless mode.** При отсутствии TTY или `--headless` — JSON events на stdout, exit code 0/1/2/3.
+- **FR-5 Dashboard hotkeys.** `q/p/d/l/t/h` — quit/pause/detail/log/tasks/help.
+- **FR-6 Budget guard.** `WHILLY_BUDGET_USD` — warning at 80%, hard stop at 100%.
+- **FR-7 Deadlock guard.** Task `in_progress` ≥ 3 итерации → mark `skipped` с reason `deadlock`.
+- **FR-8 Auth error short-circuit.** На `is_auth_error` → fail-fast, не ретраим.
+- **FR-9 Plan workspace isolation.** `WHILLY_USE_WORKSPACE=1` (default) — `.whilly_workspaces/{slug}/` git worktree, loop chdir'ит туда.
+- **FR-10 Per-task worktree.** `WHILLY_WORKTREE=1` + `MAX_PARALLEL>1` — каждая задача в отдельном `.whilly_worktrees/{task_id}` worktree, cherry-pick back при done.
+
+### 2.2 New — gap pack
+
+#### 2.2.1 GitHub Issues source
+
+- **FR-GH-1.** CLI flag `--source gh:owner/repo[:label]` (default label = `whilly:ready`).
+- **FR-GH-2.** Adapter читает open issues через `gh issue list --repo owner/repo --label whilly:ready --json number,title,body,labels --limit 50`, конвертирует в `Task` (см. §1.3.1).
+- **FR-GH-3.** Записывает `tasks.json` с `source` блоком (см. §1.3.3) — после этого loop работает обычным образом.
+- **FR-GH-4.** Idempotent: повторный запуск на тех же issues — обновляет `description`, `priority`, не теряет `status` уже взятых задач (matched by `id == "GH-{number}"`).
+- **FR-GH-5.** Issue closed во время выполнения → задача marks `skipped` с reason `issue closed externally`.
+- **FR-GH-6.** Сеть недоступна → fail с понятным сообщением, exit code 1, не оставляем half-written `tasks.json`.
+
+#### 2.2.2 PR creation sink
+
+- **FR-PR-1.** CLI flag `--pr-on-done` (или config `WHILLY_PR_ON_DONE=1`).
+- **FR-PR-2.** При task `done`:
+  1. Внутри worktree: `git push origin HEAD:whilly/{task_id}` (force-with-lease).
+  2. `gh pr create --title "{task_id}: {short description}" --body "{template}" --base main`.
+  3. Если task связан с GH issue (есть `prd_requirement` URL) — `Closes #N` в body.
+- **FR-PR-3.** Шаблон PR body:
+  ```markdown
+  Implements [issue link or task id].
+
+  ### Plan
+  - {acceptance_criteria}
+
+  ### Validation
+  - {test_steps}
+
+  ### Whilly run
+  - cost: ${cost}
+  - duration: {duration_s}s
+  - log: {log_file relative path}
+  - JSONL events: see whilly_events.jsonl
+
+  ---
+  🤖 Opened by [whilly-orchestrator](https://github.com/mshegolev/whilly-orchestrator).
+  Human review required before merge.
+  ```
+- **FR-PR-4.** Если PR creation fails — task остаётся `done`, но event `sink.pr.failed` пишется. Loop не падает.
+- **FR-PR-5.** `--draft` опция → `gh pr create --draft`.
+
+#### 2.2.3 Decision Gate
+
+- **FR-DG-1.** CLI flag `--decision-gate` (или config `WHILLY_DECISION_GATE=1`).
+- **FR-DG-2.** Перед основным prompt'ом — короткий LLM-вызов с моделью из config'а:
+  - Prompt: «Дано описание задачи: {description}. Acceptance criteria: {acceptance}. Ты возьмёшься или откажешься? Ответ JSON: `{"decision":"proceed|refuse","reason":"..."}`».
+  - Timeout: 60 секунд.
+- **FR-DG-3.** На `proceed` → продолжаем как обычно.
+- **FR-DG-4.** На `refuse` → `task.status = "skipped"`, `event: decision_gate refuse`, если source=GH → `gh issue edit {N} --add-label needs-clarification --remove-label whilly:ready`.
+- **FR-DG-5.** На `parse error` или `timeout` → fail-open: считаем proceed, log warning.
+- **FR-DG-6.** Decision Gate стоимость учитывается в budget (не выкидываем из cost tracking).
+
+### 2.3 Workshop UX
+
+- **FR-WS-1.** `examples/workshop/tasks.json` — sample plan на 5-10 простых задач (README badge, healthcheck, lint fix, etc).
+- **FR-WS-2.** `docs/workshop/TUTORIAL.md` — пошаговое руководство, ≤ 90 минут от install до self-hosting.
+- **FR-WS-3.** `docs/workshop/INDEX.md` — bilingual навигация.
+- **FR-WS-4.** README.md — секция «Workshop kit» с CTA.
+- **FR-WS-5.** GitHub repo `mshegolev/whilly-orchestrator` — 5-10 заведённых issues с label `whilly:ready` для self-hosting demo.
+
+---
+
+## 3. Non-functional requirements
+
+| # | Категория | Требование |
+|---|---|---|
+| **NFR-1** | Performance | First-run latency < 60 секунд (до первого `task.start`). |
+| **NFR-2** | Cost predictability | Decision Gate стоимость < $0.01 per task. PR sink overhead < $0.001. |
+| **NFR-3** | Reliability | gap-pack модули не должны валить main loop при ошибке — graceful degrade. |
+| **NFR-4** | Observability | Все новые ветки логирования через JSONL events + dashboard refresh. |
+| **NFR-5** | Test coverage | Новые модули ≥ 75% покрытие (unit + integration). |
+| **NFR-6** | Backwards compat | `tasks.json` flow без изменений. GH Issues = opt-in. |
+| **NFR-7** | Security | `gh` token читается из `gh auth token`, не передаётся в LLM prompt. PR никогда не auto-merge. |
+| **NFR-8** | Portability | Работает на macOS / Linux. Windows не таргет (worktree+tmux зависят от unix). |
+| **NFR-9** | Python | 3.10+, без новых runtime deps кроме `gh` CLI и `rich` (уже в проекте). |
+| **NFR-10** | Lint/format | `ruff check` + `ruff format` chistый. CI обязателен. |
+
+---
+
+## 4. Acceptance criteria
+
+### 4.1 Gap pack acceptance
+
+| # | Criteria | How to verify |
+|---|---|---|
+| **AC-1** | `whilly --source gh:mshegolev/whilly-orchestrator` создаёт `tasks.json` из открытых issues с label `whilly:ready` | manual: запуск, проверка содержимого tasks.json |
+| **AC-2** | Loop работает на этом tasks.json без падений (одна задача — `done`) | manual self-hosting demo |
+| **AC-3** | `--pr-on-done` после task done открывает PR в репо, body содержит link на issue | проверить URL из JSONL `sink.pr.created` |
+| **AC-4** | `--decision-gate` отфильтровывает 1 заведомо плохо описанный issue (skip + label flip) | ручной тест на fixture |
+| **AC-5** | Все 3 новых модуля имеют unit-тесты, `pytest -q` зелёный | CI |
+| **AC-6** | `ruff check whilly/ tests/` без ошибок | CI |
+| **AC-7** | `docs/workshop/TUTORIAL.md` проходим за ≤ 90 минут (3 dry-run на чистой VM) | manual |
+| **AC-8** | `examples/workshop/tasks.json` валиден против `validate_schema()` | `whilly --check examples/workshop/tasks.json` |
+| **AC-9** | INDEX.md, BRD, PRD, READINESS, ROADMAP, ADR pack — присутствуют, кросс-линки работают | manual review |
+| **AC-10** | Sync-скрипт копирует `docs/workshop/` в Obsidian без потерь | manual run |
+
+### 4.2 Demo acceptance
+
+Self-hosting bootstrap demo считается успешным, если:
+
+1. `whilly --source gh:mshegolev/whilly-orchestrator --pr-on-done --decision-gate` стартует.
+2. Dashboard показывает 5+ ready tasks.
+3. Decision Gate refuses ≥ 1 задачу (отметить label).
+4. Хотя бы 1 task → `done` → PR opened (видим event `sink.pr.created`).
+5. Total cost < $5 на demo (комфортный budget).
+6. Все события в `whilly_events.jsonl` валидный JSONL (jq parse-able).
+
+---
+
+## 5. Out of scope (для текущего релизного цикла)
+
+- Linear / Jira / GitLab Issues адаптеры (планируется как отдельные ADR + sources/).
+- Codex / Gemini / OpenAI backends (отдельный ADR-013, после Claude stabilization).
+- MCP server интерфейс (research first).
+- Web UI замена TUI (сохраняем `web_status.py` как read-only).
+- Auto-merge PR (security blocker).
+- Multi-tenant / SaaS (out of mission).
+- Distributed queue (in-process supervisor покрывает).
+
+---
+
+## 6. Edge cases & error handling
+
+| Scenario | Expected behavior |
+|---|---|
+| `gh` CLI отсутствует | `--source gh:` fails fast с понятным сообщением + ссылкой на install guide. |
+| `gh` token истёк / unauth | Fails fast, exit 1, suggest `gh auth login`. |
+| GitHub rate limit | Single retry с exp.backoff (5s, 30s), потом fail. |
+| Issue body отсутствует / пустое | Adapter создаёт Task с минимальным `description = title`, `acceptance_criteria = []`. |
+| Issue body содержит секреты | Adapter **не** фильтрует — это ответственность пользователя (issue tracker — открытое место). Best-effort warning при detection через regex (например, `AKIA[A-Z0-9]+`). |
+| `gh pr create` падает (push reject, no permission) | Task остаётся `done`, event `sink.pr.failed` с reason. Loop не падает. |
+| Decision Gate timeout | Fail-open (proceed) + warning в JSONL. |
+| Decision Gate parse error | Fail-open + warning. |
+| Whilly запущен на самом себе и task — модификация whilly source | Reuse existing per-task worktree isolation. PR в main (review human). |
+| Network disconnect mid-run | Task in_progress → next iteration retry; budget tracking сохранён в state. |
+
+---
+
+## 7. Open questions (deferred, not blocking)
+
+1. Нужен ли webhook-based source (GH webhooks → trigger `whilly`) вместо polling? — после workshop feedback.
+2. Стоит ли добавить `--source linear:team_id` сразу после GH? — приоритет 2, после workshop.
+3. Decision Gate prompt — на каком языке? RU vs EN — какой даёт лучший recall? — A/B на 50 issues после workshop.
+4. PR template — параметризовать через файл `.whilly/pr_template.md`? — добавить в follow-up.
+5. Codex backend — какие compatibility break'и? — ADR-013 в следующем цикле.
+
+---
+
+## 8. Cross-references
+
+- BRD: [BRD-Whilly.md](BRD-Whilly.md)
+- Readiness: [READINESS-REPORT.md](READINESS-REPORT.md)
+- Roadmap: [ROADMAP.md](ROADMAP.md)
+- ADR index: [adr/README.md](adr/README.md)
+- Tutorial: [TUTORIAL.md](TUTORIAL.md)
+- CLI reference: [../Whilly-Usage.md](../Whilly-Usage.md)
+- Task schema reference: [../Whilly-Interfaces-and-Tasks.md](../Whilly-Interfaces-and-Tasks.md)
+- Source: [../../whilly/](../../whilly/)
+- Sample plan: [../../examples/workshop/tasks.json](../../examples/workshop/tasks.json)
+
+---
+
+**Status:** v1 · 2026-04-20 · pending review after gap pack delivery.

--- a/docs/workshop/READINESS-REPORT.md
+++ b/docs/workshop/READINESS-REPORT.md
@@ -1,0 +1,154 @@
+# Whilly Workshop Readiness Report
+**Status:** v1 · 2026-04-20 · scope source: `HackSprint1_PRD_AgentsOrchestrator.md`
+
+> **EN:** Honest gap analysis between **whilly-orchestrator** (current `main`, v3.0.0, 6244 LOC) and the **HackSprint1** workshop scope. What works out of the box, what we still need to ship before we can run the workshop end-to-end with the *self-hosting bootstrap* demo.
+>
+> **RU:** Честный gap-анализ между **whilly-orchestrator** (`main`, v3.0.0, 6244 LOC) и scope воркшопа **HackSprint1**. Что работает из коробки, что нужно дописать до воркшопа, чтобы прогнать demo «self-hosting bootstrap» end-to-end.
+
+---
+
+## TL;DR
+
+| Layer | Coverage | Verdict |
+|---|---|---|
+| Supervisor loop | ✅ 100% | Production-grade. Ralph loop, batching, deadlock guard, budget. |
+| Worker isolation | ✅ 100% | tmux + git worktree, per-task workspace. Beats both grkr (1 backend) and yolo (Go-only). |
+| Agent backend | ✅ Claude CLI | Single backend. Codex/Gemini = stretch. |
+| State + recovery | ✅ 100% | `.whilly_state.json` resume, atomic writes via TaskManager. |
+| Logging / events | ✅ JSONL | `whilly_logs/whilly_events.jsonl`. Format documented. |
+| Dashboard / TUI | ✅ Rich Live | Hotkeys (q/p/d/l/t/h). NullDashboard for headless. |
+| Source = `tasks.json` | ✅ 100% | Atomic JSON file, schema validated. |
+| **Source = GitHub Issues** | ❌ **0%** | **GAP — blocks self-hosting demo.** |
+| **Sink = `gh pr create`** | ❌ **0%** | **GAP — blocks self-hosting demo.** |
+| **Decision Gate** | ❌ **0%** | GAP — blocks "agent refuses unclear issues" UX. |
+| PRD wizard | ✅ | Goes beyond HackSprint1 scope. |
+| TRIZ analyzer | ✅ | Goes beyond HackSprint1 scope. |
+| Decomposer | ✅ | Goes beyond HackSprint1 scope. |
+| Workshop tutorial | ⚠️ Partial | README + Usage exist, hands-on tutorial = GAP. |
+| Sample tasks / sample issues | ❌ | GAP — needs `examples/workshop/tasks.json` + 5-10 demo GH issues. |
+
+**Verdict:** Whilly is **technically ahead of the HackSprint1 MVP target**. The remaining workshop blockers are the **GitHub source/sink pair**, the **Decision Gate**, and the **hands-on tutorial pack**. These are scoped in [ROADMAP.md](ROADMAP.md) and tracked as the **gap pack** for this sprint.
+
+---
+
+## 1. Coverage matrix vs HackSprint1 PRD
+
+Section IDs reference the original `HackSprint1_PRD_AgentsOrchestrator.md`.
+
+### 1.1 Must-have (PRD §4)
+
+| PRD requirement | Whilly module | Status | Notes |
+|---|---|---|---|
+| Source adapter (1 source) | `task_manager.py` | ✅ JSON | Reads `tasks.json`. **GitHub Issues source missing.** |
+| Supervisor loop | `cli.py::run_plan` | ✅ | Continuous loop, batch planning, deadlock + budget guards. |
+| Worker (git worktree) | `worktree_runner.py` | ✅ | Per-plan + per-task isolation, cherry-pick back. |
+| Agent backend (1 LLM) | `agent_runner.py` | ✅ | Claude CLI subprocess, JSON output parsing, usage accounting. |
+| State file | `state_store.py` | ✅ | `.whilly_state.json`, `--resume` support. |
+| JSONL events | `cli.py::_log_event` | ✅ | `whilly_logs/whilly_events.jsonl`. |
+
+### 1.2 Nice-to-have (PRD §4)
+
+| PRD requirement | Whilly module | Status | Notes |
+|---|---|---|---|
+| Decision Gate (proceed/refuse) | — | ❌ | **GAP.** Agent always tries; no upfront refuse. |
+| PR creation | — | ❌ | **GAP.** Whilly commits, never opens PR. |
+| TUI dashboard | `dashboard.py` | ✅✅ | Goes beyond — Rich Live, hotkeys, multi-pane. |
+| Pluggable backends | `agent_runner.py` | ⚠️ | Interface exists implicitly; only Claude is implemented. Adding Codex = stretch (~half day). |
+
+### 1.3 Bonus (not in HackSprint1 PRD, exists in whilly)
+
+| Feature | Whilly module | Value for workshop |
+|---|---|---|
+| PRD wizard / generator | `prd_wizard.py`, `prd_generator.py` | Demo path: PRD → tasks.json in 1 command. |
+| TRIZ analyzer | `triz_analyzer.py` | Edge case for advanced track. |
+| LLM-based batching | `orchestrator.py::plan_batches_llm` | Stretch demo. |
+| Task decomposer | `decomposer.py` | Mid-run subtask creation. |
+| Notifications | `notifications.py` | Budget warning, deadlock, auth alert. |
+| Reports + Markdown summary | `reporter.py` | Per-iteration JSON + end-of-run MD. |
+| History DB | `history.py` | Cross-run analytics. |
+| Web status | `web_status.py` | HTTP read-only status endpoint. |
+
+---
+
+## 2. Workshop demo readiness checklist
+
+Demo target (per user choice in kickoff): **whilly self-hosting** — whilly closes its own GitHub issues, opens its own PRs, the human reviews and merges.
+
+| # | Step in demo | Required gap-pack item | Status |
+|---|---|---|---|
+| 1 | Demo machine has Claude CLI + Anthropic key | external prereq | ✅ |
+| 2 | Repo `mshegolev/whilly-orchestrator` is public, has open issues | seed 5-10 issues with `whilly:ready` label | ❌ — to do |
+| 3 | `whilly --source gh:mshegolev/whilly-orchestrator` reads issues | `whilly/sources/github_issues.py` | ❌ — to do |
+| 4 | Loop picks 1 ready issue, hands to agent | reuses existing TaskManager flow | ✅ pending #3 |
+| 5 | Agent works in isolated worktree | reuses existing worktree_runner | ✅ |
+| 6 | After done → `gh pr create`, PR linked to issue | `whilly/sinks/github_pr.py` | ❌ — to do |
+| 7 | Decision Gate refuses 1 unclear issue (label flip) | `whilly/decision_gate.py` | ❌ — to do |
+| 8 | Live dashboard shows progress, cost, JSONL stream | reuses existing dashboard | ✅ |
+| 9 | Tutorial walks audience through steps 1-7 | `docs/workshop/TUTORIAL.md` | ❌ — to do |
+| 10 | Sample `tasks.json` for participants without GitHub auth | `examples/workshop/tasks.json` | ❌ — to do |
+
+**6 items missing**, all small/medium scope. See [ROADMAP.md](ROADMAP.md) for breakdown and [PRD-Whilly.md](PRD-Whilly.md) for acceptance criteria.
+
+---
+
+## 3. Strengths over reference projects
+
+| Aspect | grkr (bash) | yolo-runner (Go) | **whilly (Python)** |
+|---|---|---|---|
+| Onboarding for Python team | low (bash) | medium (Go) | **highest** |
+| Parallelism | none | concurrency flag | **tmux + worktree, batch planning** |
+| Dashboard | none | Bubble Tea TUI | **Rich Live, hotkeys** |
+| State recovery | basic | yes | **`.whilly_state.json`, --resume** |
+| Decomposer / TRIZ | no | no | **yes** |
+| PRD wizard | no | no | **yes** |
+| Decision Gate | yes | no | **planned (gap pack)** |
+| GitHub Issues source | yes | yes (multi) | **planned (gap pack)** |
+| PR creation | yes | yes | **planned (gap pack)** |
+| Pluggable backends | 1 (Codex) | 5+ | 1 (Claude) — stretch |
+| LOC | ~200 (bash) | ~30k (Go) | 6244 (Python) |
+
+Whilly's **niche**: a Python-native, batteries-included orchestrator with a real TUI, sitting between the "everything is bash" minimalism of grkr and the "build your own Go framework" weight of yolo-runner.
+
+---
+
+## 4. Risks for the workshop
+
+| # | Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|---|
+| W1 | Participants don't have `gh` auth → PR demo fails | High | Medium | Fall back to `tasks.json` track. Pre-flight check in TUTORIAL.md. |
+| W2 | Anthropic rate limits during live demo | Medium | High | Pre-record demo, have $0.50 safety budget. Show JSONL replay. |
+| W3 | `gh` CLI version mismatch (need ≥2.40 for some flags) | Medium | Low | Pin minimum in TUTORIAL prerequisites. |
+| W4 | Whilly TUI breaks on small terminal (<100 cols) | Medium | Low | `--headless` mode documented as fallback. |
+| W5 | Self-hosting demo fails: agent can't write inside worktree | Low | High | Smoke-tested before workshop, fallback to local plan. |
+| W6 | Budget cap kicks in mid-demo | Low | Medium | Set `WHILLY_BUDGET_USD=10` for demo, warn at 80%. |
+| W7 | Workshop materials drift from code | High over time | Medium | Sync script `scripts/sync_workshop_docs.sh` + CI check. |
+
+---
+
+## 5. Cut-line for "minimum viable workshop"
+
+If we have only **2 hours** before workshop start:
+
+- ✅ TUTORIAL.md "Hour 1: install + first run on tasks.json" — works today, no code change.
+- ❌ Hours 2-6 require gap pack code → schedule full afternoon block.
+
+If we have **1 day** (this session's target):
+
+- ✅ Ship gap pack: GH source + PR sink + Decision Gate + tutorial.
+- ✅ Bilingual INDEX, BRD, PRD, ADR.
+- ⚠️ Recorded demo video = stretch.
+
+---
+
+## 6. Open questions deferred to the workshop session
+
+These are **not blockers** but should be discussed live with participants:
+
+- Should we add MCP server interface for whilly (publish whilly tools as MCP)?
+- Multi-agent backend dispatch (round-robin Claude/Codex) — worth a third workshop hour?
+- Linear / Jira adapters — when?
+- Web UI vs Rich TUI — keep both?
+
+---
+
+**Bottom line:** whilly already implements **more than the HackSprint1 MVP target**. The remaining 6 workshop blockers are scoped, small, and tracked. After the gap pack lands, whilly is ready to run the self-hosting bootstrap demo end-to-end.

--- a/docs/workshop/ROADMAP.md
+++ b/docs/workshop/ROADMAP.md
@@ -1,0 +1,203 @@
+---
+title: Whilly Workshop — Roadmap & Decomposition
+type: roadmap
+created: 2026-04-20
+status: v1
+related: [PRD-Whilly.md, READINESS-REPORT.md]
+---
+
+# Whilly Workshop Roadmap
+
+> **EN:** Decomposition of the gap pack into atomic tasks. Each row maps to (a) a planned commit, (b) a `tasks.json` entry, and (c) a GitHub issue with label `whilly:ready`. This document is the **single source of truth** for what ships in the current cycle.
+>
+> **RU:** Декомпозиция gap-пака в атомарные задачи. Каждая строка соответствует (a) запланированному коммиту, (b) записи в `tasks.json`, (c) issue в GitHub с label `whilly:ready`.
+
+---
+
+## Phase plan
+
+```
+Phase 1 — Documents & scaffolding              [DONE in this session]
+Phase 2 — Code: GH source adapter              [in progress]
+Phase 3 — Code: PR sink                        [pending, depends on Phase 2]
+Phase 4 — Code: Decision Gate                  [pending, can parallel Phase 3]
+Phase 5 — Workshop UX (tutorial, samples)      [pending, depends on 2-4]
+Phase 6 — README + bilingual + Obsidian sync   [pending, depends on 5]
+Phase 7 — Tests & lint hardening               [parallel with 2-6]
+Phase 8 — Demo dry-run + recording             [pending, depends on all]
+```
+
+---
+
+## Decomposed task list
+
+> Each task here is intended to map 1:1 to a GitHub Issue (label `whilly:ready`) and a `tasks.json` entry in `examples/workshop/tasks.json`. Status reflects what's done **in this session**.
+
+### Phase 1 — Documents & scaffolding (✅ done)
+
+| ID | Task | Files | Status |
+|---|---|---|---|
+| WS-001 | Create `docs/workshop/` structure + INDEX.md | `docs/workshop/INDEX.md` | ✅ |
+| WS-002 | Write BRD-Whilly.md (RU primary, EN summary) | `docs/workshop/BRD-Whilly.md` | ✅ |
+| WS-003 | Write PRD-Whilly.md | `docs/workshop/PRD-Whilly.md` | ✅ |
+| WS-004 | Write READINESS-REPORT.md | `docs/workshop/READINESS-REPORT.md` | ✅ |
+| WS-005 | Write ROADMAP.md (this file) | `docs/workshop/ROADMAP.md` | 🟡 in progress |
+| WS-006 | Write ADR pack (12 records) | `docs/workshop/adr/*.md` | ⏳ next |
+
+### Phase 2 — GitHub Issues source adapter
+
+| ID | Task | Files | Acceptance | Est |
+|---|---|---|---|---|
+| GH-101 | Create `whilly/sources/__init__.py` package | `whilly/sources/__init__.py` | imports clean | 5m |
+| GH-102 | Implement `GitHubIssuesSource` reading `gh issue list` | `whilly/sources/github_issues.py` | unit test passes with mocked subprocess | 60m |
+| GH-103 | CLI flag `--source gh:owner/repo[:label]` parsing | `whilly/cli.py` | `whilly --source gh:foo/bar` triggers source | 20m |
+| GH-104 | Adapter writes to `tasks.json` with `source` block | `whilly/sources/github_issues.py` | written file passes `validate_schema` | 30m |
+| GH-105 | Idempotent re-fetch (preserve in_progress/done by id) | `whilly/sources/github_issues.py` | unit test: re-fetch keeps `done` status | 30m |
+| GH-106 | Issue closed externally → mark `skipped` | `whilly/sources/github_issues.py` | unit test | 20m |
+| GH-107 | Unit tests with `subprocess.run` mocked | `tests/test_github_issues_source.py` | ≥ 75% coverage | 30m |
+| GH-108 | JSONL event `source.fetch` emitted | `whilly/cli.py` | event present | 10m |
+
+**Phase 2 total: ~3.5 hours**
+
+### Phase 3 — PR creation sink
+
+| ID | Task | Files | Acceptance | Est |
+|---|---|---|---|---|
+| PR-201 | Create `whilly/sinks/__init__.py` package | `whilly/sinks/__init__.py` | imports clean | 5m |
+| PR-202 | Implement `GitHubPRSink.open(task, worktree, agent_result)` | `whilly/sinks/github_pr.py` | unit test with mocked git+gh | 60m |
+| PR-203 | PR body template with cost/duration/log link | `whilly/sinks/github_pr.py` | rendered output matches snapshot | 20m |
+| PR-204 | `Closes #N` injection if `prd_requirement` is GH URL | `whilly/sinks/github_pr.py` | regex extraction tested | 20m |
+| PR-205 | CLI flag `--pr-on-done` (+ env `WHILLY_PR_ON_DONE`) | `whilly/cli.py`, `whilly/config.py` | flag works | 15m |
+| PR-206 | Hook PR sink into `run_plan` after task done | `whilly/cli.py` | manual smoke | 30m |
+| PR-207 | Graceful failure → `sink.pr.failed` event | `whilly/sinks/github_pr.py` | unit test | 15m |
+| PR-208 | `--draft` PR option | `whilly/sinks/github_pr.py`, `whilly/cli.py` | flag works | 10m |
+| PR-209 | Unit tests | `tests/test_github_pr_sink.py` | ≥ 75% coverage | 30m |
+
+**Phase 3 total: ~3.5 hours**
+
+### Phase 4 — Decision Gate
+
+| ID | Task | Files | Acceptance | Est |
+|---|---|---|---|---|
+| DG-301 | `whilly/decision_gate.py` with `evaluate(task) -> Decision` | `whilly/decision_gate.py` | unit test | 45m |
+| DG-302 | Decision dataclass `{decision, reason, cost_usd}` | `whilly/decision_gate.py` | unit test | 10m |
+| DG-303 | Prompt template (RU primary) | `whilly/decision_gate.py` | snapshot test | 15m |
+| DG-304 | Fail-open on timeout/parse error | `whilly/decision_gate.py` | unit test | 15m |
+| DG-305 | CLI flag `--decision-gate` (+ env `WHILLY_DECISION_GATE`) | `whilly/cli.py`, `whilly/config.py` | flag works | 15m |
+| DG-306 | Hook into `run_plan` between batch planning & dispatch | `whilly/cli.py` | manual smoke | 30m |
+| DG-307 | On refuse + GH source → label flip via `gh issue edit` | `whilly/decision_gate.py`, `whilly/sources/github_issues.py` | manual smoke | 20m |
+| DG-308 | JSONL events `decision_gate proceed/refuse` | `whilly/cli.py` | events present | 10m |
+| DG-309 | Cost tracking (Decision Gate cost in budget) | `whilly/cli.py` | budget includes gate cost | 15m |
+| DG-310 | Unit tests | `tests/test_decision_gate.py` | ≥ 75% coverage | 30m |
+
+**Phase 4 total: ~3.5 hours**
+
+### Phase 5 — Workshop UX
+
+| ID | Task | Files | Acceptance | Est |
+|---|---|---|---|---|
+| WS-501 | `examples/workshop/tasks.json` (5-10 demo tasks) | `examples/workshop/tasks.json` | passes `validate_schema` | 30m |
+| WS-502 | `docs/workshop/TUTORIAL.md` (RU + EN sections) | `docs/workshop/TUTORIAL.md` | walks 90-min path | 90m |
+| WS-503 | Create 5-10 GH issues in `mshegolev/whilly-orchestrator` | GitHub | issues exist with `whilly:ready` label | 20m |
+| WS-504 | Add screenshots of dashboard | `docs/workshop/img/` | images present | 30m |
+
+**Phase 5 total: ~3 hours**
+
+### Phase 6 — README + bilingual + Obsidian sync
+
+| ID | Task | Files | Acceptance | Est |
+|---|---|---|---|---|
+| RM-601 | Add Workshop section to README.md | `README.md` | renders cleanly on GitHub | 20m |
+| RM-602 | Create `README-RU.md` (краткая версия) | `README-RU.md` | bilingual coverage | 60m |
+| RM-603 | `scripts/sync_workshop_docs.sh` | `scripts/sync_workshop_docs.sh` | rsync works to Obsidian path | 20m |
+| RM-604 | First sync run, verify Obsidian copies | Obsidian: `02-Projects/ai/workshop/whilly/` | files present | 5m |
+
+**Phase 6 total: ~1.5 hours**
+
+### Phase 7 — Tests & lint
+
+| ID | Task | Files | Acceptance | Est |
+|---|---|---|---|---|
+| TST-701 | Pytest fixtures for `gh` CLI mock | `tests/conftest.py` | reusable | 30m |
+| TST-702 | Run `ruff check whilly/ tests/` clean | (lint) | zero errors | 15m |
+| TST-703 | Run `ruff format whilly/ tests/` | (format) | applied | 5m |
+| TST-704 | `pytest -q` all green | (CI) | passing | 15m |
+| TST-705 | Update CI to include new modules | `.github/workflows/ci.yml` | passes | 15m |
+
+**Phase 7 total: ~1.5 hours**
+
+### Phase 8 — Demo dry-run
+
+| ID | Task | Files | Acceptance | Est |
+|---|---|---|---|---|
+| DR-801 | Smoke test: `whilly --source gh:... --pr-on-done --decision-gate` | (manual) | event log valid, ≥ 1 PR opened | 30m |
+| DR-802 | Capture demo screencast (~3 min) | `docs/workshop/demo.gif` | embedded in README | 60m |
+| DR-803 | Update READINESS-REPORT.md status row | `docs/workshop/READINESS-REPORT.md` | reflects done state | 10m |
+
+**Phase 8 total: ~1.5 hours**
+
+---
+
+## Dependency graph (high level)
+
+```
+Phase 1 ──▶ Phase 2 ──┬─▶ Phase 3 ─┐
+                       │            │
+                       └─▶ Phase 4 ─┤
+                                    ▼
+                                Phase 5 ──▶ Phase 6 ──▶ Phase 8
+                                    ▲
+                                Phase 7 (parallel with 2-6)
+```
+
+Phase 3 and Phase 4 can run in parallel (no shared files).
+
+---
+
+## Total time budget
+
+| Phase | Effort |
+|---|---|
+| Phase 1 (docs) | ~4h ✅ done |
+| Phase 2 (GH source) | ~3.5h |
+| Phase 3 (PR sink) | ~3.5h |
+| Phase 4 (Decision Gate) | ~3.5h |
+| Phase 5 (Workshop UX) | ~3h |
+| Phase 6 (README + sync) | ~1.5h |
+| Phase 7 (tests/lint) | ~1.5h |
+| Phase 8 (demo) | ~1.5h |
+| **Total** | **~22h** for full pack |
+
+If solo with constrained budget (current night session):
+- **Hard target:** Phase 1 ✅ + Phase 2 + Phase 3 + Phase 4 (lite) + Phase 5 (tutorial only) + Phase 7 (lint) ≈ 13 hours.
+- **Stretch:** + Phase 6 + Phase 8 = full delivery.
+
+---
+
+## Risks per phase
+
+| Phase | Risk | Mitigation |
+|---|---|---|
+| 2 | `gh` CLI version mismatch | pin minimum in TUTORIAL prerequisites |
+| 3 | git push permission denied in worktree | document SSH key setup; fallback to HTTPS+token |
+| 4 | Decision Gate misclassifies | conservative prompt + manual review label |
+| 5 | TUTORIAL > 90 min | cut "advanced" subsections; track 90-min line strict |
+| 6 | sync script overwrites Obsidian custom changes | dry-run flag + diff before copy |
+| 7 | New tests slow down CI | mark slow tests `pytest.mark.slow`, skip in PR check |
+| 8 | Live demo fails | pre-recorded backup, fallback to JSONL replay |
+
+---
+
+## Definition of done (whole gap pack)
+
+- [ ] All Phase 2-8 tasks completed and committed.
+- [ ] All AC-1 to AC-10 in PRD §4 verified.
+- [ ] `pytest -q` green, `ruff check` zero errors, CI green.
+- [ ] At least 1 self-hosting demo run end-to-end with PR opened.
+- [ ] `docs/workshop/` synced to Obsidian.
+- [ ] README workshop section published.
+- [ ] Tag v3.1.0, PyPI bump.
+
+---
+
+**Status:** v1 · 2026-04-20 · live document, updated as phases complete.

--- a/docs/workshop/TUTORIAL.md
+++ b/docs/workshop/TUTORIAL.md
@@ -1,0 +1,416 @@
+---
+title: Whilly Workshop Tutorial — 90-minute hands-on
+type: tutorial
+created: 2026-04-20
+status: v1
+audience: bilingual (EN summary above each track, RU detail)
+related: [INDEX.md, BRD-Whilly.md, PRD-Whilly.md]
+---
+
+# Whilly Workshop Tutorial
+
+> **EN summary:** End-to-end 90-minute hands-on. Two parallel tracks:
+> - **Track A (`tasks.json`)** — works without GitHub auth, ~30 min, every participant can complete.
+> - **Track B (GitHub Issues)** — full self-hosting demo, ~60 min, requires `gh auth login` and write access to a sandbox repo.
+> Targets the HackSprint1 minimum requirements: source → agent → PR → retry → real repo.
+>
+> **RU:** Hands-on на 90 минут в двух треках: Track A (`tasks.json`) — без GitHub auth, Track B (GitHub Issues) — полный self-hosting. Закрывает все 5 минимальных требований HackSprint1.
+
+---
+
+## ⏱ Pre-flight checklist (5 минут)
+
+Прежде чем начать, проверь:
+
+```bash
+# Python 3.10+
+python3 --version
+# 3.10.x or higher
+
+# git
+git --version
+# 2.40+ recommended
+
+# Claude CLI (для Track A и Track B)
+claude --version
+# any recent version
+
+# Anthropic API key
+echo $ANTHROPIC_API_KEY
+# должен быть непустым
+
+# tmux (опционально, для параллельных агентов)
+tmux -V
+
+# gh CLI (только для Track B)
+gh --version
+gh auth status
+# должен показывать "Logged in to github.com"
+```
+
+Если что-то отсутствует:
+
+| Tool | macOS | Linux |
+|---|---|---|
+| Python 3.10+ | `brew install python@3.12` | apt/dnf |
+| git | preinstalled | apt/dnf |
+| Claude CLI | https://docs.claude.com/en/docs/claude-code | same |
+| tmux | `brew install tmux` | `apt install tmux` |
+| gh | `brew install gh` then `gh auth login` | https://cli.github.com/ |
+
+---
+
+## 🚀 Install whilly (5 минут)
+
+```bash
+# Option A — from PyPI
+pip install whilly-orchestrator
+
+# Option B — from source (recommended for workshop, you'll modify it)
+git clone https://github.com/mshegolev/whilly-orchestrator
+cd whilly-orchestrator
+pip install -e ".[dev]"
+
+whilly --help
+```
+
+Если `whilly --help` выводит usage — установка сработала.
+
+---
+
+# Track A — `tasks.json` (no GitHub auth required)
+
+> **Цель:** за 30 минут увидеть Ralph loop в действии — агент берёт задачу, выполняет, помечает `done`, переходит к следующей.
+
+## Step A.1 — Скопировать sample plan (2 мин)
+
+```bash
+cp examples/workshop/tasks.json my_first_run.json
+cat my_first_run.json
+```
+
+Содержимое:
+
+```json
+{
+  "project": "workshop-track-a",
+  "tasks": [
+    {
+      "id": "TASK-001",
+      "phase": "Phase 1",
+      "category": "doc",
+      "priority": "low",
+      "description": "Create a file HELLO.md with one line: 'Hello from Whilly!'",
+      "status": "pending",
+      "dependencies": [],
+      "key_files": ["HELLO.md"],
+      "acceptance_criteria": ["HELLO.md exists with the exact line"],
+      "test_steps": ["test -s HELLO.md"]
+    }
+  ]
+}
+```
+
+## Step A.2 — Запустить (3 мин)
+
+```bash
+whilly my_first_run.json
+```
+
+Появится Rich TUI dashboard. Смотри:
+
+- В левой колонке — список задач, статус `pending` → `in_progress`.
+- В правой — live лог агента.
+- Hotkeys: `q`=quit, `d`=detail, `l`=log, `t`=tasks, `h`=help.
+
+Через ~30-60 секунд:
+- Задача → `done`.
+- В корне репо появился `HELLO.md`.
+
+Если хочешь убедиться, что это был **агент**, а не магия:
+
+```bash
+cat HELLO.md
+# Hello from Whilly!
+git log --oneline | head -3
+# увидишь коммит с описанием задачи
+```
+
+## Step A.3 — Понять, что произошло (5 мин)
+
+```bash
+cat whilly_logs/whilly_events.jsonl | jq .
+```
+
+Увидишь поток событий:
+- `plan.start` — план загружен
+- `iteration.start` — итерация 1
+- `task.start` — TASK-001 ушла в работу
+- `task.done` — закрыта, с `cost_usd` и `duration_s`
+- `plan.end` — итог
+
+Это **JSONL events** (ADR-005). Любой инструмент (jq, grep, Python) разбирает их.
+
+## Step A.4 — Параллельный запуск (10 мин)
+
+Добавь в `my_first_run.json` ещё 2-3 задачи (разные `key_files`!) и:
+
+```bash
+WHILLY_MAX_PARALLEL=3 WHILLY_USE_TMUX=1 whilly my_first_run.json
+```
+
+Откроется tmux session `whilly-TASK-001`, `-002`, `-003` параллельно.
+
+```bash
+# В другом терминале:
+tmux ls
+# увидишь все активные agent sessions
+
+tmux attach -t whilly-TASK-001
+# живой лог агента
+```
+
+После: tmux session убивается автоматически на done.
+
+## Step A.5 — Что почитать дальше (5 мин)
+
+- [PRD §1.2 Module map](PRD-Whilly.md) — какие модули за что отвечают.
+- [adr/ADR-002](adr/ADR-002-tasks-json-source-of-truth.md) — почему `tasks.json` source of truth.
+- [adr/ADR-003](adr/ADR-003-tmux-and-worktree-parallelism.md) — почему tmux+worktree.
+
+✅ Если ты дошёл сюда — **MVP HackSprint1 минимальные требования #1, #2 у тебя уже работают**.
+
+---
+
+# Track B — GitHub Issues + PR creation (full self-hosting)
+
+> **Цель:** за 60 минут собрать полный e2e flow «GH Issue → агент → PR → retry». Закрывает все 5 минимальных требований HackSprint1.
+
+## Step B.1 — Подготовить sandbox-репо (5 мин)
+
+Если у тебя нет sandbox-репо для HackSprint1 — создай:
+
+```bash
+gh repo create my-hacksprint1-sandbox --public --add-readme
+git clone https://github.com/<your-user>/my-hacksprint1-sandbox
+cd my-hacksprint1-sandbox
+```
+
+Заведи 3 простых issue с label `whilly:ready`:
+
+```bash
+gh issue create \
+  --title "Add MIT LICENSE" \
+  --label "whilly:ready" \
+  --body "Add a standard MIT LICENSE file at repo root.
+
+**Files:** LICENSE
+
+## Acceptance
+- LICENSE file exists
+- Contains MIT text and current year
+
+## Test
+- test -s LICENSE
+- grep -q 'MIT License' LICENSE
+"
+
+gh issue create \
+  --title "Add Python .gitignore" \
+  --label "whilly:ready" \
+  --body "Add a Python-flavoured .gitignore.
+
+**Files:** .gitignore
+
+## Acceptance
+- .gitignore exists with __pycache__, .venv, .env entries
+
+## Test
+- grep -q __pycache__ .gitignore
+"
+
+gh issue create \
+  --title "Add CONTRIBUTING.md" \
+  --label "whilly:ready" \
+  --body "Create a minimal CONTRIBUTING.md.
+
+**Files:** CONTRIBUTING.md
+
+## Acceptance
+- File exists with at least Issues / PRs / Style sections
+
+## Test
+- test -s CONTRIBUTING.md
+"
+```
+
+## Step B.2 — Pull issues into a tasks.json (5 мин)
+
+С новой gap-pack функцией:
+
+```bash
+# В корне whilly-orchestrator:
+python3 -c "
+from whilly.sources import fetch_github_issues
+path, stats = fetch_github_issues('<your-user>/my-hacksprint1-sandbox')
+print(f'Fetched: new={stats.new}, updated={stats.updated}, total_open={stats.total_open}')
+print(f'Plan written to: {path}')
+"
+```
+
+Получишь `tasks.json` в текущей директории. Открой:
+
+```bash
+cat tasks.json | jq '.tasks[] | {id, status, description: .description[:50]}'
+```
+
+Должно быть 3 задачи с id `GH-1`, `GH-2`, `GH-3`.
+
+## Step B.3 — Запустить с PR creation (15 мин)
+
+```bash
+# Перейди в sandbox-репо
+cd ~/my-hacksprint1-sandbox
+
+# Скопируй сгенерированный tasks.json
+cp /path/to/whilly-orchestrator/tasks.json .
+
+# Запусти whilly (последовательно для простоты)
+WHILLY_MAX_PARALLEL=1 whilly tasks.json
+```
+
+После каждой done-задачи в whilly будет создаваться branch вида `whilly/GH-1`.
+
+Открой PR вручную (gap-pack PR sink — следующий шаг для интеграции в loop):
+
+```bash
+git push origin whilly/GH-1
+gh pr create --base main --head whilly/GH-1 --title "GH-1: Add MIT LICENSE" --body "Closes #1"
+```
+
+> 💡 **Production-режим (полная автоматизация):** в текущей gap-pack ветке `--pr-on-done` ещё не интегрирован в `cli.py`. Это твоё ДЗ — посмотри `whilly/sinks/github_pr.py` и хук в `cli.py::run_plan`. Контракт уже есть.
+
+## Step B.4 — Decision Gate (10 мин)
+
+Добавь в sandbox-репо «плохой» issue:
+
+```bash
+gh issue create --title "x" --label "whilly:ready" --body ""
+```
+
+Запусти Decision Gate:
+
+```bash
+python3 -c "
+from whilly.sources import fetch_github_issues
+from whilly.decision_gate import evaluate
+from whilly.task_manager import TaskManager
+
+# Refresh tasks.json
+fetch_github_issues('<your-user>/my-hacksprint1-sandbox')
+
+tm = TaskManager('tasks.json')
+for task in tm.tasks:
+    if task.status != 'pending':
+        continue
+    d = evaluate(task)
+    print(f'{task.id}: {d.decision} ({d.reason})')
+"
+```
+
+«Плохой» issue с пустым описанием получит `refuse` (auto-refuse без LLM-вызова — описание короче 20 символов).
+
+## Step B.5 — Наблюдай retry в действии (10 мин)
+
+Заведи issue, который умышленно сложный (агент будет ошибаться):
+
+```bash
+gh issue create \
+  --title "Add /metrics endpoint with Prometheus format" \
+  --label "whilly:ready" \
+  --body "Add Prometheus metrics endpoint.
+
+**Files:** app/metrics.py
+
+## Acceptance
+- GET /metrics returns text/plain
+- Includes process_uptime_seconds gauge
+- Includes whilly_tasks_total counter
+"
+```
+
+Запусти whilly, смотри на retry-петлю в логах:
+
+```bash
+WHILLY_MAX_PARALLEL=1 WHILLY_MAX_TASK_RETRIES=3 whilly tasks.json
+```
+
+В JSONL events увидишь повторные попытки на API errors / failed acceptance criteria.
+
+## Step B.6 — Записать демо (5 мин — но запиши когда будет готов прогон)
+
+Самое важное для HackSprint1: **записать демо-видео**.
+
+```bash
+# macOS
+brew install --cask obs
+
+# Linux
+sudo apt install obs-studio
+
+# Установи + запиши screencast 2-3 минут:
+# 0:00 — терминал, видно tasks.json и Issues в браузере
+# 0:30 — запуск whilly, появляется dashboard
+# 1:00 — первая задача → done, PR в браузере
+# 2:00 — Decision Gate refuses плохой issue, label flip виден
+# 2:30 — short summary, fadeout
+```
+
+✅ Если ты дошёл сюда и записал видео — **все 5 минимальных требований HackSprint1 закрыты**.
+
+---
+
+## What you've learned in 90 minutes
+
+- **Track A:** Ralph loop, tasks.json, JSONL events, parallel agents в tmux.
+- **Track B:** GitHub Issues source, PR creation, Decision Gate, retry-loop.
+- **Architecture:** ADR-001 to ADR-008 теперь будут читаться предметно.
+
+## Next steps
+
+1. Прочитай [PRD-Whilly.md](PRD-Whilly.md) — увидишь весь контракт целиком.
+2. Прочитай [BRD-Whilly.md](BRD-Whilly.md) §11 Decision Log — пойми D6 (выбор типа задачи).
+3. Сделай свой fork whilly, добавь второй source adapter (Linear?) — ADR-006 — это шаблон.
+4. Запиши demo-видео — это **обязательно** для зачёта HackSprint1.
+
+## Troubleshooting
+
+| Проблема | Решение |
+|---|---|
+| `claude: command not found` | https://docs.claude.com/en/docs/claude-code |
+| `gh auth status` показывает 401 (token invalid) | `unset GITHUB_TOKEN; gh auth login` |
+| Dashboard ломается на узком терминале | `WHILLY_HEADLESS=1 whilly tasks.json` |
+| Бюджет упал в 0 раньше времени | проверь `WHILLY_BUDGET_USD` env, default = unlimited |
+| tmux пишет "no server running" при attach | session уже завершилась — посмотри лог в `whilly_logs/{task_id}.log` |
+| Агент в loop'е выдаёт мусор | смотри `agent_runner.is_complete` — нужна строка `<promise>COMPLETE</promise>` |
+
+## FAQ
+
+**Q: Сколько стоит прогнать tutorial Track A?**
+A: ~$0.10-0.30 на 1-3 простых задач.
+
+**Q: Сколько стоит Track B?**
+A: ~$0.50-2 в зависимости от сложности issue. Decision Gate auto-refuse экономит на мусоре.
+
+**Q: Я соло-участник HackSprint1, успею за 10 дней?**
+A: Да — Track A + минимальные требования. Optional блоки придётся сократить до 1.
+
+**Q: Можно ли запустить без `gh` CLI?**
+A: Только Track A. Track B требует `gh`.
+
+**Q: Какой бюджет на весь HackSprint1?**
+A: BRD §8 Constraints — **~$300 личных** (бюджет не компенсируется клубом). Разнеси по дням, hard-cap через `WHILLY_BUDGET_USD=300`.
+
+---
+
+**Status:** v1 · 2026-04-20 · maintained alongside the codebase.

--- a/docs/workshop/adr/ADR-001-python-over-go-and-bash.md
+++ b/docs/workshop/adr/ADR-001-python-over-go-and-bash.md
@@ -1,0 +1,76 @@
+# ADR-001 — Python over Go and Bash
+
+- **Status:** accepted
+- **Date:** 2026-04-19 (retroactive — was the original choice)
+- **Deciders:** project author
+- **Domain:** stack choice
+
+## Context
+
+Когда whilly стартовал, на столе лежали три референсные реализации Ralph-loop:
+
+- **`stepango/grkr`** — bash, ~200 LOC, минималистичный, single-agent.
+- **`egv/yolo-runner`** — Go, ~30K LOC, multi-backend, production-minded, DAG, TUI.
+- Свои наработки автора в Python (claudeproxy, pytest-плагины, prd-генераторы).
+
+Целевая аудитория — Python-команды, которые делают AI-tooling и хотят расширять оркестратор под себя без обучения новому языку. Workshop-формат добавляет требование: код должен **читаться за один день**.
+
+## Decision
+
+**Используем Python 3.10+** как единственный язык реализации whilly. Bash остаётся только как командные хелперы (git, tmux), Go не используем.
+
+## Considered alternatives
+
+### Bash (как grkr)
+
+- ✅ Минимум зависимостей, мгновенный старт.
+- ✅ Близко к git/`gh`/`tmux` без оберток.
+- ❌ Структурированный код > 500 LOC становится нечитаемым.
+- ❌ Нет нормальных datatypes — JSON парсится через `jq`, ошибки молчат.
+- ❌ Нет тест-фреймворка приличного уровня (bats работает, но это не pytest).
+- ❌ Workshop-команды не пишут на bash на повседневной основе.
+
+### Go (как yolo-runner)
+
+- ✅ Быстро, статически типизированно, production-friendly.
+- ✅ Хорошая модель concurrency (goroutines + channels).
+- ✅ Single binary деплой.
+- ❌ Кривая входа высокая для Python-команд.
+- ❌ AI/LLM экосистема в Go догоняет Python (langchain-go, openai-go), но не паритет.
+- ❌ Меньше готовых интеграций (Rich-equivalent TUI = Bubble Tea, но другой стиль).
+- ❌ Workshop за 1 день на Go-кодовой базе нереалистично без предыдущего опыта Go.
+
+### Python
+
+- ✅ Команды AI-инженерии знают Python; самые активные SDK именно Python (anthropic, openai).
+- ✅ Богатые TUI библиотеки (`rich`, `textual`).
+- ✅ pytest, ruff, mypy — зрелый toolchain.
+- ✅ Subprocess-управление достаточно для wrapping Claude CLI и `gh`.
+- ❌ Performance ниже Go на тысячах задач — не критично для целевого scale (1-100 tasks/run).
+- ❌ Деплой не single binary — но pip-install достаточен.
+
+## Consequences
+
+### Positive
+
+- Workshop participants могут читать и форкать код в первый же час.
+- Используем `rich` для dashboard — выглядит современно без TUI-фреймворка.
+- Расширяемость через obvious модули (`whilly/sources/`, `whilly/sinks/`).
+- Тесты пишутся быстро на pytest + standard mocking.
+
+### Negative
+
+- Не получаем "single binary" — нужно `pip install`.
+- На действительно больших масштабах (1000+ параллельных tasks/sec) уперлись бы в GIL — но whilly не targeting это.
+- Нужна Python 3.10+ среда.
+
+### Neutral
+
+- Возможен будущий `whilly-core` на Go как стрейч-цель (после стабилизации API), но не в этом цикле.
+
+## References
+
+- [grkr](https://github.com/stepango/grkr) — bash-вариант.
+- [yolo-runner](https://github.com/egv/yolo-runner) — Go-вариант.
+- BRD §8 Constraints (стек = Python).
+- PRD §1.2 Module map.

--- a/docs/workshop/adr/ADR-002-tasks-json-source-of-truth.md
+++ b/docs/workshop/adr/ADR-002-tasks-json-source-of-truth.md
@@ -1,0 +1,85 @@
+# ADR-002 — `tasks.json` as the source of truth
+
+- **Status:** accepted
+- **Date:** 2026-04-19 (retroactive)
+- **Deciders:** project author
+- **Domain:** state model
+
+## Context
+
+Loop'у нужно знать "что сделано / что pending / что in_progress". Источник этого знания должен:
+
+1. Переживать crash (агент упал → state не теряется).
+2. Атомарно обновляться (несколько агентов могут читать/писать одновременно).
+3. Быть человекочитаемым (debug, ручная правка).
+4. Не требовать инфраструктуры (БД, очереди).
+5. Поддерживать source adapters: даже если задачи из GitHub Issues, loop работает по тому же контракту.
+
+## Decision
+
+**`tasks.json` — единственный source of truth task state**, во всех режимах работы. Сторонние source-адаптеры (GitHub Issues, Linear, Jira) **конвертируют** свой формат в `tasks.json` при загрузке и обновляют его при изменениях.
+
+## Considered alternatives
+
+### SQLite
+
+- ✅ ACID, конкурентные чтения.
+- ✅ Богатые запросы (filter by status, etc).
+- ❌ Не human-readable (нужен `sqlite3` CLI).
+- ❌ Лишняя зависимость для простого use case.
+- ❌ Сложнее показывать diff в PR.
+
+### Redis / NATS distributed queue
+
+- ✅ Production-grade распределённая очередь.
+- ❌ Требует инфраструктуры — workshop friction.
+- ❌ Overkill для in-process supervisor с ≤ 5 агентов.
+- ❌ Не human-readable.
+
+### GitHub Issues directly (no local file)
+
+- ✅ Single source.
+- ❌ Network call per status change → latency, rate limit.
+- ❌ Не работает offline.
+- ❌ Нет своего поля для `key_files`/`acceptance` без парсинга markdown каждый раз.
+
+### `tasks.json` + atomic write via `os.replace`
+
+- ✅ Human-readable, diff-friendly.
+- ✅ POSIX atomic guarantee (`os.replace` is atomic on same filesystem).
+- ✅ Нулевая инфраструктура.
+- ✅ Source-адаптеры могут upserting в этот же файл.
+- ❌ Не масштабируется на сотни параллельных писателей — но не наш сценарий.
+
+## Decision details
+
+- File path: каждый план — отдельный `tasks.json` (или `<name>_tasks.json`).
+- Schema: см. PRD §1.3.3.
+- Atomic write: `TaskManager.save()` пишет через `tempfile.mkstemp` в той же директории + `os.replace`.
+- Read: `TaskManager.reload()` перечитывает файл целиком — дёшево даже на 1000+ tasks.
+- Конкурентность: loop читает после каждой fairness-точки (после batch dispatch, после deadlock check). При параллельном external-write последний выигрывает.
+- Source-адаптер block в schema: `{"source": {"type": "github_issues", "repo": "...", ...}}` — позволяет re-fetch при следующем запуске.
+
+## Consequences
+
+### Positive
+
+- Workshop-участник может открыть `tasks.json` в редакторе и понять состояние мгновенно.
+- Рестарт после crash тривиален (plus `--resume` для дополнительного контекста).
+- PR-ревью изменений в plan видны как обычный JSON diff.
+- Source-адаптер — отдельная ответственность, чистая модульность.
+
+### Negative
+
+- Не подходит для сотен writer'ов одновременно — но это не цель.
+- Все ridurre к JSON — сложные графы dependencies парсятся вручную.
+
+### Neutral
+
+- Будущий "DB-backed" режим возможен через слой абстракции — но не запланирован.
+
+## References
+
+- `whilly/task_manager.py` — реализация.
+- PRD §1.3.3 — schema.
+- ADR-006 — GitHub Issues source upserts в tasks.json.

--- a/docs/workshop/adr/ADR-003-tmux-and-worktree-parallelism.md
+++ b/docs/workshop/adr/ADR-003-tmux-and-worktree-parallelism.md
@@ -1,0 +1,90 @@
+# ADR-003 — tmux + git worktree for parallelism
+
+- **Status:** accepted
+- **Date:** 2026-04-19 (retroactive)
+- **Deciders:** project author
+- **Domain:** concurrency / isolation
+
+## Context
+
+Loop должен поддерживать параллельный запуск N агентов. Каждый агент должен:
+
+1. Иметь **изолированную рабочую копию репо** (не ломать друг друга через перекрывающиеся правки).
+2. Иметь **отдельный stdout/stderr** для дашборда (`l` hotkey показывает живой лог).
+3. Управляться **долгоживущим супервизором** (Python loop), который не блокируется на одном агенте.
+4. Переживать `kill -9` супервизора — running tasks доделают свою работу, можно потом attach.
+
+## Decision
+
+**Параллелизм = tmux session + git worktree per task**:
+
+- Каждый агент запускается в собственном tmux session `whilly-{task_id}`.
+- Каждой задаче (опционально, при `MAX_PARALLEL>1` и `WHILLY_WORKTREE=1`) создаётся git worktree `.whilly_worktrees/{task_id}/`.
+- Супервизор пишет prompt в файл, открывает session с `claude … -p file:promptfile`, мониторит exit code через `EXIT_CODE=N` маркер в логе.
+- На done — supervisor cherry-picks коммиты из worktree обратно в основной branch, удаляет worktree.
+
+## Considered alternatives
+
+### `subprocess.Popen` + threading
+
+- ✅ Pure Python, нет внешних зависимостей.
+- ✅ Работает в headless (CI) окружении.
+- ❌ Логи сложно показывать "живьём" (буферизация).
+- ❌ Kill супервизора убивает детей.
+- ❌ Нельзя "attach" к запущенному агенту мышкой.
+
+### Docker containers
+
+- ✅ Сильнейшая изоляция.
+- ❌ Workshop friction (Docker setup, image pull).
+- ❌ Намного медленнее старт.
+- ❌ Не работает на корпоративных машинах без Docker.
+
+### `asyncio` coroutines
+
+- ✅ Single-process, понятный control flow.
+- ❌ Не помогает с изоляцией FS — overlap key_files = race.
+- ❌ Не показывает "живые" логи без отдельной работы.
+
+### tmux + worktree (выбрано)
+
+- ✅ Каждый агент = standalone process в своей copy-on-write копии репо.
+- ✅ `tmux attach` — живой просмотр.
+- ✅ Detach-able: kill whilly не убивает агента.
+- ✅ Логи в `whilly_logs/{task_id}.log` — можно tail -f.
+- ✅ Worktree — встроен в git, ноль внешних tools.
+- ❌ Tmux требуется на машине пользователя.
+- ❌ Не работает на Windows (но это и не цель).
+
+## Decision details
+
+- **Subprocess fallback:** если `tmux_available()` == False ИЛИ `WHILLY_USE_TMUX=0` — переходим на чистый subprocess (`subprocess.Popen` + `cwd=worktree_path`).
+- **Plan-level workspace:** `WHILLY_USE_WORKSPACE=1` (default) — главный supervisor chdir'ит в `.whilly_workspaces/{slug}/` (тоже git worktree). Это защищает основное репо от случайных правок.
+- **Per-task worktree:** активируется только когда `MAX_PARALLEL>1` AND `WHILLY_WORKTREE=1` — оверхед `git worktree add` стоит дорого только если есть конкуренция.
+- **Cherry-pick back:** на task done supervisor делает `git -C .whilly_workspaces/{slug} cherry-pick {worktree_commits}` и удаляет worktree через `git worktree remove`.
+- **Stale worktree cleanup:** при старте loop сканит `.whilly_worktrees/`, удаляет завершённые.
+
+## Consequences
+
+### Positive
+
+- Параллельные агенты не мешают друг другу.
+- Workshop-демо «3 агента в 3 tmux pane'ах» очень нагляден.
+- Crash recovery естественный: tmux session живёт, supervisor restart attach'ится.
+- `tmux attach -t whilly-{task_id}` — debugging tool из коробки.
+
+### Negative
+
+- Зависимость от tmux на хосте.
+- Worktree creation добавляет ~200ms на task — ничтожно при N>1, но overhead для одной маленькой задачи.
+- Cherry-pick conflicts могут возникать на overlapping changes — текущий план учитывает только `key_files` overlap, но edge cases возможны.
+
+### Neutral
+
+- Subprocess-only режим существует и работает — просто без `tmux attach`.
+
+## References
+
+- `whilly/tmux_runner.py`, `whilly/worktree_runner.py`.
+- ADR-002 — state model независим от runner.
+- PRD §2.1 FR-9, FR-10.

--- a/docs/workshop/adr/ADR-004-claude-cli-subprocess-vs-sdk.md
+++ b/docs/workshop/adr/ADR-004-claude-cli-subprocess-vs-sdk.md
@@ -1,0 +1,84 @@
+# ADR-004 — Claude CLI subprocess instead of Anthropic SDK
+
+- **Status:** accepted
+- **Date:** 2026-04-19 (retroactive)
+- **Deciders:** project author
+- **Domain:** agent backend integration
+
+## Context
+
+Whilly запускает Claude как агента. У нас есть выбор:
+
+1. Использовать Anthropic Python SDK напрямую (`anthropic.Anthropic().messages.create(...)`).
+2. Запускать Claude CLI (`claude -p "prompt"`) как subprocess и парсить JSON вывод.
+
+Контекст требует:
+
+- **Полноценный coding agent** с tools (Read, Edit, Bash, Glob, Grep) — не просто chat completion.
+- **Permission model** для опасных операций (Bash, Edit) — либо TTY-prompts, либо `--dangerously-skip-permissions`.
+- **Cost / token tracking** на каждый run.
+- **Совместимость с user-side Claude Code конфигурацией** (CLAUDE.md, hooks, MCP servers).
+
+## Decision
+
+**Используем Claude CLI как subprocess** (`claude --output-format json -p <prompt>`). НЕ интегрируемся с Anthropic SDK напрямую.
+
+Бинарник CLI ищется как `claude` в PATH или через override `CLAUDE_BIN`.
+
+## Considered alternatives
+
+### Anthropic SDK (`anthropic` Python package)
+
+- ✅ Прямой API контроль, тонкие настройки модели.
+- ✅ Стриминг responses доступен.
+- ❌ **Нет встроенного coding agent loop** — нужно реализовывать tools (Read/Edit/Bash) самим.
+- ❌ Нужно управлять permission model самостоятельно.
+- ❌ Не использует пользовательский CLAUDE.md / hooks / MCP servers.
+- ❌ Дублируем то, что уже есть в Claude CLI.
+
+### Claude CLI subprocess (выбрано)
+
+- ✅ Coding agent loop "из коробки" — Claude CLI уже умеет читать/писать файлы, запускать bash, использовать MCP.
+- ✅ Учитывает пользовательский `~/.claude/CLAUDE.md`, settings, hooks, slash commands.
+- ✅ `--output-format json` даёт стабильный machine-readable summary с `total_cost_usd`, `usage`, `result`.
+- ✅ `<promise>COMPLETE</promise>` маркер в результате — простой контракт «агент закрыл задачу».
+- ❌ Subprocess overhead (~50ms старт CLI).
+- ❌ Зависим от того, что у пользователя установлен и настроен Claude CLI.
+- ❌ Streaming output сложнее (используем file-based лог).
+
+### Codex CLI / Aider / другие
+
+- Не на уровне Claude по качеству для нашей целевой аудитории — отложено в ADR следующего цикла.
+
+## Decision details
+
+- **Сборка команды:** `claude [permission_args] --output-format json --model <model> -p <prompt>`.
+- **Permission args:** по умолчанию `--dangerously-skip-permissions` (полный non-interactive). `WHILLY_CLAUDE_SAFE=1` → `--permission-mode acceptEdits` (interactive — для локальной отладки с TTY).
+- **Output parsing:** `_parse_claude_output(raw)` извлекает `result`, `total_cost_usd`, `usage` из JSON.
+- **Completion signal:** строка `<promise>COMPLETE</promise>` в `result_text` → `is_complete=True`. Prompt builder инструктирует агента эту строку выдавать.
+- **Retry logic:** на API errors (403/500/529) — exp.backoff в `cli.py`. На auth errors — fail-fast.
+- **Model id:** конфигурируется через `WHILLY_MODEL` (default `claude-opus-4-6[1m]`).
+
+## Consequences
+
+### Positive
+
+- Whilly наследует все возможности Claude CLI без переизобретения.
+- Пользователь может настраивать поведение агента через `CLAUDE.md` в репо — workshop-friendly.
+- MCP servers работают автоматически.
+- Можно скриптить "просто запусти агента вручную" (без whilly) той же командой — debugging easy.
+
+### Negative
+
+- Тяжелее юнит-тестировать (нужно мокать subprocess).
+- Зависим от стабильности JSON-формата CLI (формат менялся между версиями — мы парсим defensively).
+- Нет доступа к streaming (но есть к файловому логу — `dashboard l` hotkey).
+
+### Neutral
+
+- В будущем добавить SDK-backend как опцию — возможно, но не приоритет.
+
+## References
+
+- `whilly/agent_runner.py`.
+- ADR-007 — PR sink тоже использует CLI (`gh`) по тем же причинам.

--- a/docs/workshop/adr/ADR-005-jsonl-events.md
+++ b/docs/workshop/adr/ADR-005-jsonl-events.md
@@ -1,0 +1,127 @@
+# ADR-005 — JSONL events as the observability layer
+
+- **Status:** accepted
+- **Date:** 2026-04-19 (retroactive)
+- **Deciders:** project author
+- **Domain:** observability
+
+## Context
+
+Loop делает много мелких событий: старт plan, старт iteration, dispatch task, agent done, budget warning, deadlock, finish. Нужен способ:
+
+1. **Долгоживуще логировать** для post-hoc анализа (cost analytics, debug).
+2. **Стримить в реальном времени** в dashboard / TUI / dashboard-like CI tools.
+3. **Парсить простыми инструментами** (`jq`, `grep`, Python one-liners).
+4. **Не зависеть от внешней инфраструктуры** (без Loki, Datadog, Sentry).
+5. **Workshop-friendly** — участник видит лог в терминале и понимает, что происходит.
+
+## Decision
+
+**Все события loop'а пишутся в `whilly_logs/whilly_events.jsonl`** — построчный JSON (один JSON object на строку). Дополнительно: в headless mode этот же поток пишется на stdout.
+
+## Considered alternatives
+
+### Plain text logs (`logging` module)
+
+- ✅ Привычно.
+- ❌ Не парсится без regex.
+- ❌ Поля сваливаются в один string.
+- ❌ Сложно фильтровать по cost / event type / task_id.
+
+### structlog → JSON formatter
+
+- ✅ Те же JSONL events.
+- ✅ Богатые processors.
+- ❌ Дополнительная dependency.
+- ❌ Overkill для нашего объёма.
+
+### OpenTelemetry / OTLP
+
+- ✅ Industry standard.
+- ❌ Требует collector.
+- ❌ Не workshop-friendly.
+
+### SQLite log table
+
+- ✅ Запросы.
+- ❌ Не human-readable.
+- ❌ Не stream-friendly.
+
+### JSONL (выбрано)
+
+- ✅ Standard ad-hoc формат.
+- ✅ `jq`-friendly: `cat events.jsonl | jq '. | select(.event=="task.done") | .cost_usd'`.
+- ✅ Append-only, не нужен lock на чтение.
+- ✅ Streaming — строка пишется → следующая утилита её читает.
+- ✅ Schema эволюционирует свободно (новые поля игнорируются старыми парсерами).
+- ❌ Нет встроенной типизации (но есть документированный schema).
+
+## Decision details
+
+### File location
+
+- `whilly_logs/whilly_events.jsonl` (relative to plan workspace cwd).
+- Одна строка на событие, append-only.
+- При rotate — переименовать `events.jsonl` → `events.jsonl.YYYYMMDD`, начать новый файл.
+
+### Required fields per event
+
+```jsonc
+{
+  "ts": "ISO 8601 UTC",          // обязательно
+  "event": "string",             // обязательно, snake_case
+  // ... event-specific payload
+}
+```
+
+### Event taxonomy (текущая)
+
+| Event | Payload | Emitter |
+|---|---|---|
+| `plan.start` | plan_path, total tasks | cli |
+| `plan.end` | done, failed, skipped, cost_total | cli |
+| `iteration.start` | iter_num, ready | cli |
+| `iteration.end` | iter_num, done_count_delta | cli |
+| `task.start` | task_id, worker (tmux/subprocess) | cli |
+| `task.done` | task_id, cost_usd, duration_s, tokens | cli |
+| `task.failed` | task_id, reason, retry_count | cli |
+| `task.skipped` | task_id, reason | cli |
+| `budget.warning` | spent, cap | cli |
+| `budget.exceeded` | spent, cap | cli |
+| `deadlock.detected` | task_id, iterations_stuck | cli |
+| `auth.error` | task_id | cli |
+| `source.fetch` | source_type, repo, new, updated | source adapter (gap pack) |
+| `decision_gate` | task_id, decision, reason, cost_usd | decision_gate (gap pack) |
+| `sink.pr.created` | task_id, pr_url, branch | pr sink (gap pack) |
+| `sink.pr.failed` | task_id, reason | pr sink (gap pack) |
+
+### Headless mode
+
+При `WHILLY_HEADLESS=1` ИЛИ `not sys.stdout.isatty()`:
+
+- TUI отключается (`NullDashboard`).
+- События дополнительно пишутся на stdout (по строке на event) — для CI можно `whilly --headless | jq …`.
+
+## Consequences
+
+### Positive
+
+- `jq` + grep — единственные инструменты нужны для post-hoc analysis.
+- Workshop participants видят живой stream когда run в headless.
+- Schema можно расширять (gap pack добавил 4 новых event без поломки старого).
+- Test friendly — assert на содержимое JSONL легко.
+
+### Negative
+
+- На сотнях тысяч событий файл растёт — нет авто-rotate (будет добавлено при необходимости).
+- Не индексируется для random access — только sequential.
+- Нет схемы валидации (можно добавить через `pydantic` опционально).
+
+### Neutral
+
+- Можно подключить collector (Vector, Fluentd) без изменения emitter — просто tail JSONL.
+
+## References
+
+- `whilly/cli.py::_log_event`, `_emit_json`.
+- ADR-006, ADR-007, ADR-008 — все вводят новые JSONL event types.

--- a/docs/workshop/adr/ADR-006-github-issues-source-adapter.md
+++ b/docs/workshop/adr/ADR-006-github-issues-source-adapter.md
@@ -1,0 +1,153 @@
+# ADR-006 — GitHub Issues source adapter
+
+- **Status:** accepted (gap pack)
+- **Date:** 2026-04-20
+- **Deciders:** project author
+- **Domain:** source
+
+## Context
+
+Workshop demo требует "self-hosting bootstrap" — whilly запускается на репо `mshegolev/whilly-orchestrator` и закрывает свои же issues. Нужен модуль, который:
+
+1. Читает open issues с конкретного label (`whilly:ready`).
+2. Конвертирует issue → `Task` без потерь (priority, files, acceptance, traceability).
+3. Записывает результат в `tasks.json`, чтобы дальше работал стандартный loop.
+4. Idempotent — повторный запуск не теряет статус уже взятых задач.
+5. Не вводит новых runtime dependency кроме `gh` CLI.
+
+## Decision
+
+**Реализуем `whilly/sources/github_issues.py`** — модуль, который:
+
+- Вызывает `gh issue list --repo {owner/repo} --label {label} --state open --json number,title,body,labels,url --limit 50`.
+- Парсит каждый issue в `Task` с детерминированным `id = f"GH-{number}"`.
+- Записывает `tasks.json` в текущую директорию (или путь из `--out`).
+- Сохраняет `source` блок в JSON для re-fetch / трейсабилити.
+
+CLI: `whilly --source gh:owner/repo` или `whilly --source gh:owner/repo:custom-label`.
+
+## Considered alternatives
+
+### PyGithub Python SDK
+
+- ✅ Удобный объектный API.
+- ❌ Дополнительная dependency (PyGithub).
+- ❌ Дублирует работу `gh` (которая у пользователя обычно уже стоит для других task).
+- ❌ Auth handling — нужно отдельно учить токен из gh keyring.
+
+### `gh issue list --json` + Python json (выбрано)
+
+- ✅ Zero new Python deps.
+- ✅ Reuse user's existing `gh auth` (keyring, env, gh config).
+- ✅ Workshop participants скорее всего уже имеют `gh` (любой минимальный onboarding для GH require'ит).
+- ❌ Subprocess overhead — но это однократный fetch, не critical path.
+
+### Webhook-based (push GH issues → whilly endpoint)
+
+- ✅ Real-time.
+- ❌ Требует public endpoint — workshop friction.
+- ❌ Переусложнение для текущего scale.
+
+## Decision details
+
+### CLI integration
+
+```bash
+# basic
+whilly --source gh:mshegolev/whilly-orchestrator
+
+# custom label
+whilly --source gh:owner/repo:custom-label
+
+# combined with other gap pack flags
+whilly --source gh:mshegolev/whilly-orchestrator --pr-on-done --decision-gate
+```
+
+После fetch создаётся `tasks.json`, дальше loop работает обычным образом.
+
+### Issue → Task mapping
+
+| Task field | Source from issue |
+|---|---|
+| `id` | `f"GH-{number}"` |
+| `phase` | `"GH-Issues"` |
+| `category` | `"github-issue"` |
+| `priority` | label `priority:critical/high/medium/low` (default `medium`) |
+| `description` | issue title + first 500 chars of body |
+| `dependencies` | parsed from issue body `**Depends:** GH-N, GH-M` |
+| `key_files` | parsed from issue body `**Files:** path1, path2` |
+| `acceptance_criteria` | parsed from `## Acceptance` section bullets |
+| `test_steps` | parsed from `## Test` section bullets |
+| `prd_requirement` | issue URL |
+
+### Idempotent re-fetch logic
+
+```
+existing_tasks = load tasks.json (if exists)
+fetched = parse gh issue list
+
+for fetched_task in fetched:
+    if existing has fetched_task.id:
+        # Update mutable fields, preserve status
+        existing.update(description, priority, key_files, acceptance, test_steps)
+        keep status
+    else:
+        existing.append(fetched_task with status="pending")
+
+# Mark "skipped" if previously open issue is no longer in fetched
+for old in existing where source=GH:
+    if old.id not in fetched_ids and old.status in ("pending", "in_progress"):
+        old.status = "skipped"
+        old.note = "issue closed externally"
+```
+
+### `source` block in tasks.json
+
+```json
+{
+  "project": "github-mshegolev/whilly-orchestrator",
+  "source": {
+    "type": "github_issues",
+    "repo": "mshegolev/whilly-orchestrator",
+    "label": "whilly:ready",
+    "fetched_at": "2026-04-20T03:30:00Z"
+  },
+  "tasks": [/* ... */]
+}
+```
+
+### Errors
+
+| Scenario | Behavior |
+|---|---|
+| `gh` отсутствует | exit 1, hint to install |
+| `gh auth status` fails | exit 1, hint `gh auth login` |
+| Repo не существует | exit 1, repo URL in error |
+| Network timeout | single retry (5s, 30s), then exit 1 |
+| Issue body содержит секреты (`AKIA...` regex match) | warning в JSONL, продолжаем |
+
+## Consequences
+
+### Positive
+
+- Self-hosting demo работает.
+- Reuse `gh` auth — никакого нового token management.
+- Loop остаётся source-agnostic — любые будущие adapters встают в эту же модель.
+- Idempotent re-fetch позволяет периодический pull без потери прогресса.
+
+### Negative
+
+- Polling-based (не push) — задержка между creation issue и его pickup whilly.
+- `gh` CLI должен быть установлен (но это уже подразумевается для workshop).
+- Парсинг markdown body — fragile; documenting expected format в TUTORIAL.
+
+### Neutral
+
+- В будущем: Linear / Jira / GitLab adapters следуют этому же паттерну.
+
+## References
+
+- `whilly/sources/github_issues.py` (gap pack).
+- PRD §2.2.1 FR-GH-1 to FR-GH-6.
+- ADR-002 — source-агностичный state model.
+- ADR-007 — PR sink, использует тот же `gh` CLI.

--- a/docs/workshop/adr/ADR-007-pr-creation-sink.md
+++ b/docs/workshop/adr/ADR-007-pr-creation-sink.md
@@ -1,0 +1,130 @@
+# ADR-007 — PR creation sink via `gh` CLI
+
+- **Status:** accepted (gap pack)
+- **Date:** 2026-04-20
+- **Deciders:** project author
+- **Domain:** sink
+
+## Context
+
+После того, как агент закрыл задачу (`task.status = done`), результат должен попасть в общий процесс ревью. Для self-hosting demo — это PR в `mshegolev/whilly-orchestrator`. В производственном scenario — PR в любой проект, на котором whilly запущен.
+
+Требования:
+
+1. **Никогда не пушить в main напрямую** — security gate.
+2. PR должен содержать **traceability** (issue link, task id, cost, duration).
+3. Не блокировать loop при ошибке создания PR.
+4. Совместимо с per-task worktree (`WHILLY_WORKTREE=1`) — push из правильной директории.
+5. Совместимо с plan-level workspace (`.whilly_workspaces/{slug}/`) когда per-task worktree не используется.
+
+## Decision
+
+**Реализуем `whilly/sinks/github_pr.py`** — модуль, активируемый через `--pr-on-done` (или `WHILLY_PR_ON_DONE=1`). После каждой done task:
+
+1. Внутри worktree: `git push origin HEAD:whilly/{task_id}` (force-with-lease).
+2. `gh pr create --title "..." --body "..." --base main` (либо `--draft` если флаг).
+3. Если task имеет `prd_requirement` = GH issue URL → `Closes #N` в body.
+4. Логируем `sink.pr.created` или `sink.pr.failed`.
+
+Loop **не падает** при ошибке sink — task остаётся `done`, PR-failure лог.
+
+## Considered alternatives
+
+### PyGithub.create_pull(...)
+
+- ✅ Прямой API.
+- ❌ Дополнительная dependency.
+- ❌ Дублирует то, что уже делает `gh`.
+
+### Direct git push to main
+
+- ❌ Запрещено security gate.
+
+### `gh` CLI (выбрано)
+
+- ✅ Reuse auth.
+- ✅ Использует пользовательскую конфигурацию (default branch, labels, reviewers).
+- ✅ Один и тот же tool для source и sink — ноль cognitive load.
+
+### Webhook/API custom
+
+- ❌ Переусложнение.
+
+## Decision details
+
+### Branch naming
+
+- `whilly/{task_id}` (e.g. `whilly/GH-42`, `whilly/TASK-001`).
+- При collision (branch existed) — добавляется суффикс `-{timestamp}`.
+
+### PR body template
+
+```markdown
+Implements [issue link or task id].
+
+### Description
+{task.description}
+
+### Acceptance criteria
+{ - "..." for each task.acceptance_criteria }
+
+### Validation
+{ - "..." for each task.test_steps }
+
+### Whilly run
+- task_id: {task.id}
+- cost: ${cost_usd}
+- duration: {duration_s}s
+- agent log: `{log_file_path}`
+- JSONL events: `whilly_logs/whilly_events.jsonl`
+
+---
+🤖 Opened by [whilly-orchestrator](https://github.com/mshegolev/whilly-orchestrator).
+Human review required before merge.
+```
+
+### Push semantics
+
+- `git push origin HEAD:whilly/{task_id} --force-with-lease`
+- `--force-with-lease` защищает от перезаписи чужих коммитов.
+- Если push fails (permission, conflict) → `sink.pr.failed` event, task остаётся done.
+
+### `gh pr create` invocation
+
+```bash
+gh pr create \
+  --base main \
+  --head whilly/{task_id} \
+  --title "{task.id}: {task.description[:60]}" \
+  --body "$(cat /tmp/whilly_pr_body_{task.id}.md)" \
+  [--draft]
+```
+
+### Closes #N injection
+
+Если `task.prd_requirement` matches `github.com/.../issues/(\d+)` → injection в body выше списка acceptance: `Closes #{N}`.
+
+## Consequences
+
+### Positive
+
+- Self-hosting demo замыкается: issue → agent → PR → human review → merge.
+- Полная traceability в PR — ревьюер видит cost / duration / log.
+- `--draft` удобен для review pile up без notification noise.
+- Loop не ломается на sink errors — robust.
+
+### Negative
+
+- Зависим от `gh` CLI и git push permissions.
+- PR title обрезается на 60 символов — длинные descriptions усекаются (acceptable).
+- Не управляет labels / reviewers — но можно добавить флагами в follow-up.
+
+### Neutral
+
+- Будущие sinks (Slack notification, Jira comment) — отдельные модули по тому же контракту.
+
+## References
+
+- `whilly/sinks/github_pr.py` (gap pack).
+- PRD §2.2.2 FR-PR-1 to FR-PR-5.
+- ADR-006 — GH source.

--- a/docs/workshop/adr/ADR-008-decision-gate.md
+++ b/docs/workshop/adr/ADR-008-decision-gate.md
@@ -1,0 +1,162 @@
+# ADR-008 — Decision Gate before agent dispatch
+
+- **Status:** accepted (gap pack)
+- **Date:** 2026-04-20
+- **Deciders:** project author
+- **Domain:** quality / cost control
+
+## Context
+
+Не все задачи в очереди достойны того, чтобы агент тратил на них токены. Issues со скудным описанием, без acceptance criteria, противоречивые — лучше отбросить с label `needs-clarification`, чем потратить $0.50 и получить мусорный PR.
+
+Идея взята из `stepango/grkr`, где есть **Decision Gate** — короткий вызов, в котором агент сам решает proceed / refuse до начала имплементации.
+
+Требования:
+
+1. **Дёшево** — Decision Gate должен стоить < $0.01 per task (в 50× меньше типичной задачи).
+2. **Быстро** — < 60 секунд.
+3. **Conservative** — лучше пропустить плохую задачу, чем отбросить хорошую (false positives дороже false negatives).
+4. **Fail-open** — при timeout / parse error считаем proceed (не блокируем работу).
+5. **Cost учитывается** в общем budget.
+6. **Workshop UX** — refuse → label flip в GH issue, чтобы было видно почему задача в backlog.
+
+## Decision
+
+**Реализуем `whilly/decision_gate.py`** — модуль, активируемый через `--decision-gate` (или `WHILLY_DECISION_GATE=1`).
+
+Перед основным prompt'ом (после batch planning, до dispatch'а) — короткий LLM-вызов:
+
+- Prompt: «Дано описание задачи. Решишь ли её или откажешься?» + structured JSON output.
+- Timeout: 60 секунд.
+- На `proceed` → продолжаем нормальный flow.
+- На `refuse` → `task.status = "skipped"`, JSONL event, label flip в GH (если source=GH).
+
+## Considered alternatives
+
+### Always proceed (без gate)
+
+- ✅ Проще.
+- ❌ Тратим токены на мусорные задачи.
+- ❌ Получаем шумные PR на ревью.
+
+### Pre-filter в source adapter (rule-based)
+
+- ✅ Дёшево, без LLM.
+- ❌ Жёсткие правила пропускают edge cases.
+- ❌ Не понимают семантику задачи.
+
+### Decision Gate как отдельный коммерческий evaluator
+
+- ❌ Vendor lock-in.
+
+### LLM Decision Gate (выбрано)
+
+- ✅ Дёшево если использовать дешёвую модель (Haiku) или короткий prompt.
+- ✅ Понимает семантику.
+- ✅ Conservative-биас prompt'ом.
+- ❌ Зависим от стабильности LLM.
+- ❌ Дополнительная latency на каждую задачу.
+
+## Decision details
+
+### Prompt template (RU primary)
+
+```
+Ты — gate-агент, проверяющий задачи перед исполнением.
+
+Задача:
+- ID: {task.id}
+- Описание: {task.description}
+- Acceptance: {task.acceptance_criteria or "не задано"}
+- key_files: {task.key_files or "не указаны"}
+
+Реши: брать в работу или отказаться?
+
+Откажись если:
+- описание < 20 символов или явно бессмысленно
+- противоречивые требования
+- нужны секреты / доступы которых нет
+
+Возьмись если:
+- описание понятно, есть хотя бы 1 acceptance criterion
+- ИЛИ описание простое и однозначное (badge, README fix, version bump)
+
+Ответ строго JSON одной строкой:
+{"decision":"proceed"|"refuse","reason":"≤120 chars"}
+```
+
+### Implementation contract
+
+```python
+@dataclass
+class Decision:
+    decision: str           # "proceed" | "refuse"
+    reason: str
+    cost_usd: float
+
+def evaluate(task: Task, model: str = None, timeout_s: int = 60) -> Decision:
+    """Run decision gate for a task. Fail-open."""
+```
+
+### Hook into main loop
+
+```
+for batch in batches:
+    for task in batch:
+        if config.decision_gate:
+            d = decision_gate.evaluate(task, model=config.model)
+            log_event("decision_gate", task_id=task.id, decision=d.decision, reason=d.reason, cost_usd=d.cost_usd)
+            budget.add(d.cost_usd)
+
+            if d.decision == "refuse":
+                tm.mark_status([task.id], "skipped")
+                if source_is_gh:
+                    gh_label_flip(task, remove="whilly:ready", add="needs-clarification", comment=d.reason)
+                continue
+        # ... normal dispatch
+```
+
+### Fail-open
+
+- Timeout → log warning, treat as proceed.
+- JSON parse error → log warning, treat as proceed.
+- Reasoning: false-refuse раздражает и блокирует прогресс. False-proceed только тратит ~$0.50.
+
+### Cost considerations
+
+- Используем тот же модель что и main loop (consistency).
+- Prompt ~ 200 токенов, response ~ 50 токенов → ≈ $0.005 per task на Sonnet, ≈ $0.001 на Haiku.
+- Можно опционально override через `WHILLY_DECISION_GATE_MODEL=claude-haiku-4-5-20251001`.
+
+### Workshop UX
+
+- На refuse → `gh issue edit {N} --remove-label whilly:ready --add-label needs-clarification`.
+- Опционально: `gh issue comment {N} --body "Whilly Decision Gate refused: {reason}"` (controlled by `--decision-gate-comment` flag).
+
+## Consequences
+
+### Positive
+
+- Cost saving — не тратим главный prompt на заведомо плохие задачи.
+- Cleaner PR queue — мусорные задачи не доходят до агента.
+- Workshop demo: показываем агенту 1 «плохую» задачу, видим refuse + label flip.
+- JSONL event — измеримый KPI «decision gate refusal rate».
+
+### Negative
+
+- Дополнительные ~$0.001-0.005 на каждую задачу (даже на хорошие).
+- Latency +1-5 sec на task.
+- Conservative prompt может пропускать edge cases — нужна периодическая проверка accuracy.
+- Зависим от стабильности модели.
+
+### Neutral
+
+- В будущем — A/B test prompt formulations для точности.
+- Можно сделать opt-in только для GH source (config: `--decision-gate=gh-only`) — отложено.
+
+## References
+
+- `whilly/decision_gate.py` (gap pack).
+- PRD §2.2.3 FR-DG-1 to FR-DG-6.
+- Источник идеи: `stepango/grkr` README.
+- ADR-006 — label flip требует GH source.

--- a/docs/workshop/adr/ADR-009-triz-analyzer.md
+++ b/docs/workshop/adr/ADR-009-triz-analyzer.md
@@ -1,0 +1,66 @@
+# ADR-009 — TRIZ analyzer for ambiguous tasks
+
+- **Status:** accepted (retrospective)
+- **Date:** 2026-04-19 (retroactive — fixture in v3.0.0)
+- **Deciders:** project author
+- **Domain:** quality / planning
+
+## Context
+
+В реальном task board часть задач формулируется как противоречия: «нужно быстро, но безопасно», «нужно гибко, но просто». Стандартный агент в такой задаче бьётся о trade-off без понимания методологии. **TRIZ** (Theory of Inventive Problem Solving) — методология, формализующая противоречия и предлагающая 40 inventive principles для их разрешения. Идея: использовать LLM-based TRIZ-агента для предварительного анализа таких задач — дать агенту-имплементатору лучший контекст.
+
+## Decision
+
+**Реализуем `whilly/triz_analyzer.py`** как опциональный pre-step для задач, помеченных `category=triz` или с явным флагом `--triz`. Анализатор:
+
+1. Извлекает противоречие (technical / physical) из задачи.
+2. Применяет TRIZ matrix → возвращает 2-4 inventive principles.
+3. Расширяет prompt задачи: добавляет «contradiction summary» + «suggested principles».
+
+## Considered alternatives
+
+### Не использовать TRIZ
+
+- ✅ Проще.
+- ❌ На задачах с явными противоречиями — снижение качества PR.
+
+### TRIZ как обязательный шаг
+
+- ❌ Overhead на каждую задачу.
+
+### TRIZ только при флаге (выбрано)
+
+- ✅ Opt-in.
+- ✅ Образовательно для workshop — участники видят TRIZ в действии.
+- ✅ Не блокирует основной flow.
+
+## Decision details
+
+- Module: `whilly/triz_analyzer.py` (390 LOC).
+- API: `analyze(task: Task) -> TRIZResult` (contradictions, principles, recommended_actions).
+- Cost: 1 LLM call (~ $0.005-0.02 per task).
+- Trigger: `category="triz"` в task ИЛИ CLI флаг `--triz` для всего plan.
+- Output: расширенный prompt в `build_task_prompt()`.
+
+## Consequences
+
+### Positive
+
+- Workshop hour 5 demo: TRIZ применяется к задаче «сделать API быстрым и безопасным» — видим 2-4 принципа, лучший PR.
+- Образовательный эффект.
+- Не блокирует обычный flow.
+
+### Negative
+
+- Дополнительный cost.
+- Зависит от качества TRIZ knowledge в LLM.
+- Не всегда применимо — TRIZ-агент может выдать generic советы.
+
+### Neutral
+
+- Можно расширять matrix evidence (custom principles per project).
+
+## References
+
+- `whilly/triz_analyzer.py`.
+- TRIZ background: G.S. Altshuller, "And Suddenly the Inventor Appeared".

--- a/docs/workshop/adr/ADR-010-prd-wizard.md
+++ b/docs/workshop/adr/ADR-010-prd-wizard.md
@@ -1,0 +1,73 @@
+# ADR-010 — PRD wizard pipeline
+
+- **Status:** accepted (retrospective)
+- **Date:** 2026-04-19 (retroactive)
+- **Deciders:** project author
+- **Domain:** workflow
+
+## Context
+
+Часть пользователей приходит к whilly без готового `tasks.json` — у них есть только идея фичи. Стандартный flow требует:
+
+1. Написать PRD.
+2. Превратить PRD в декомпозированный список задач.
+3. Заполнить `tasks.json` со всеми полями (id, dependencies, key_files, acceptance, test_steps).
+
+Это значимый порог входа. Workshop участник, желающий за час получить «ага-эффект», уйдёт ещё на этапе написания PRD.
+
+## Decision
+
+**Включаем PRD pipeline в whilly как first-class feature**:
+
+- `whilly --prd-wizard [slug]` — interactive Claude CLI session с master prompt'ом, выдаёт `PRD-{slug}.md`.
+- `whilly --plan PRD-foo.md` — non-interactive генерация `tasks.json` из существующего PRD.
+- `whilly --init "описание идеи" [--plan] [--go]` — fast path: idea → PRD → tasks → optional auto-run.
+
+## Considered alternatives
+
+### Не включать PRD pipeline в whilly
+
+- ✅ Меньше scope.
+- ❌ Workshop friction — нужны внешние инструменты.
+
+### Только non-interactive `--plan`
+
+- ✅ Просто.
+- ❌ Не помогает тем, у кого нет PRD.
+
+### Полный wizard с auto-run (выбрано)
+
+- ✅ От идеи до running агентов в одной команде.
+- ✅ Workshop hour 1: `whilly --init "add /health endpoint" --plan --go` — wow-effect.
+- ❌ Сложнее код.
+
+## Decision details
+
+- `whilly/prd_wizard.py` (372 LOC) — orchestrates Claude CLI in interactive mode, hands master prompt for PRD generation.
+- `whilly/prd_generator.py` (375 LOC) — non-interactive PRD generation when no Claude TTY available.
+- `whilly/prd_launcher.py` (148 LOC) — splits master prompt by sections, manages session.
+- Output: `PRD-{slug}.md` in `.planning/` dir.
+- `--plan PRD.md` запускает task generation через LLM, output → `{slug}_tasks.json`.
+
+## Consequences
+
+### Positive
+
+- Полный pipeline: idea → PRD → tasks → execution.
+- Workshop demo «from zero to running agents in 5 minutes» possible.
+- Reusable: PRD format совместим с follow-up редактирования вручную.
+
+### Negative
+
+- 895 LOC дополнительно.
+- LLM-quality зависит от модели — на слабых моделях PRD получается посредственный.
+- Wizard режим требует TTY и user attention — не для headless.
+
+### Neutral
+
+- В будущем — поддержка других PRD форматов (template variants).
+
+## References
+
+- `whilly/prd_wizard.py`, `prd_generator.py`, `prd_launcher.py`.
+- `--init`, `--plan`, `--prd-wizard` CLI flags.

--- a/docs/workshop/adr/ADR-011-task-decomposer.md
+++ b/docs/workshop/adr/ADR-011-task-decomposer.md
@@ -1,0 +1,74 @@
+# ADR-011 — Mid-run task decomposer
+
+- **Status:** accepted (retrospective)
+- **Date:** 2026-04-19 (retroactive)
+- **Deciders:** project author
+- **Domain:** workflow
+
+## Context
+
+Часть задач в `tasks.json` оказываются "слишком большими" — `description` 500+ символов, 5+ acceptance criteria, hours-long expected work. Агент в такой задаче либо:
+
+- Долго работает и тратит много токенов.
+- Делает половину работы и помечает done преждевременно.
+- Падает с timeout.
+
+Хотелось бы разбивать такие задачи **во время выполнения** — при обнаружении oversized task разделить её на 2-4 подзадачи, добавить в plan, и продолжить.
+
+## Decision
+
+**Реализуем `whilly/decomposer.py`** — модуль, активирующийся раз в `WHILLY_DECOMPOSE_EVERY` итераций. Если в pending есть task с heuristic = oversized:
+
+1. LLM-вызов: «Разбей задачу X на 2-4 подзадачи».
+2. Подзадачи добавляются в `tasks.json` с `dependencies = [X]` или заменяют X.
+3. Loop переходит к следующей итерации с обновлённым plan.
+
+## Considered alternatives
+
+### Не декомпозировать (полагаемся на пользователя)
+
+- ✅ Простой control flow.
+- ❌ Пользователи часто пишут крупные задачи.
+- ❌ Падают runs из-за timeout.
+
+### Декомпозировать при load (один раз)
+
+- ✅ Проще.
+- ❌ Не реагирует на новые задачи добавленные mid-run (от source adapter polling).
+
+### Mid-run decomposer (выбрано)
+
+- ✅ Адаптивно.
+- ✅ Работает с новыми задачами от GH source.
+- ❌ Дополнительный LLM cost.
+
+## Decision details
+
+- Heuristic для oversized: `description > 500 chars` OR `acceptance_criteria > 5` OR `key_files > 8`.
+- Trigger: каждые `WHILLY_DECOMPOSE_EVERY` (default 5) итераций главного loop.
+- LLM prompt: получает task, возвращает JSON list of subtasks.
+- Subtasks merge: добавляются в `tasks.json` через `TaskManager.append`, parent task переходит в `skipped` со ссылкой на children.
+- Cost: 1 LLM call per decomposition (~$0.01-0.05).
+
+## Consequences
+
+### Positive
+
+- Большие задачи не блокируют loop.
+- Адаптивный — реагирует на новые задачи (source pulls).
+- Workshop edge case demo.
+
+### Negative
+
+- LLM-качество decomposition варьируется.
+- Дополнительный cost на каждые N итераций.
+- Возможен infinite decomposition loop если decomposer выдаёт только oversized subtasks — guarded by `MAX_DECOMPOSE_DEPTH=3`.
+
+### Neutral
+
+- Можно расширять heuristics (e.g., factor in cost history).
+
+## References
+
+- `whilly/decomposer.py`.
+- `WHILLY_DECOMPOSE_EVERY`, `WHILLY_DECOMPOSE_THRESHOLD` env vars.

--- a/docs/workshop/adr/ADR-012-self-hosting-bootstrap-demo.md
+++ b/docs/workshop/adr/ADR-012-self-hosting-bootstrap-demo.md
@@ -1,0 +1,119 @@
+# ADR-012 — Self-hosting bootstrap demo
+
+- **Status:** accepted (gap pack)
+- **Date:** 2026-04-20
+- **Deciders:** project author
+- **Domain:** workshop / demo
+
+## Context
+
+Workshop требует впечатляющего demo. Возможные сценарии:
+
+1. **Sample tasks.json:** показать `whilly` запущенным на синтетическом sample plan. Безопасно, повторимо, но "игрушечно".
+2. **Real third-party repo:** запустить `whilly` на open-source проекте. Реалистично, но сложно подготовить (нужны safe issues).
+3. **Self-hosting bootstrap:** `whilly` запускается на собственном репо `mshegolev/whilly-orchestrator`, читает свои же issues, делает свои же PRs.
+
+## Decision
+
+**Канонический demo — self-hosting bootstrap**:
+
+```bash
+whilly --source gh:mshegolev/whilly-orchestrator \
+       --pr-on-done \
+       --decision-gate
+```
+
+Демонстрирует:
+- Реальную интеграцию с GH Issues.
+- Ralph loop в действии.
+- Decision Gate (refusing 1 «плохо описанный» issue).
+- PR creation с traceability.
+- Dashboard / TUI работает.
+
+## Considered alternatives
+
+### Sample plan only
+
+- ✅ Safe.
+- ❌ Не показывает GH integration.
+- ❌ "Игрушечный" — снижает доверие.
+
+### Real third-party repo
+
+- ✅ Realistic.
+- ❌ Подготовка: нужно найти подходящий проект, заведённые issues, разрешение от maintainers.
+- ❌ Side effects невозможно предсказать (PR в чужое репо могут не понравиться).
+
+### Self-hosting bootstrap (выбрано)
+
+- ✅ Полный контроль над issues и PR.
+- ✅ Драматический эффект «whilly решает свои собственные tasks».
+- ✅ Workshop participants могут потом по тому же паттерну запустить на своих репо.
+- ✅ Issues и PRs остаются в whilly repo как examples.
+- ❌ Реальные изменения в whilly могут затронуть пользователей (но review гейт защищает).
+
+## Decision details
+
+### Подготовка
+
+- В `mshegolev/whilly-orchestrator` заводится 5-10 issues с label `whilly:ready`. Примеры:
+  - `Add CONTRIBUTING.md badge to README`
+  - `Bump pyproject.toml version pin for ruff`
+  - `Add /healthcheck endpoint to web_status.py`
+  - `Fix typo in dashboard.py docstring`
+  - `Add example tasks.json for sandbox testing`
+  - 1 заведомо «плохой» issue без описания — для показа Decision Gate refuse
+- README.md имеет секцию "Workshop kit" с CTA на TUTORIAL.md.
+
+### Demo flow (~3 минуты)
+
+```
+0:00 — Open terminal, cd whilly-orchestrator
+0:10 — Show README "Workshop kit" section
+0:30 — Run command
+       whilly --source gh:mshegolev/whilly-orchestrator --pr-on-done --decision-gate
+
+0:45 — Source adapter fetches issues, dashboard appears
+1:00 — Decision Gate rejects 1 issue (label flip visible in browser)
+1:15 — 2 agents launch in parallel tmux sessions
+1:30 — First task done, PR appears in browser
+2:30 — Second task done, second PR appears
+3:00 — Stop demo, show JSONL events file
+```
+
+### Safety gates
+
+- **Always human review** PR before merge — никаких auto-merge.
+- **Worktree isolation** — agents не модифицируют main checkout.
+- **Budget cap** `WHILLY_BUDGET_USD=10` на demo.
+- **Per-PR draft option** — `--draft` если хотим preview без notification noise.
+
+### Recovery if demo fails
+
+- Pre-recorded screencast (target: `docs/workshop/demo.gif`, 3 min).
+- JSONL replay через `dashboard --replay events.jsonl` (future feature).
+
+## Consequences
+
+### Positive
+
+- Сильное "wow" впечатление: agent работает на orchestrator'е, в котором он живёт.
+- Issues и PRs в репо — постоянная exhibition workshop'а.
+- Workshop participants легко reproduces — fork → label → run.
+
+### Negative
+
+- Зависимость от стабильности `mshegolev/whilly-orchestrator` (issue lifecycle).
+- Может создать "PR noise" в репо если запускать часто.
+- Required: issues должны быть подготовлены и обновляться.
+
+### Neutral
+
+- Альтернативный demo на sample plan остаётся как Plan B (для участников без `gh` auth).
+
+## References
+
+- BRD §10 D6 — выбор demo сценария.
+- PRD §4.2 Demo acceptance.
+- README workshop section.
+- TUTORIAL.md последняя секция.

--- a/docs/workshop/adr/README.md
+++ b/docs/workshop/adr/README.md
@@ -1,0 +1,46 @@
+# Architecture Decision Records — Whilly
+
+> **EN:** Lightweight MADR (Markdown ADR) records documenting the **why** behind whilly's architecture. Each ADR captures a decision, its context, considered alternatives, and consequences. Read in any order; cross-references are explicit.
+>
+> **RU:** Облегчённые MADR-записи, фиксирующие **почему** в архитектуре whilly. Каждый ADR описывает решение, контекст, альтернативы и последствия. Читать можно в любом порядке.
+
+---
+
+## Index
+
+| # | Title | Status | Domain |
+|---|---|---|---|
+| [001](ADR-001-python-over-go-and-bash.md) | Python over Go and Bash | accepted | Stack choice |
+| [002](ADR-002-tasks-json-source-of-truth.md) | tasks.json as source of truth | accepted | State |
+| [003](ADR-003-tmux-and-worktree-parallelism.md) | tmux + git worktree for parallelism | accepted | Concurrency |
+| [004](ADR-004-claude-cli-subprocess-vs-sdk.md) | Claude CLI subprocess vs Anthropic SDK | accepted | Backend |
+| [005](ADR-005-jsonl-events.md) | JSONL events as observability layer | accepted | Observability |
+| [006](ADR-006-github-issues-source-adapter.md) | GitHub Issues source adapter | accepted (gap pack) | Source |
+| [007](ADR-007-pr-creation-sink.md) | PR creation sink via `gh` CLI | accepted (gap pack) | Sink |
+| [008](ADR-008-decision-gate.md) | Decision Gate before agent dispatch | accepted (gap pack) | Quality |
+| [009](ADR-009-triz-analyzer.md) | TRIZ analyzer for ambiguous tasks | accepted | Quality |
+| [010](ADR-010-prd-wizard.md) | PRD wizard pipeline | accepted | Workflow |
+| [011](ADR-011-task-decomposer.md) | Mid-run task decomposer | accepted | Workflow |
+| [012](ADR-012-self-hosting-bootstrap-demo.md) | Self-hosting bootstrap demo | accepted (gap pack) | Demo |
+
+---
+
+## Status meanings
+
+- **proposed** — under discussion, not yet implemented
+- **accepted** — decision is in effect, code follows it
+- **deprecated** — superseded but kept for history
+- **superseded by ADR-XXX** — replaced explicitly
+
+---
+
+## How to add a new ADR
+
+1. Copy the most recent ADR as a template.
+2. Number sequentially (`ADR-013-...md`).
+3. Status starts `proposed`.
+4. Add a row to the index above.
+5. Reference relevant code (`whilly/X.py`) and PRD sections.
+6. Open a PR; merge only after team review.
+
+ADRs **never** get rewritten after `accepted`. To change a decision, write a new ADR that supersedes the old one.

--- a/examples/workshop/tasks.json
+++ b/examples/workshop/tasks.json
@@ -1,0 +1,124 @@
+{
+  "project": "workshop-track-a",
+  "prd_file": "docs/workshop/PRD-Whilly.md",
+  "created_at": "2026-04-20T00:00:00Z",
+  "agent_instructions": {
+    "before": [
+      "Прочитай tasks.json и progress.txt прежде чем начать.",
+      "Работай только над задачей с указанным id, ничего лишнего не трогай.",
+      "Для каждой задачи: реализуй -> запусти test_steps -> убедись что acceptance_criteria выполнены -> допиши <promise>COMPLETE</promise> в конец отчёта."
+    ],
+    "after": [
+      "Если test_steps не прошли, не помечай задачу done — попробуй исправить или явно скажи в чём проблема.",
+      "Никогда не пушь в main напрямую — здесь worktree, изменения сами поднимутся."
+    ]
+  },
+  "tasks": [
+    {
+      "id": "TASK-001",
+      "phase": "Phase 1 — Hello",
+      "category": "doc",
+      "priority": "high",
+      "description": "Create file HELLO.md with exactly one line: 'Hello from Whilly!' (no trailing newline beyond the standard one).",
+      "status": "pending",
+      "dependencies": [],
+      "key_files": ["HELLO.md"],
+      "acceptance_criteria": [
+        "HELLO.md exists at repo root",
+        "HELLO.md content is the single line 'Hello from Whilly!' with terminating newline"
+      ],
+      "test_steps": [
+        "test -s HELLO.md",
+        "head -1 HELLO.md | grep -q '^Hello from Whilly!$'"
+      ],
+      "prd_requirement": "Workshop Track A — Step A.2"
+    },
+    {
+      "id": "TASK-002",
+      "phase": "Phase 1 — Sandbox",
+      "category": "doc",
+      "priority": "medium",
+      "description": "Create README_WORKSHOP.md describing how to run this workshop tasks.json end-to-end. Include the whilly install command and the run command. Keep it under 30 lines.",
+      "status": "pending",
+      "dependencies": [],
+      "key_files": ["README_WORKSHOP.md"],
+      "acceptance_criteria": [
+        "README_WORKSHOP.md exists",
+        "Contains pip install whilly-orchestrator",
+        "Contains the whilly run command",
+        "Length <= 30 lines"
+      ],
+      "test_steps": [
+        "test -s README_WORKSHOP.md",
+        "grep -q 'pip install whilly-orchestrator' README_WORKSHOP.md",
+        "grep -q 'whilly' README_WORKSHOP.md",
+        "test $(wc -l < README_WORKSHOP.md) -le 30"
+      ],
+      "prd_requirement": "Workshop Track A — Step A.4 (parallel run example)"
+    },
+    {
+      "id": "TASK-003",
+      "phase": "Phase 2 — Quality gates",
+      "category": "test",
+      "priority": "medium",
+      "description": "Create a tiny pytest tests/test_workshop_smoke.py that asserts 1 + 1 == 2 and that the file HELLO.md exists at repo root. This proves the workshop tasks.json executes through pytest.",
+      "status": "pending",
+      "dependencies": ["TASK-001"],
+      "key_files": ["tests/test_workshop_smoke.py"],
+      "acceptance_criteria": [
+        "tests/test_workshop_smoke.py exists",
+        "Contains test_arithmetic and test_hello_md_exists",
+        "pytest -q tests/test_workshop_smoke.py passes"
+      ],
+      "test_steps": [
+        "test -s tests/test_workshop_smoke.py",
+        "grep -q 'def test_arithmetic' tests/test_workshop_smoke.py",
+        "grep -q 'def test_hello_md_exists' tests/test_workshop_smoke.py",
+        "pytest -q tests/test_workshop_smoke.py"
+      ],
+      "prd_requirement": "Workshop Track A — quality gate optional block"
+    },
+    {
+      "id": "TASK-004",
+      "phase": "Phase 3 — Observability",
+      "category": "doc",
+      "priority": "low",
+      "description": "Create OBSERVABILITY.md with 5 bullet points on what to look at when whilly run finishes: whilly_events.jsonl, per-task logs, dashboard hotkeys, budget tracking, and tmux ls.",
+      "status": "pending",
+      "dependencies": [],
+      "key_files": ["OBSERVABILITY.md"],
+      "acceptance_criteria": [
+        "OBSERVABILITY.md exists",
+        "Contains exactly 5 bullet points starting with '-' or '*'",
+        "Mentions whilly_events.jsonl",
+        "Mentions tmux"
+      ],
+      "test_steps": [
+        "test -s OBSERVABILITY.md",
+        "grep -q whilly_events.jsonl OBSERVABILITY.md",
+        "grep -q tmux OBSERVABILITY.md"
+      ],
+      "prd_requirement": "Workshop Track A — observability optional block"
+    },
+    {
+      "id": "TASK-005",
+      "phase": "Phase 3 — Observability",
+      "category": "test",
+      "priority": "low",
+      "description": "Add a tiny script scripts/show_costs.sh that prints the total cost from whilly_logs/whilly_events.jsonl using jq. The script must be idempotent and handle the 'no events file yet' case gracefully (print 0.0).",
+      "status": "pending",
+      "dependencies": ["TASK-004"],
+      "key_files": ["scripts/show_costs.sh"],
+      "acceptance_criteria": [
+        "scripts/show_costs.sh exists and is executable",
+        "Runs without error when no events file present (prints 0.0)",
+        "Uses jq to sum cost_usd from task.done events"
+      ],
+      "test_steps": [
+        "test -x scripts/show_costs.sh",
+        "bash -c 'rm -f /tmp/_whilly_events_test.jsonl; ./scripts/show_costs.sh /tmp/_whilly_events_test.jsonl' | grep -q '0'"
+      ],
+      "prd_requirement": "Workshop Track A — cost analysis optional block"
+    }
+  ]
+}

--- a/scripts/sync_workshop_docs.sh
+++ b/scripts/sync_workshop_docs.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Sync workshop docs from this repo into the Obsidian vault.
+#
+# Source: docs/workshop/        (canonical, lives with the code)
+# Dest:   <vault>/02-Projects/ai/workshop/whilly/
+#
+# Usage:
+#   scripts/sync_workshop_docs.sh             # uses default vault path
+#   scripts/sync_workshop_docs.sh --dry-run   # show what would be copied
+#   VAULT_PATH=/path scripts/sync_workshop_docs.sh
+#
+# rsync semantics:
+#   --delete to keep the destination in lockstep with the source
+#   --exclude .DS_Store, *.swp, .git
+#
+# Idempotent. Safe to re-run.
+
+set -euo pipefail
+
+# ── Defaults ───────────────────────────────────────────────
+DEFAULT_VAULT="${HOME}/Documents/Obsidian Vault"
+VAULT_PATH="${VAULT_PATH:-$DEFAULT_VAULT}"
+SUBPATH="02-Projects/ai/workshop/whilly"
+
+DRY_RUN=""
+if [ "${1:-}" = "--dry-run" ] || [ "${1:-}" = "-n" ]; then
+    DRY_RUN="--dry-run"
+fi
+
+# ── Resolve paths ──────────────────────────────────────────
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SRC_DIR="${REPO_ROOT}/docs/workshop"
+DEST_DIR="${VAULT_PATH}/${SUBPATH}"
+
+if [ ! -d "$SRC_DIR" ]; then
+    echo "✗ Source directory not found: $SRC_DIR" >&2
+    exit 1
+fi
+if [ ! -d "$VAULT_PATH" ]; then
+    echo "✗ Obsidian vault not found: $VAULT_PATH" >&2
+    echo "  Set VAULT_PATH to your vault location." >&2
+    exit 1
+fi
+
+mkdir -p "$DEST_DIR"
+
+echo "Sync workshop docs"
+echo "  src:  $SRC_DIR"
+echo "  dest: $DEST_DIR"
+[ -n "$DRY_RUN" ] && echo "  mode: DRY RUN (no files copied)"
+echo ""
+
+# ── rsync ──────────────────────────────────────────────────
+rsync -av $DRY_RUN \
+    --delete \
+    --exclude='.DS_Store' \
+    --exclude='*.swp' \
+    --exclude='.git/' \
+    "${SRC_DIR}/" \
+    "${DEST_DIR}/"
+
+if [ -z "$DRY_RUN" ]; then
+    echo ""
+    echo "✓ Sync complete."
+    echo "  Files in destination:"
+    ls -la "$DEST_DIR" | tail -n +2
+fi

--- a/tests/test_decision_gate.py
+++ b/tests/test_decision_gate.py
@@ -1,0 +1,211 @@
+"""Unit tests for whilly.decision_gate."""
+
+from __future__ import annotations
+
+
+import pytest
+
+from whilly.agent_runner import AgentResult, AgentUsage
+from whilly.decision_gate import (
+    PROCEED,
+    REFUSE,
+    Decision,
+    build_prompt,
+    evaluate,
+    label_flip_for_gh_task,
+    parse_decision,
+)
+from whilly.task_manager import Task
+
+
+def _make_task(**overrides) -> Task:
+    base = dict(
+        id="GH-1",
+        phase="GH-Issues",
+        category="github-issue",
+        priority="medium",
+        description="Add a /health endpoint to the FastAPI server returning ok",
+        status="pending",
+        dependencies=[],
+        key_files=["app/server.py"],
+        acceptance_criteria=["GET /health returns 200"],
+        test_steps=["curl localhost"],
+        prd_requirement="https://github.com/foo/bar/issues/1",
+    )
+    base.update(overrides)
+    return Task(**base)
+
+
+# ── parse_decision ─────────────────────────────────────────────────────────────
+
+
+class TestParseDecision:
+    def test_clean_proceed(self):
+        d, r = parse_decision('{"decision":"proceed","reason":"clear"}')
+        assert d == PROCEED
+        assert r == "clear"
+
+    def test_clean_refuse(self):
+        d, r = parse_decision('{"decision":"refuse","reason":"empty"}')
+        assert d == REFUSE
+        assert r == "empty"
+
+    def test_decision_with_padding(self):
+        d, _ = parse_decision('  {"decision":"proceed","reason":"x"}  \n')
+        assert d == PROCEED
+
+    def test_extra_text_around(self):
+        text = 'Sure, here you go: {"decision":"refuse","reason":"missing acceptance"}\n--end'
+        d, r = parse_decision(text)
+        assert d == REFUSE
+        assert "missing" in r
+
+    def test_invalid_decision_value_falls_open(self):
+        d, _ = parse_decision('{"decision":"maybe","reason":"x"}')
+        assert d == PROCEED
+
+    def test_empty_text_falls_open(self):
+        d, r = parse_decision("")
+        assert d == PROCEED
+        assert "fail-open" in r
+
+    def test_keyword_fallback_refuse(self):
+        d, _ = parse_decision("the gate would refuse this one")
+        assert d == REFUSE
+
+    def test_keyword_fallback_no_match_proceeds(self):
+        d, _ = parse_decision("nonsense without keywords")
+        assert d == PROCEED
+
+
+# ── build_prompt ───────────────────────────────────────────────────────────────
+
+
+class TestBuildPrompt:
+    def test_includes_id_priority_acceptance(self):
+        p = build_prompt(_make_task())
+        assert "GH-1" in p
+        assert "medium" in p
+        assert "GET /health returns 200" in p
+        assert "app/server.py" in p
+
+    def test_empty_acceptance_renders_marker(self):
+        p = build_prompt(_make_task(acceptance_criteria=[]))
+        assert "не задано" in p
+
+    def test_empty_files_renders_marker(self):
+        p = build_prompt(_make_task(key_files=[]))
+        assert "не указаны" in p
+
+
+# ── evaluate ───────────────────────────────────────────────────────────────────
+
+
+class TestEvaluateAutoRefuseShortDescription:
+    def test_short_description_auto_refuses_without_runner_call(self):
+        called = []
+
+        def runner(*args, **kwargs):
+            called.append(args)
+            raise AssertionError("runner should not be called for short descriptions")
+
+        d = evaluate(_make_task(description="x"), runner=runner)
+        assert d.decision == REFUSE
+        assert "too short" in d.reason
+        assert d.cost_usd == 0.0
+        assert called == []
+
+
+class TestEvaluateProceedFromRunner:
+    def test_proceed_returned_with_cost(self):
+        result = AgentResult(
+            result_text='{"decision":"proceed","reason":"clear"}',
+            usage=AgentUsage(cost_usd=0.003),
+            exit_code=0,
+        )
+
+        def runner(prompt, model, timeout):
+            return result
+
+        d = evaluate(_make_task(), runner=runner)
+        assert d.decision == PROCEED
+        assert d.reason == "clear"
+        assert d.cost_usd == pytest.approx(0.003)
+
+
+class TestEvaluateRefuseFromRunner:
+    def test_refuse_returned(self):
+        result = AgentResult(
+            result_text='{"decision":"refuse","reason":"no acceptance"}',
+            usage=AgentUsage(cost_usd=0.002),
+            exit_code=0,
+        )
+
+        d = evaluate(_make_task(), runner=lambda p, m, t: result)
+        assert d.decision == REFUSE
+        assert d.reason == "no acceptance"
+
+
+class TestEvaluateFailOpen:
+    def test_runner_exception_fails_open_to_proceed(self):
+        def runner(*args, **kwargs):
+            raise RuntimeError("network down")
+
+        d = evaluate(_make_task(), runner=runner)
+        assert d.decision == PROCEED
+        assert "network down" in d.reason
+
+    def test_runner_nonzero_exit_fails_open(self):
+        result = AgentResult(result_text="", exit_code=2)
+
+        d = evaluate(_make_task(), runner=lambda p, m, t: result)
+        assert d.decision == PROCEED
+        assert "exit 2" in d.reason
+
+    def test_unparsable_response_falls_open(self):
+        result = AgentResult(result_text="just plain text", exit_code=0)
+
+        d = evaluate(_make_task(), runner=lambda p, m, t: result)
+        assert d.decision == PROCEED
+
+
+# ── label_flip_for_gh_task ─────────────────────────────────────────────────────
+
+
+class TestLabelFlip:
+    def test_no_flip_when_decision_is_proceed(self):
+        d = Decision(decision=PROCEED, reason="ok")
+        flipped = label_flip_for_gh_task(_make_task(), d, runner=lambda args: 0)
+        assert flipped is False
+
+    def test_no_flip_when_not_a_gh_task(self):
+        d = Decision(decision=REFUSE, reason="x")
+        task = _make_task(id="TASK-001", prd_requirement="")
+        assert label_flip_for_gh_task(task, d, runner=lambda args: 0) is False
+
+    def test_no_flip_when_url_lacks_issue_number(self):
+        d = Decision(decision=REFUSE, reason="x")
+        task = _make_task(prd_requirement="https://github.com/foo/bar/wiki/page")
+        assert label_flip_for_gh_task(task, d, runner=lambda args: 0) is False
+
+    def test_flip_called_with_correct_args(self):
+        d = Decision(decision=REFUSE, reason="x")
+        captured = []
+
+        def fake_runner(args):
+            captured.append(args)
+            return 0
+
+        flipped = label_flip_for_gh_task(_make_task(), d, runner=fake_runner)
+        assert flipped is True
+        assert captured
+        args = captured[0]
+        assert "issue" in args and "edit" in args
+        assert "1" in args  # issue number
+        assert "--add-label" in args and "needs-clarification" in args
+        assert "--remove-label" in args and "whilly:ready" in args
+
+    def test_flip_runner_failure_returns_false(self):
+        d = Decision(decision=REFUSE, reason="x")
+        flipped = label_flip_for_gh_task(_make_task(), d, runner=lambda args: 1)
+        assert flipped is False

--- a/tests/test_github_issues_source.py
+++ b/tests/test_github_issues_source.py
@@ -1,0 +1,315 @@
+"""Unit tests for whilly.sources.github_issues."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from whilly.sources import github_issues as gh
+from whilly.sources.github_issues import (
+    DEFAULT_LABEL,
+    GitHubIssuesSource,
+    FetchStats,
+    _detect_secrets,
+    _extract_inline_field,
+    _extract_section,
+    _priority_from_labels,
+    fetch_github_issues,
+    issue_to_task,
+    merge_into_plan,
+)
+
+
+# ── source spec parsing ────────────────────────────────────────────────────────
+
+
+class TestSpecParsing:
+    def test_parse_with_gh_prefix_default_label(self):
+        spec = GitHubIssuesSource.parse("gh:foo/bar")
+        assert spec.owner == "foo"
+        assert spec.repo == "bar"
+        assert spec.label == DEFAULT_LABEL
+        assert spec.repo_full == "foo/bar"
+        assert spec.project_name == "github-foo-bar"
+
+    def test_parse_without_gh_prefix(self):
+        spec = GitHubIssuesSource.parse("foo/bar")
+        assert spec.owner == "foo"
+        assert spec.repo == "bar"
+
+    def test_parse_with_custom_label(self):
+        spec = GitHubIssuesSource.parse("gh:foo/bar:my-label")
+        assert spec.label == "my-label"
+
+    def test_parse_invalid_no_slash(self):
+        with pytest.raises(ValueError, match="owner/repo"):
+            GitHubIssuesSource.parse("gh:foobar")
+
+    def test_parse_invalid_empty_owner(self):
+        with pytest.raises(ValueError, match="owner/repo"):
+            GitHubIssuesSource.parse("gh:/bar")
+
+
+# ── label parsing ──────────────────────────────────────────────────────────────
+
+
+class TestPriorityFromLabels:
+    def test_default_medium(self):
+        assert _priority_from_labels([]) == "medium"
+
+    def test_priority_critical(self):
+        labels = [{"name": "priority:critical"}, {"name": "bug"}]
+        assert _priority_from_labels(labels) == "critical"
+
+    def test_priority_low(self):
+        assert _priority_from_labels([{"name": "Priority:Low"}]) == "low"
+
+    def test_unknown_labels_default_medium(self):
+        assert _priority_from_labels([{"name": "bug"}, {"name": "feature"}]) == "medium"
+
+
+# ── secret detection ───────────────────────────────────────────────────────────
+
+
+class TestSecretDetection:
+    def test_aws_key_detected(self):
+        text = "Use this credential: AKIAIOSFODNN7EXAMPLE"
+        hits = _detect_secrets(text)
+        assert any("AKIA" in h for h in hits)
+
+    def test_github_pat_detected(self):
+        text = "token=ghp_" + "A" * 40
+        hits = _detect_secrets(text)
+        assert any("ghp_" in h for h in hits)
+
+    def test_clean_text(self):
+        assert _detect_secrets("just a normal description") == []
+
+
+# ── inline / section extraction ────────────────────────────────────────────────
+
+
+class TestExtractors:
+    def test_inline_field_files(self):
+        body = "**Files:** src/a.py, src/b.py , tests/c.py\nrest"
+        assert _extract_inline_field(body, "Files") == ["src/a.py", "src/b.py", "tests/c.py"]
+
+    def test_inline_field_missing(self):
+        assert _extract_inline_field("nothing here", "Files") == []
+
+    def test_section_acceptance(self):
+        body = "Some intro\n## Acceptance\n- returns 200\n- body matches schema\n\n## Test\n- curl localhost\n"
+        assert _extract_section(body, "Acceptance") == ["returns 200", "body matches schema"]
+        assert _extract_section(body, "Test") == ["curl localhost"]
+
+    def test_section_case_insensitive(self):
+        body = "## acceptance\n- one"
+        assert _extract_section(body, "Acceptance") == ["one"]
+
+    def test_section_missing(self):
+        assert _extract_section("# Other\n- x", "Acceptance") == []
+
+
+# ── issue → task ───────────────────────────────────────────────────────────────
+
+
+class TestIssueToTask:
+    def test_basic_conversion(self):
+        issue = {
+            "number": 42,
+            "title": "Add /health endpoint",
+            "body": (
+                "We need a healthcheck.\n\n"
+                "**Files:** app/server.py\n"
+                "## Acceptance\n"
+                "- GET /health -> 200\n"
+                "## Test\n"
+                "- curl -s localhost/health\n"
+            ),
+            "labels": [{"name": "priority:high"}],
+            "url": "https://github.com/foo/bar/issues/42",
+        }
+        task, secrets = issue_to_task(issue)
+        assert task.id == "GH-42"
+        assert task.phase == "GH-Issues"
+        assert task.category == "github-issue"
+        assert task.priority == "high"
+        assert task.status == "pending"
+        assert task.key_files == ["app/server.py"]
+        assert task.acceptance_criteria == ["GET /health -> 200"]
+        assert task.test_steps == ["curl -s localhost/health"]
+        assert task.prd_requirement == "https://github.com/foo/bar/issues/42"
+        assert "/health endpoint" in task.description
+        assert secrets == []
+
+    def test_empty_body(self):
+        issue = {"number": 5, "title": "Quick fix", "body": "", "labels": [], "url": ""}
+        task, secrets = issue_to_task(issue)
+        assert task.id == "GH-5"
+        assert task.description == "Quick fix"
+        assert task.acceptance_criteria == []
+        assert task.priority == "medium"
+
+    def test_secret_warning(self):
+        issue = {
+            "number": 1,
+            "title": "x",
+            "body": "key=AKIAIOSFODNN7EXAMPLE more text",
+            "labels": [],
+            "url": "",
+        }
+        _, secrets = issue_to_task(issue)
+        assert secrets
+
+    def test_long_body_truncated(self):
+        body = "Header\n" + ("line\n" * 200)
+        issue = {"number": 1, "title": "T", "body": body, "labels": [], "url": ""}
+        task, _ = issue_to_task(issue)
+        assert "…" in task.description
+        assert len(task.description) < 600
+
+
+# ── merge_into_plan idempotency ────────────────────────────────────────────────
+
+
+class TestMergeIntoPlan:
+    @pytest.fixture
+    def source(self) -> GitHubIssuesSource:
+        return GitHubIssuesSource(owner="foo", repo="bar", label=DEFAULT_LABEL)
+
+    def test_merge_into_empty_file_creates_plan(self, tmp_path: Path, source: GitHubIssuesSource):
+        plan = tmp_path / "tasks.json"
+        issues = [
+            {"number": 1, "title": "first", "body": "", "labels": [], "url": ""},
+            {"number": 2, "title": "second", "body": "", "labels": [], "url": ""},
+        ]
+        stats = merge_into_plan(issues, source, plan)
+        assert stats.new == 2
+        assert stats.updated == 0
+        data = json.loads(plan.read_text())
+        ids = [t["id"] for t in data["tasks"]]
+        assert ids == ["GH-1", "GH-2"]
+        assert data["source"]["repo"] == "foo/bar"
+        assert data["project"] == "github-foo-bar"
+
+    def test_re_fetch_preserves_status(self, tmp_path: Path, source: GitHubIssuesSource):
+        plan = tmp_path / "tasks.json"
+        # First fetch.
+        merge_into_plan(
+            [{"number": 1, "title": "T", "body": "old", "labels": [], "url": ""}],
+            source,
+            plan,
+        )
+        # Mutate a task's status as if loop ran.
+        data = json.loads(plan.read_text())
+        data["tasks"][0]["status"] = "in_progress"
+        plan.write_text(json.dumps(data))
+
+        # Re-fetch with updated body.
+        stats = merge_into_plan(
+            [{"number": 1, "title": "T new", "body": "fresh body", "labels": [], "url": ""}],
+            source,
+            plan,
+        )
+        assert stats.new == 0
+        assert stats.updated == 1
+        data2 = json.loads(plan.read_text())
+        assert data2["tasks"][0]["status"] == "in_progress"  # preserved
+        assert "fresh body" in data2["tasks"][0]["description"]  # refreshed
+
+    def test_externally_closed_issue_marked_skipped(self, tmp_path: Path, source: GitHubIssuesSource):
+        plan = tmp_path / "tasks.json"
+        merge_into_plan(
+            [
+                {"number": 1, "title": "A", "body": "", "labels": [], "url": ""},
+                {"number": 2, "title": "B", "body": "", "labels": [], "url": ""},
+            ],
+            source,
+            plan,
+        )
+        # Re-fetch with #2 missing (closed externally).
+        stats = merge_into_plan(
+            [{"number": 1, "title": "A", "body": "", "labels": [], "url": ""}],
+            source,
+            plan,
+        )
+        assert stats.closed_externally == 1
+        data = json.loads(plan.read_text())
+        statuses = {t["id"]: t["status"] for t in data["tasks"]}
+        assert statuses["GH-1"] == "pending"
+        assert statuses["GH-2"] == "skipped"
+
+    def test_done_status_not_overridden_when_issue_disappears(self, tmp_path: Path, source: GitHubIssuesSource):
+        plan = tmp_path / "tasks.json"
+        merge_into_plan(
+            [{"number": 1, "title": "A", "body": "", "labels": [], "url": ""}],
+            source,
+            plan,
+        )
+        data = json.loads(plan.read_text())
+        data["tasks"][0]["status"] = "done"
+        plan.write_text(json.dumps(data))
+
+        merge_into_plan([], source, plan)  # issue gone
+        data = json.loads(plan.read_text())
+        # done status preserved — only pending/in_progress get auto-skipped.
+        assert data["tasks"][0]["status"] == "done"
+
+
+# ── fetch_github_issues end-to-end (gh mocked) ────────────────────────────────
+
+
+class TestFetchEndToEnd:
+    def test_fetch_invokes_gh_and_writes_plan(self, tmp_path: Path):
+        plan = tmp_path / "tasks.json"
+        gh_payload = json.dumps(
+            [
+                {
+                    "number": 7,
+                    "title": "Add CONTRIBUTING badge",
+                    "body": "Easy one.\n\n## Acceptance\n- README has the badge\n",
+                    "labels": [{"name": "priority:low"}],
+                    "url": "https://github.com/owner/repo/issues/7",
+                }
+            ]
+        )
+
+        class _CompletedProc:
+            returncode = 0
+            stdout = gh_payload
+            stderr = ""
+
+        with patch.object(gh, "_run_gh", return_value=_CompletedProc()) as mock_run:
+            path, stats = fetch_github_issues("owner/repo", out_path=plan)
+        mock_run.assert_called_once()
+        assert path == plan.resolve()
+        assert stats.new == 1
+        loaded = json.loads(plan.read_text())
+        assert loaded["tasks"][0]["id"] == "GH-7"
+        assert loaded["tasks"][0]["priority"] == "low"
+
+    def test_fetch_propagates_gh_failure(self, tmp_path: Path):
+        plan = tmp_path / "tasks.json"
+
+        class _FailedProc:
+            returncode = 1
+            stdout = ""
+            stderr = "auth failed"
+
+        with patch.object(gh, "_run_gh", return_value=_FailedProc()):
+            with pytest.raises(RuntimeError, match="gh issue list failed"):
+                fetch_github_issues("owner/repo", out_path=plan)
+
+    def test_fetch_invalid_repo_format(self, tmp_path: Path):
+        with pytest.raises(ValueError, match="owner/repo"):
+            fetch_github_issues("just-a-name", out_path=tmp_path / "x.json")
+
+    def test_stats_dataclass_defaults(self):
+        s = FetchStats()
+        assert s.new == 0
+        assert s.updated == 0
+        assert s.closed_externally == 0
+        assert s.secret_warnings == []

--- a/tests/test_github_pr_sink.py
+++ b/tests/test_github_pr_sink.py
@@ -1,0 +1,188 @@
+"""Unit tests for whilly.sinks.github_pr."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+
+from whilly.sinks import github_pr as gp
+from whilly.sinks.github_pr import (
+    GitHubPRSink,
+    PRResult,
+    _branch_name,
+    _extract_issue_number,
+    _short_title,
+    open_pr_for_task,
+    render_pr_body,
+)
+from whilly.task_manager import Task
+
+
+def _make_task(**overrides) -> Task:
+    base = dict(
+        id="GH-42",
+        phase="GH-Issues",
+        category="github-issue",
+        priority="medium",
+        description="Add /health endpoint returning ok",
+        status="done",
+        dependencies=[],
+        key_files=["app/server.py"],
+        acceptance_criteria=["GET /health returns 200"],
+        test_steps=["curl -s localhost/health"],
+        prd_requirement="https://github.com/foo/bar/issues/42",
+    )
+    base.update(overrides)
+    return Task(**base)
+
+
+# ── pure helpers ───────────────────────────────────────────────────────────────
+
+
+class TestBranchName:
+    def test_clean_id(self):
+        assert _branch_name(_make_task(id="TASK-001"), "whilly") == "whilly/TASK-001"
+
+    def test_unsafe_chars_replaced(self):
+        assert _branch_name(_make_task(id="GH 42!"), "whilly") == "whilly/GH-42-"
+
+    def test_custom_prefix(self):
+        assert _branch_name(_make_task(id="X"), "agent") == "agent/X"
+
+
+class TestShortTitle:
+    def test_short_first_line(self):
+        t = _make_task(description="Add foo")
+        assert _short_title(t) == "GH-42: Add foo"
+
+    def test_long_truncated(self):
+        long_desc = "a" * 200
+        title = _short_title(_make_task(description=long_desc))
+        assert title.startswith("GH-42: ")
+        assert title.endswith("…")
+        assert len(title) <= 80
+
+    def test_empty_description_falls_back_to_id(self):
+        t = _make_task(description="")
+        assert _short_title(t) == "GH-42"
+
+
+class TestIssueExtraction:
+    def test_extracts_number(self):
+        assert _extract_issue_number("https://github.com/foo/bar/issues/42") == 42
+
+    def test_no_url(self):
+        assert _extract_issue_number("") is None
+        assert _extract_issue_number("not a url") is None
+
+    def test_other_url(self):
+        assert _extract_issue_number("https://github.com/foo/bar/pull/3") is None
+
+
+# ── PR body rendering ─────────────────────────────────────────────────────────
+
+
+class TestRenderBody:
+    def test_with_issue_link(self):
+        body = render_pr_body(_make_task(), cost_usd=0.42, duration_s=12.0, log_file="logs/x.log")
+        assert "Closes #42." in body
+        assert "GET /health returns 200" in body
+        assert "$0.4200" in body
+        assert "12.0s" in body
+        assert "logs/x.log" in body
+        assert "🤖 Opened by" in body
+
+    def test_without_issue_link_with_prd_url(self):
+        t = _make_task(prd_requirement="https://example.com/spec/123")
+        body = render_pr_body(t)
+        assert "Closes #" not in body
+        assert "Implements [GH-42](https://example.com/spec/123)" in body
+
+    def test_without_any_url(self):
+        t = _make_task(prd_requirement="")
+        body = render_pr_body(t)
+        assert "Implements task `GH-42`." in body
+
+    def test_omits_empty_sections(self):
+        t = _make_task(acceptance_criteria=[], test_steps=[])
+        body = render_pr_body(t)
+        assert "Acceptance criteria" not in body
+        assert "Validation" not in body
+
+
+# ── open_pr_for_task with mocked subprocess ────────────────────────────────────
+
+
+class _Proc:
+    def __init__(self, returncode: int = 0, stdout: str = "", stderr: str = ""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+class TestOpenPRForTask:
+    def test_happy_path(self, tmp_path: Path):
+        worktree = tmp_path
+        push = _Proc(0, "")
+        pr = _Proc(0, "https://github.com/foo/bar/pull/77\n")
+
+        with patch.object(gp, "_run", side_effect=[push, pr]) as mock_run:
+            result = open_pr_for_task(_make_task(), worktree_path=worktree)
+
+        assert result.ok is True
+        assert result.pr_url == "https://github.com/foo/bar/pull/77"
+        assert result.branch == "whilly/GH-42"
+        # First call is git push, second is gh pr create.
+        first_cmd = mock_run.call_args_list[0].args[0]
+        assert first_cmd[0] == "git"
+        assert "push" in first_cmd
+
+    def test_missing_worktree(self, tmp_path: Path):
+        result = open_pr_for_task(_make_task(), worktree_path=tmp_path / "missing")
+        assert result.ok is False
+        assert "worktree not found" in result.reason
+
+    def test_push_failure(self, tmp_path: Path):
+        push = _Proc(1, "", "fatal: permission denied\n")
+        with patch.object(gp, "_run", return_value=push):
+            result = open_pr_for_task(_make_task(), worktree_path=tmp_path)
+        assert result.ok is False
+        assert "git push failed" in result.reason
+
+    def test_gh_pr_create_failure(self, tmp_path: Path):
+        push = _Proc(0)
+        pr = _Proc(1, "", "validation failed\n")
+        with patch.object(gp, "_run", side_effect=[push, pr]):
+            result = open_pr_for_task(_make_task(), worktree_path=tmp_path)
+        assert result.ok is False
+        assert "gh pr create failed" in result.reason
+
+    def test_pr_already_exists_returns_ok_with_url(self, tmp_path: Path):
+        push = _Proc(0)
+        pr_fail = _Proc(1, "", "a pull request already exists for this branch")
+        view = _Proc(0, json.dumps({"url": "https://github.com/foo/bar/pull/12"}))
+        with patch.object(gp, "_run", side_effect=[push, pr_fail, view]):
+            result = open_pr_for_task(_make_task(), worktree_path=tmp_path)
+        assert result.ok is True
+        assert result.pr_url == "https://github.com/foo/bar/pull/12"
+
+    def test_draft_flag_passed(self, tmp_path: Path):
+        push = _Proc(0)
+        pr = _Proc(0, "https://x/pr/1\n")
+        with patch.object(gp, "_run", side_effect=[push, pr]) as mock_run:
+            open_pr_for_task(_make_task(), worktree_path=tmp_path, draft=True)
+        gh_cmd = mock_run.call_args_list[1].args[0]
+        assert "--draft" in gh_cmd
+
+
+class TestGitHubPRSinkClass:
+    def test_open_delegates_to_module_function(self, tmp_path: Path):
+        sink = GitHubPRSink(base_branch="develop", draft=True)
+        with patch.object(gp, "open_pr_for_task", return_value=PRResult(ok=True, pr_url="x")) as m:
+            res = sink.open(_make_task(), worktree_path=tmp_path)
+        assert res.ok
+        assert m.call_args.kwargs["base"] == "develop"
+        assert m.call_args.kwargs["draft"] is True
+        assert m.call_args.kwargs["branch_prefix"] == "whilly"

--- a/tests/test_whilly_headless.py
+++ b/tests/test_whilly_headless.py
@@ -9,7 +9,6 @@ Covers:
 
 from __future__ import annotations
 
-import importlib.util
 import json
 import os
 import shutil
@@ -19,30 +18,14 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from whilly import cli as whilly_main
+from whilly.config import WhillyConfig
+from whilly.dashboard import NullDashboard
+
 _requires_claude = pytest.mark.skipif(
     shutil.which("claude") is None,
     reason="requires 'claude' CLI in PATH (not available in CI runner)",
 )
-
-# Ensure project root on path
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
-
-from whilly.config import WhillyConfig
-from whilly.dashboard import NullDashboard
-
-# ── Load whilly.py as 'whilly_main' to avoid shadowing by whilly/ package ───
-
-
-def _load_whilly_main():
-    """Import whilly.py script as 'whilly_main' module."""
-    whilly_py = Path(__file__).resolve().parent.parent / "whilly.py"
-    spec = importlib.util.spec_from_file_location("whilly_main", str(whilly_py))
-    mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)
-    return mod
-
-
-whilly_main = _load_whilly_main()
 
 
 # ── Fixtures ──────────────────────────────────────────────────
@@ -244,6 +227,7 @@ class TestRunPlanHeadless:
             patch.object(whilly_main, "Reporter") as MockReporter,
             patch.object(whilly_main, "needs_decompose", return_value=False),
             patch.object(whilly_main, "notify_plan_done"),
+            patch("whilly.cli.time.sleep"),
         ):
             mock_reporter = MagicMock()
             mock_reporter.totals = MagicMock()
@@ -275,6 +259,7 @@ class TestRunPlanHeadless:
             patch.object(whilly_main, "Reporter") as MockReporter,
             patch.object(whilly_main, "needs_decompose", return_value=False),
             patch.object(whilly_main, "notify_plan_done"),
+            patch("whilly.cli.time.sleep"),
         ):
             mock_reporter = MagicMock()
             mock_reporter.totals = MagicMock()
@@ -291,12 +276,15 @@ class TestRunPlanHeadless:
     @_requires_claude
     def test_exit_code_1_on_failures(self, failed_plan_file, tmp_path):
         """Exit code is 1 when some tasks failed."""
-        config = WhillyConfig(HEADLESS=True, LOG_DIR=str(tmp_path / "logs"), MAX_PARALLEL=1)
+        config = WhillyConfig(
+            HEADLESS=True, LOG_DIR=str(tmp_path / "logs"), MAX_PARALLEL=1, MAX_TASK_RETRIES=0
+        )
 
         with (
             patch.object(whilly_main, "Reporter") as MockReporter,
             patch.object(whilly_main, "needs_decompose", return_value=False),
             patch.object(whilly_main, "notify_plan_done"),
+            patch("whilly.cli.time.sleep"),
         ):
             mock_reporter = MagicMock()
             mock_reporter.totals = MagicMock()

--- a/whilly/decision_gate.py
+++ b/whilly/decision_gate.py
@@ -1,0 +1,271 @@
+"""Decision Gate — short LLM-based pre-check before dispatching an agent.
+
+Idea borrowed from `stepango/grkr`: before spending a full agent run on a task,
+ask a cheap LLM gate "should we take this task or refuse?". On refuse, the task
+is marked `skipped` and (optionally) labelled `needs-clarification` upstream.
+
+Fail-open semantics: any error (timeout, parse failure, LLM down) defaults to
+`proceed` so we never starve the loop on infrastructure flakes.
+
+Programmatic:
+    from whilly.decision_gate import evaluate
+    decision = evaluate(task)  # returns Decision(decision="proceed"|"refuse", reason=..., cost_usd=...)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass
+from typing import Callable
+
+from whilly.agent_runner import AgentResult, run_agent
+from whilly.task_manager import Task
+
+log = logging.getLogger("whilly")
+
+
+DEFAULT_MODEL = "claude-haiku-4-5-20251001"
+DEFAULT_TIMEOUT_S = 60
+MIN_DESCRIPTION_LEN = 20
+
+# Where decisions land. Public to keep tests friendly.
+PROCEED = "proceed"
+REFUSE = "refuse"
+
+
+@dataclass
+class Decision:
+    decision: str  # "proceed" | "refuse"
+    reason: str
+    cost_usd: float = 0.0
+    raw_text: str = ""  # for debug only
+
+
+# ── Prompt ────────────────────────────────────────────────────────────────────
+
+
+PROMPT_TEMPLATE = """Ты — gate-агент, проверяющий задачи перед исполнением.
+Твоя цель — отсеять заведомо мусорные/неполные задачи, чтобы не тратить токены.
+
+Задача:
+- ID: {id}
+- Priority: {priority}
+- Описание:
+{description}
+- Acceptance criteria: {acceptance}
+- key_files: {key_files}
+
+Реши: брать в работу или отказаться?
+
+Откажись (refuse) если:
+- описание явно бессмысленное или короче 20 символов
+- противоречивые требования
+- нужны секреты / доступы которых нет
+- acceptance отсутствует И описание неоднозначно
+
+Возьмись (proceed) если:
+- описание понятно и есть хотя бы 1 acceptance criterion
+- ИЛИ описание простое и однозначное (badge, README fix, version bump)
+- При сомнениях — proceed (false-refuse дороже false-proceed).
+
+Ответ строго одной строкой валидного JSON, без пояснений и без блока ```:
+{{"decision":"proceed"|"refuse","reason":"≤120 chars"}}
+"""
+
+
+def build_prompt(task: Task) -> str:
+    acceptance = ", ".join(task.acceptance_criteria) if task.acceptance_criteria else "не задано"
+    files = ", ".join(task.key_files) if task.key_files else "не указаны"
+    return PROMPT_TEMPLATE.format(
+        id=task.id,
+        priority=task.priority,
+        description=(task.description or "(пусто)").strip(),
+        acceptance=acceptance,
+        key_files=files,
+    )
+
+
+# ── Result parsing ────────────────────────────────────────────────────────────
+
+
+_JSON_BLOB_RE = re.compile(r"\{[^{}]*\"decision\"\s*:\s*\"(?P<dec>proceed|refuse)\"[^{}]*\}", re.IGNORECASE)
+
+
+def parse_decision(raw_text: str) -> tuple[str, str]:
+    """Extract (decision, reason) from raw LLM output.
+
+    Tolerant: accepts bare JSON, fenced JSON, JSON with extra text around.
+    Returns (PROCEED, "...") on parse failure (fail-open).
+    """
+    if not raw_text:
+        return PROCEED, "fail-open: empty LLM response"
+
+    # 1) Try direct JSON parse first.
+    candidate = raw_text.strip()
+    try:
+        parsed = json.loads(candidate)
+        decision = (parsed.get("decision") or "").lower()
+        reason = (parsed.get("reason") or "").strip()
+        if decision in (PROCEED, REFUSE):
+            return decision, reason or "no reason"
+    except (json.JSONDecodeError, AttributeError):
+        pass
+
+    # 2) Search for an embedded JSON blob.
+    m = _JSON_BLOB_RE.search(candidate)
+    if m:
+        try:
+            sub = candidate[m.start() : m.end()]
+            parsed = json.loads(sub)
+            decision = (parsed.get("decision") or "").lower()
+            reason = (parsed.get("reason") or "").strip()
+            if decision in (PROCEED, REFUSE):
+                return decision, reason or "no reason"
+        except json.JSONDecodeError:
+            pass
+
+    # 3) Bare keyword fallback.
+    low = candidate.lower()
+    if "refuse" in low and "proceed" not in low:
+        return REFUSE, "fallback keyword: refuse"
+    return PROCEED, "fail-open: could not parse decision"
+
+
+# ── Evaluation ────────────────────────────────────────────────────────────────
+
+
+# Type alias for the runner — used to inject mocks in tests.
+RunnerFn = Callable[[str, str, int | None], AgentResult]
+
+
+def _default_runner(prompt: str, model: str, timeout: int | None) -> AgentResult:
+    return run_agent(prompt, model=model, timeout=timeout)
+
+
+def evaluate(
+    task: Task,
+    model: str = DEFAULT_MODEL,
+    timeout_s: int = DEFAULT_TIMEOUT_S,
+    runner: RunnerFn = _default_runner,
+) -> Decision:
+    """Run the decision gate for a task.
+
+    Always returns a Decision (never raises). The default runner uses the
+    `whilly.agent_runner.run_agent` underneath; tests inject a fake runner.
+    """
+    # Hard rule: descriptions shorter than MIN_DESCRIPTION_LEN are auto-refused
+    # without spending an LLM call.
+    desc = (task.description or "").strip()
+    if len(desc) < MIN_DESCRIPTION_LEN:
+        return Decision(
+            decision=REFUSE,
+            reason=f"description too short ({len(desc)} chars < {MIN_DESCRIPTION_LEN})",
+            cost_usd=0.0,
+        )
+
+    prompt = build_prompt(task)
+    try:
+        result = runner(prompt, model, timeout_s)
+    except Exception as exc:  # noqa: BLE001
+        log.warning("Decision gate LLM call raised: %s", exc)
+        return Decision(decision=PROCEED, reason=f"fail-open: runner exception {exc}", cost_usd=0.0)
+
+    if result.exit_code != 0:
+        log.warning("Decision gate non-zero exit (%s) for %s", result.exit_code, task.id)
+        return Decision(
+            decision=PROCEED,
+            reason=f"fail-open: runner exit {result.exit_code}",
+            cost_usd=result.usage.cost_usd,
+            raw_text=result.result_text,
+        )
+
+    decision, reason = parse_decision(result.result_text)
+    return Decision(
+        decision=decision,
+        reason=reason,
+        cost_usd=result.usage.cost_usd,
+        raw_text=result.result_text,
+    )
+
+
+# ── Optional GH label flip on refuse ──────────────────────────────────────────
+
+
+def label_flip_for_gh_task(
+    task: Task,
+    decision: Decision,
+    add_label: str = "needs-clarification",
+    remove_label: str = "whilly:ready",
+    add_comment: bool = False,
+    runner: Callable[[list[str]], int] | None = None,
+) -> bool:
+    """If task originated from GitHub Issues source and was refused, flip labels.
+
+    Returns True if a label flip was attempted, False if not applicable.
+    `runner` (optional) accepts a list of CLI args and returns exit code; default
+    invokes `gh` via subprocess.
+    """
+    if decision.decision != REFUSE:
+        return False
+    if not (task.id.startswith("GH-") and task.prd_requirement):
+        return False
+
+    # Extract issue number from prd_requirement URL.
+    m = re.search(r"/issues/(\d+)", task.prd_requirement)
+    if not m:
+        return False
+    issue_n = m.group(1)
+
+    # owner/repo from the URL too.
+    repo_m = re.search(r"github\.com/([^/]+/[^/]+)/issues/", task.prd_requirement)
+    if not repo_m:
+        return False
+    repo = repo_m.group(1)
+
+    args = [
+        "issue",
+        "edit",
+        issue_n,
+        "--repo",
+        repo,
+        "--add-label",
+        add_label,
+        "--remove-label",
+        remove_label,
+    ]
+
+    if runner is None:
+        import os as _os
+        import subprocess
+
+        env = dict(_os.environ)
+        env.pop("GITHUB_TOKEN", None)
+        env.pop("GH_TOKEN", None)
+        proc = subprocess.run(["gh", *args], capture_output=True, text=True, env=env, check=False)
+        if proc.returncode != 0:
+            log.warning("gh issue edit (label flip) failed for %s: %s", task.id, proc.stderr.strip())
+            return False
+        if add_comment:
+            comment_proc = subprocess.run(
+                [
+                    "gh",
+                    "issue",
+                    "comment",
+                    issue_n,
+                    "--repo",
+                    repo,
+                    "--body",
+                    f"Whilly Decision Gate refused this task: {decision.reason}",
+                ],
+                capture_output=True,
+                text=True,
+                env=env,
+                check=False,
+            )
+            if comment_proc.returncode != 0:
+                log.warning("gh issue comment failed for %s: %s", task.id, comment_proc.stderr.strip())
+        return True
+    else:
+        return runner(args) == 0

--- a/whilly/sinks/__init__.py
+++ b/whilly/sinks/__init__.py
@@ -1,0 +1,5 @@
+"""Sink adapters: post-processing of completed tasks (PR creation, notifications, ...)."""
+
+from whilly.sinks.github_pr import GitHubPRSink, PRResult, open_pr_for_task
+
+__all__ = ["GitHubPRSink", "PRResult", "open_pr_for_task"]

--- a/whilly/sinks/github_pr.py
+++ b/whilly/sinks/github_pr.py
@@ -1,0 +1,256 @@
+"""GitHub PR creation sink.
+
+After a task is marked done, push the worktree commits to a feature branch and
+open a pull request via the `gh` CLI. Designed to *never* break the main loop:
+on any failure we return a `PRResult` with `ok=False` and let the caller log it.
+
+Programmatic:
+    from whilly.sinks import open_pr_for_task
+    result = open_pr_for_task(task, worktree_path=Path("..."), base="main")
+    if not result.ok:
+        log.warning("PR sink failed for %s: %s", task.id, result.reason)
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+from whilly.task_manager import Task
+
+log = logging.getLogger("whilly")
+
+
+# ── Public spec ────────────────────────────────────────────────────────────────
+
+
+DEFAULT_GH_BIN = "gh"
+DEFAULT_GIT_BIN = "git"
+DEFAULT_BASE_BRANCH = "main"
+
+_ISSUE_URL_RE = re.compile(r"github\.com/[^/]+/[^/]+/issues/(\d+)", re.IGNORECASE)
+
+
+@dataclass
+class PRResult:
+    """Outcome of a PR creation attempt."""
+
+    ok: bool
+    pr_url: str = ""
+    branch: str = ""
+    reason: str = ""  # populated on failure
+
+
+@dataclass
+class GitHubPRSink:
+    """Configuration for the PR sink."""
+
+    base_branch: str = DEFAULT_BASE_BRANCH
+    draft: bool = False
+    branch_prefix: str = "whilly"
+    gh_bin: str = DEFAULT_GH_BIN
+    git_bin: str = DEFAULT_GIT_BIN
+
+    def open(self, task: Task, worktree_path: Path, **extras) -> PRResult:
+        """Open a PR for `task` using the working tree at `worktree_path`."""
+        return open_pr_for_task(
+            task=task,
+            worktree_path=worktree_path,
+            base=self.base_branch,
+            draft=self.draft,
+            branch_prefix=self.branch_prefix,
+            gh_bin=self.gh_bin,
+            git_bin=self.git_bin,
+            **extras,
+        )
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+
+def _strip_env_tokens() -> dict:
+    """Return os.environ copy with GH/GITHUB tokens removed (prefer keyring auth)."""
+    import os as _os
+
+    env = dict(_os.environ)
+    env.pop("GITHUB_TOKEN", None)
+    env.pop("GH_TOKEN", None)
+    return env
+
+
+def _run(cmd: list[str], cwd: Path, timeout: int = 60) -> subprocess.CompletedProcess:
+    """Run a CLI inside `cwd`, return CompletedProcess (no raise)."""
+    return subprocess.run(
+        cmd,
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        env=_strip_env_tokens(),
+        check=False,
+    )
+
+
+def _branch_name(task: Task, prefix: str) -> str:
+    safe_id = re.sub(r"[^A-Za-z0-9._-]+", "-", task.id)
+    return f"{prefix}/{safe_id}"
+
+
+def _short_title(task: Task, max_len: int = 60) -> str:
+    """Return a one-line title prefix for the PR. Falls back to task.id."""
+    raw = (task.description or "").strip().splitlines()[0] if task.description else ""
+    if not raw:
+        return task.id
+    if len(raw) > max_len:
+        raw = raw[: max_len - 1].rstrip() + "…"
+    return f"{task.id}: {raw}"
+
+
+def _extract_issue_number(prd_requirement: str) -> int | None:
+    """If prd_requirement is a GH issue URL, return the issue number."""
+    if not prd_requirement:
+        return None
+    m = _ISSUE_URL_RE.search(prd_requirement)
+    if not m:
+        return None
+    try:
+        return int(m.group(1))
+    except (TypeError, ValueError):
+        return None
+
+
+def render_pr_body(
+    task: Task,
+    cost_usd: float = 0.0,
+    duration_s: float = 0.0,
+    log_file: str = "",
+) -> str:
+    """Render the markdown body for the PR. Pure function, no IO."""
+    lines: list[str] = []
+
+    issue_n = _extract_issue_number(task.prd_requirement)
+    if issue_n is not None:
+        lines.append(f"Closes #{issue_n}.")
+        lines.append("")
+    elif task.prd_requirement:
+        lines.append(f"Implements [{task.id}]({task.prd_requirement}).")
+        lines.append("")
+    else:
+        lines.append(f"Implements task `{task.id}`.")
+        lines.append("")
+
+    lines.append("### Description")
+    lines.append((task.description or "(no description)").strip())
+    lines.append("")
+
+    if task.acceptance_criteria:
+        lines.append("### Acceptance criteria")
+        for ac in task.acceptance_criteria:
+            lines.append(f"- {ac}")
+        lines.append("")
+
+    if task.test_steps:
+        lines.append("### Validation")
+        for ts in task.test_steps:
+            lines.append(f"- {ts}")
+        lines.append("")
+
+    lines.append("### Whilly run")
+    lines.append(f"- task_id: `{task.id}`")
+    lines.append(f"- cost: ${cost_usd:.4f}")
+    lines.append(f"- duration: {duration_s:.1f}s")
+    if log_file:
+        lines.append(f"- agent log: `{log_file}`")
+    lines.append("- JSONL events: `whilly_logs/whilly_events.jsonl`")
+    lines.append("")
+    lines.append("---")
+    lines.append("🤖 Opened by [whilly-orchestrator](https://github.com/mshegolev/whilly-orchestrator).")
+    lines.append("Human review required before merge.")
+    return "\n".join(lines)
+
+
+# ── Top-level entry point ─────────────────────────────────────────────────────
+
+
+def open_pr_for_task(
+    task: Task,
+    worktree_path: Path,
+    base: str = DEFAULT_BASE_BRANCH,
+    draft: bool = False,
+    branch_prefix: str = "whilly",
+    cost_usd: float = 0.0,
+    duration_s: float = 0.0,
+    log_file: str = "",
+    push_timeout: int = 60,
+    pr_timeout: int = 60,
+    gh_bin: str = DEFAULT_GH_BIN,
+    git_bin: str = DEFAULT_GIT_BIN,
+) -> PRResult:
+    """Push the worktree branch and open a PR.
+
+    Steps:
+    1. `git push origin HEAD:{branch} --force-with-lease`
+    2. `gh pr create --base {base} --head {branch} --title ... --body-file ...`
+
+    Never raises — failures populate PRResult.reason.
+    """
+    branch = _branch_name(task, branch_prefix)
+    title = _short_title(task)
+    body = render_pr_body(task, cost_usd=cost_usd, duration_s=duration_s, log_file=log_file)
+
+    if not worktree_path.exists():
+        return PRResult(ok=False, branch=branch, reason=f"worktree not found: {worktree_path}")
+
+    # 1) push
+    push_cmd = [git_bin, "push", "origin", f"HEAD:{branch}", "--force-with-lease"]
+    try:
+        push_proc = _run(push_cmd, cwd=worktree_path, timeout=push_timeout)
+    except subprocess.TimeoutExpired:
+        return PRResult(ok=False, branch=branch, reason="git push timeout")
+    if push_proc.returncode != 0:
+        msg = (push_proc.stderr or push_proc.stdout or "").strip().splitlines()[-1:] or ["unknown"]
+        return PRResult(ok=False, branch=branch, reason=f"git push failed: {msg[0]}")
+
+    # 2) gh pr create
+    pr_cmd = [
+        gh_bin,
+        "pr",
+        "create",
+        "--base",
+        base,
+        "--head",
+        branch,
+        "--title",
+        title,
+        "--body",
+        body,
+    ]
+    if draft:
+        pr_cmd.append("--draft")
+
+    try:
+        pr_proc = _run(pr_cmd, cwd=worktree_path, timeout=pr_timeout)
+    except subprocess.TimeoutExpired:
+        return PRResult(ok=False, branch=branch, reason="gh pr create timeout")
+
+    if pr_proc.returncode != 0:
+        # If a PR already exists we treat that as ok and try to extract its URL via gh pr view.
+        stderr = (pr_proc.stderr or "").strip()
+        if "already exists" in stderr.lower():
+            view_proc = _run([gh_bin, "pr", "view", branch, "--json", "url"], cwd=worktree_path)
+            if view_proc.returncode == 0:
+                try:
+                    import json
+
+                    url = json.loads(view_proc.stdout).get("url", "")
+                    return PRResult(ok=True, pr_url=url, branch=branch, reason="pr already existed")
+                except Exception:  # noqa: BLE001
+                    return PRResult(ok=True, pr_url="", branch=branch, reason="pr already existed")
+        msg = stderr.splitlines()[-1:] or ["unknown"]
+        return PRResult(ok=False, branch=branch, reason=f"gh pr create failed: {msg[0]}")
+
+    pr_url = (pr_proc.stdout or "").strip().splitlines()[-1] if pr_proc.stdout else ""
+    return PRResult(ok=True, pr_url=pr_url, branch=branch)

--- a/whilly/sources/__init__.py
+++ b/whilly/sources/__init__.py
@@ -1,0 +1,5 @@
+"""Source adapters: convert external task trackers (GitHub Issues, etc.) into tasks.json."""
+
+from whilly.sources.github_issues import GitHubIssuesSource, fetch_github_issues
+
+__all__ = ["GitHubIssuesSource", "fetch_github_issues"]

--- a/whilly/sources/github_issues.py
+++ b/whilly/sources/github_issues.py
@@ -1,0 +1,414 @@
+"""GitHub Issues source adapter.
+
+Reads open issues from a GitHub repo via the `gh` CLI and converts them into
+whilly Tasks written to a `tasks.json` plan file.
+
+Idempotent: re-fetching keeps the status of issues already taken into work.
+
+CLI usage:
+    whilly --source gh:owner/repo                 # default label whilly:ready
+    whilly --source gh:owner/repo:ready           # custom label
+    whilly --source gh:owner/repo --source-out my_plan.json
+
+Programmatic:
+    from whilly.sources import fetch_github_issues
+    fetch_github_issues("owner/repo", label="whilly:ready", out_path="tasks.json")
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import logging
+import re
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from whilly.task_manager import Task
+
+log = logging.getLogger("whilly")
+
+
+# ── Public spec ────────────────────────────────────────────────────────────────
+
+DEFAULT_LABEL = "whilly:ready"
+DEFAULT_LIMIT = 50
+DEFAULT_GH_BIN = "gh"
+
+# A small allowlist of priority labels we honor on issues.
+PRIORITY_LABELS = {
+    "priority:critical": "critical",
+    "priority:high": "high",
+    "priority:medium": "medium",
+    "priority:low": "low",
+}
+
+# Heuristic regex to detect leaked secrets in issue body — best effort warning.
+_SECRET_PATTERNS = [
+    re.compile(r"AKIA[0-9A-Z]{16}"),  # AWS access key id
+    re.compile(r"ghp_[A-Za-z0-9]{36,}"),  # GitHub PAT
+    re.compile(r"sk-[A-Za-z0-9]{32,}"),  # OpenAI / generic SK
+    re.compile(r"xox[abposr]-[A-Za-z0-9-]{10,}"),  # Slack tokens
+]
+
+
+@dataclass
+class FetchStats:
+    """Summary of what changed during a fetch."""
+
+    new: int = 0  # newly added tasks
+    updated: int = 0  # mutable fields refreshed
+    closed_externally: int = 0  # tasks marked skipped because issue was closed
+    secret_warnings: list[str] = field(default_factory=list)
+    total_open: int = 0  # total open issues retrieved
+
+
+# ── CLI source spec parsing ────────────────────────────────────────────────────
+
+
+@dataclass
+class GitHubIssuesSource:
+    """Parsed `--source gh:owner/repo[:label]` spec."""
+
+    owner: str
+    repo: str
+    label: str = DEFAULT_LABEL
+    limit: int = DEFAULT_LIMIT
+
+    @property
+    def repo_full(self) -> str:
+        return f"{self.owner}/{self.repo}"
+
+    @property
+    def project_name(self) -> str:
+        return f"github-{self.owner}-{self.repo}"
+
+    @classmethod
+    def parse(cls, spec: str) -> GitHubIssuesSource:
+        """Parse 'gh:owner/repo' or 'gh:owner/repo:label'.
+
+        Accepts the leading 'gh:' prefix or a bare 'owner/repo' for convenience.
+        """
+        s = spec.strip()
+        if s.startswith("gh:"):
+            s = s[3:]
+
+        # Split off optional label after a ':' that follows owner/repo.
+        if s.count("/") < 1:
+            raise ValueError(f"Invalid GitHub source spec: {spec!r} — expected gh:owner/repo[:label]")
+
+        # owner/repo[:label]
+        repo_part, sep, label = s.partition(":")
+        owner_repo_pieces = repo_part.split("/", 1)
+        if len(owner_repo_pieces) != 2 or not all(owner_repo_pieces):
+            raise ValueError(f"Invalid GitHub source spec: {spec!r} — owner/repo missing")
+
+        owner, repo = owner_repo_pieces
+        return cls(owner=owner, repo=repo, label=(label or DEFAULT_LABEL))
+
+
+# ── gh CLI invocation ──────────────────────────────────────────────────────────
+
+
+def _gh_bin() -> str:
+    """Resolve gh CLI path. WHILLY_GH_BIN env overrides for corp mirrors."""
+    import os as _os
+
+    return _os.environ.get("WHILLY_GH_BIN") or DEFAULT_GH_BIN
+
+
+def _run_gh(args: list[str], timeout: int = 30) -> subprocess.CompletedProcess:
+    """Run `gh` with GITHUB_TOKEN unset to prefer the user's keyring auth.
+
+    GITHUB_TOKEN env is sometimes set to expired CI tokens; gh prefers that env over the keyring,
+    which causes spurious 401s. We unset it explicitly for this subprocess only.
+    """
+    import os as _os
+
+    env = dict(_os.environ)
+    env.pop("GITHUB_TOKEN", None)
+    env.pop("GH_TOKEN", None)
+
+    cmd = [_gh_bin(), *args]
+    return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout, env=env, check=False)
+
+
+def _gh_issue_list(source: GitHubIssuesSource, timeout: int = 30) -> list[dict]:
+    """Fetch open issues with the given label. Raises RuntimeError on failure."""
+    args = [
+        "issue",
+        "list",
+        "--repo",
+        source.repo_full,
+        "--state",
+        "open",
+        "--label",
+        source.label,
+        "--limit",
+        str(source.limit),
+        "--json",
+        "number,title,body,labels,url,createdAt,updatedAt",
+    ]
+    proc = _run_gh(args, timeout=timeout)
+    if proc.returncode != 0:
+        msg = proc.stderr.strip() or proc.stdout.strip() or "no output"
+        raise RuntimeError(f"gh issue list failed (exit {proc.returncode}): {msg}")
+
+    try:
+        return json.loads(proc.stdout or "[]")
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"gh returned non-JSON: {exc}") from exc
+
+
+# ── Issue → Task conversion ────────────────────────────────────────────────────
+
+
+def _extract_section(body: str, section_name: str) -> list[str]:
+    """Extract bullet items under a `## {section_name}` heading.
+
+    Stops at the next heading or the end of the body. Returns text of bullet
+    items with the leading dash/asterisk stripped.
+    """
+    if not body:
+        return []
+
+    lines = body.splitlines()
+    in_section = False
+    items: list[str] = []
+    heading_re = re.compile(rf"^#{{1,6}}\s+{re.escape(section_name)}\b", re.IGNORECASE)
+    next_heading_re = re.compile(r"^#{1,6}\s+\S")
+    bullet_re = re.compile(r"^\s*[-*]\s+(.+?)\s*$")
+
+    for ln in lines:
+        if heading_re.match(ln):
+            in_section = True
+            continue
+        if in_section and next_heading_re.match(ln):
+            break
+        if in_section:
+            m = bullet_re.match(ln)
+            if m:
+                items.append(m.group(1).strip())
+    return items
+
+
+def _extract_inline_field(body: str, field_name: str) -> list[str]:
+    """Extract '**Field:** a, b, c' style inline lists from issue body.
+
+    Returns trimmed comma-separated tokens.
+    """
+    if not body:
+        return []
+    pattern = re.compile(rf"\*\*{re.escape(field_name)}:\*\*\s*(.+?)\s*(?:\n|$)", re.IGNORECASE)
+    m = pattern.search(body)
+    if not m:
+        return []
+    raw = m.group(1)
+    return [tok.strip() for tok in raw.split(",") if tok.strip()]
+
+
+def _detect_secrets(text: str) -> list[str]:
+    """Return names of secret pattern matches found in text. Best effort."""
+    hits: list[str] = []
+    for rx in _SECRET_PATTERNS:
+        if rx.search(text):
+            hits.append(rx.pattern)
+    return hits
+
+
+def _priority_from_labels(labels: list[dict]) -> str:
+    """Map GitHub labels to whilly priority. Default 'medium'."""
+    for label in labels:
+        name = (label.get("name") or "").lower()
+        if name in PRIORITY_LABELS:
+            return PRIORITY_LABELS[name]
+    return "medium"
+
+
+def issue_to_task(issue: dict) -> tuple[Task, list[str]]:
+    """Convert a single gh JSON issue into a whilly Task.
+
+    Returns (task, secret_pattern_hits) — second element non-empty when the
+    body matched any of the secret regexes (the caller can warn).
+    """
+    number = issue.get("number")
+    title = issue.get("title", "").strip() or f"Issue #{number}"
+    body = issue.get("body") or ""
+    labels = issue.get("labels") or []
+    url = issue.get("url", "")
+
+    description_short = title
+    if body:
+        # Keep the first 480 chars of body so the task stays human-friendly.
+        snippet = body.strip().replace("\r\n", "\n")
+        if len(snippet) > 480:
+            snippet = snippet[:480].rsplit("\n", 1)[0] + "\n…"
+        description_short = f"{title}\n\n{snippet}"
+
+    task = Task(
+        id=f"GH-{number}",
+        phase="GH-Issues",
+        category="github-issue",
+        priority=_priority_from_labels(labels),
+        description=description_short,
+        status="pending",
+        dependencies=_extract_inline_field(body, "Depends"),
+        key_files=_extract_inline_field(body, "Files"),
+        acceptance_criteria=_extract_section(body, "Acceptance"),
+        test_steps=_extract_section(body, "Test"),
+        prd_requirement=url,
+    )
+    return task, _detect_secrets(body)
+
+
+# ── Plan file IO + idempotent merge ────────────────────────────────────────────
+
+
+def _build_source_block(source: GitHubIssuesSource) -> dict:
+    return {
+        "type": "github_issues",
+        "repo": source.repo_full,
+        "label": source.label,
+        "fetched_at": _dt.datetime.now(_dt.timezone.utc).isoformat(),
+    }
+
+
+def _load_existing(plan_path: Path) -> dict:
+    if not plan_path.exists():
+        return {"project": "", "tasks": []}
+    try:
+        return json.loads(plan_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        raise RuntimeError(f"existing plan {plan_path} is not valid JSON: {exc}") from exc
+
+
+def _atomic_write_json(plan_path: Path, data: dict) -> None:
+    """Write JSON atomically (tmp + os.replace)."""
+    import os
+    import tempfile
+
+    dir_path = plan_path.parent
+    dir_path.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=dir_path, prefix=".whilly_src_", suffix=".tmp")
+    try:
+        os.write(fd, (json.dumps(data, ensure_ascii=False, indent=2) + "\n").encode("utf-8"))
+        os.close(fd)
+        os.replace(tmp, plan_path)
+    except BaseException:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        if Path(tmp).exists():
+            Path(tmp).unlink(missing_ok=True)
+        raise
+
+
+def merge_into_plan(
+    issues: list[dict],
+    source: GitHubIssuesSource,
+    plan_path: Path,
+) -> FetchStats:
+    """Idempotent merge of fetched issues into the plan file at `plan_path`.
+
+    - Adds new tasks (status pending).
+    - For existing tasks (matched by id == "GH-{number}"): refreshes
+      description, priority, key_files, acceptance, test_steps. Status preserved.
+    - Tasks that previously came from this source but are no longer in `issues`
+      and were still pending/in_progress are marked `skipped` (issue closed
+      externally).
+    """
+    stats = FetchStats(total_open=len(issues))
+    existing = _load_existing(plan_path)
+    existing_tasks = existing.get("tasks", [])
+    existing_by_id = {t.get("id"): t for t in existing_tasks}
+
+    fetched_ids: set[str] = set()
+    for raw in issues:
+        task, secret_hits = issue_to_task(raw)
+        fetched_ids.add(task.id)
+        if secret_hits:
+            stats.secret_warnings.append(f"{task.id}: matched patterns {secret_hits}")
+
+        if task.id in existing_by_id:
+            cur = existing_by_id[task.id]
+            # Preserve status; refresh mutable fields.
+            for field_name in (
+                "description",
+                "priority",
+                "key_files",
+                "acceptance_criteria",
+                "test_steps",
+                "prd_requirement",
+                "dependencies",
+            ):
+                cur[field_name] = getattr(task, field_name)
+            stats.updated += 1
+        else:
+            existing_tasks.append(task.to_dict())
+            stats.new += 1
+
+    # Mark stale tasks that disappeared from the source as skipped.
+    for cur in existing_tasks:
+        if not cur.get("id", "").startswith("GH-"):
+            continue
+        if cur["id"] in fetched_ids:
+            continue
+        if cur.get("status") in ("pending", "in_progress"):
+            cur["status"] = "skipped"
+            stats.closed_externally += 1
+
+    # Stamp project + source block.
+    if not existing.get("project"):
+        existing["project"] = source.project_name
+    existing["source"] = _build_source_block(source)
+    existing["tasks"] = existing_tasks
+
+    _atomic_write_json(plan_path, existing)
+    return stats
+
+
+# ── Top-level convenience function ─────────────────────────────────────────────
+
+
+def fetch_github_issues(
+    repo: str,
+    label: str = DEFAULT_LABEL,
+    out_path: str | Path = "tasks.json",
+    limit: int = DEFAULT_LIMIT,
+    timeout: int = 30,
+) -> tuple[Path, FetchStats]:
+    """Fetch open issues with the given label and merge into the plan file.
+
+    Args:
+        repo: 'owner/repo' string.
+        label: GitHub label that gates inclusion (default whilly:ready).
+        out_path: tasks.json path to upsert into.
+        limit: max issues to fetch in one call.
+        timeout: gh CLI timeout in seconds.
+
+    Returns:
+        (plan_path, stats) — the resolved Path and merge counters.
+    """
+    if "/" not in repo:
+        raise ValueError(f"repo must be 'owner/repo', got {repo!r}")
+    owner, repo_name = repo.split("/", 1)
+    source = GitHubIssuesSource(owner=owner, repo=repo_name, label=label, limit=limit)
+
+    issues = _gh_issue_list(source, timeout=timeout)
+    plan_path = Path(out_path).resolve()
+    stats = merge_into_plan(issues, source, plan_path)
+
+    log.info(
+        "GitHub source: %s issues fetched (new=%d, updated=%d, closed_externally=%d)",
+        stats.total_open,
+        stats.new,
+        stats.updated,
+        stats.closed_externally,
+    )
+    if stats.secret_warnings:
+        for warning in stats.secret_warnings:
+            log.warning("Secret-like pattern detected in issue body: %s", warning)
+
+    return plan_path, stats


### PR DESCRIPTION
## Summary

Adds a complete **HackSprint1 workshop kit** plus the three **gap-pack modules** required to run the self-hosting bootstrap demo end-to-end (issue → agent → PR → review).

- **Documents (`docs/workshop/`)** — INDEX, BRD (HackSprint1 framing), PRD, READINESS gap-analysis, ROADMAP (Phase 1-8, 22 atomic tasks), TUTORIAL (90-min hands-on), and **12 ADRs** covering all architectural decisions.
- **Code (gap pack)** — `whilly/sources/github_issues.py`, `whilly/sinks/github_pr.py`, `whilly/decision_gate.py`. All three are loop-agnostic, fail-soft, and have unit tests.
- **Workshop infra** — `examples/workshop/tasks.json` (5 sample tasks), `scripts/sync_workshop_docs.sh`, `README-RU.md`, 7 demo issues already seeded in this repo with label `whilly:ready` (#1-#7, #7 intentionally bad for Decision Gate refuse demo).

## What's NOT in this PR (intentional)

- **README workshop section** is drafted locally but deferred — `README.md` has pre-existing uncommitted changes that need separate review/commit.
- **CLI wiring** of `--source` / `--pr-on-done` / `--decision-gate` flags into `cli.py::run_plan` — modules ready and tested, integration tracked in ROADMAP Phase 2-4 acceptance.
- **Live demo screencast** (Phase 8, requires actual run with budget).

## Numbers

- **30 files added**, **+4794 lines**.
- **71 new unit tests** (149 total, all green).
- **`ruff check`** clean on all new modules.
- **0 changes** to existing `whilly/*.py` modules — pure additive.

## Test plan

- [x] \`python3 -m pytest -q\` — 149 passed
- [x] \`python3 -m ruff check whilly/sources whilly/sinks whilly/decision_gate.py tests/test_github_issues_source.py tests/test_github_pr_sink.py tests/test_decision_gate.py\` — All checks passed
- [x] End-to-end smoke: \`fetch_github_issues('mshegolev/whilly-orchestrator')\` → 7 issues parsed correctly, files/acceptance/priority extracted
- [x] Sample \`examples/workshop/tasks.json\` validates against \`TaskManager\`
- [x] \`scripts/sync_workshop_docs.sh --dry-run\` clean (21 files)

## Reading order

1. \`docs/workshop/INDEX.md\` — navigation
2. \`docs/workshop/READINESS-REPORT.md\` — what's missing vs HackSprint1 PRD scope
3. \`docs/workshop/BRD-Whilly.md\` — HackSprint1 framing (10 days, curators, optional blocks priority)
4. \`docs/workshop/TUTORIAL.md\` — hands-on
5. \`whilly/sources/github_issues.py\` + \`tests/test_github_issues_source.py\`
6. \`whilly/sinks/github_pr.py\` + \`tests/test_github_pr_sink.py\`
7. \`whilly/decision_gate.py\` + \`tests/test_decision_gate.py\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)