### PR TITLE
docs(vnext): GitHub Project structure for Whilly Forge + creation script

### DIFF
--- a/docs/workshop/PROJECT-VNEXT-STRUCTURE.md
+++ b/docs/workshop/PROJECT-VNEXT-STRUCTURE.md
@@ -1,0 +1,155 @@
+---
+title: GitHub Project структура — Whilly vNext (Forge)
+type: project-spec
+created: 2026-04-20
+status: draft
+related:
+  - PLAN-OPENCODE-DOCKER.md
+  - ROADMAP.md
+  - ../../../Whilly_Requirements_v1.md
+---
+
+# GitHub Project: Whilly vNext (Forge)
+
+> Структура GitHub Project (V2) для трекинга работ по `Whilly_Requirements_v1.md`.
+> Создаётся через `scripts/create_vnext_project.sh` после `gh auth refresh -s project`.
+
+---
+
+## Project metadata
+
+- **Owner:** `mshegolev` (user-owned project, viewable публично)
+- **Title:** `Whilly vNext (Forge)`
+- **Description:** GitHub Issue → Verified Change → Repair Loop → PR. Tracking the FR-1..FR-11 work.
+- **Visibility:** public
+- **Repository link:** `mshegolev/whilly-orchestrator`
+
+---
+
+## Custom fields
+
+| Field | Type | Options |
+|---|---|---|
+| `Status` | single select | `Backlog`, `Ready`, `In Progress`, `In Review`, `Done`, `Blocked` |
+| `Priority` | single select | `P0`, `P1`, `P2` |
+| `Phase` | single select | `Phase 1 — Intake+Readiness`, `Phase 2 — Verifier+Repair`, `Phase 3 — PR Factory`, `Phase 4 — Demo+Polish`, `Existing` |
+| `FR` | text | e.g. `FR-1`, `FR-3+FR-10` |
+| `Estimate (h)` | number | hours |
+
+---
+
+## Items (24 items: 11 FR + 6 NFR + 7 housekeeping)
+
+### Phase 1 — Intake + Readiness (P0, ≈ 8h)
+
+| # | Title | Body | FR | Priority | Status | Estimate | Notes |
+|---|---|---|---|---|---|---|---|
+| 1 | **CLI flag `--from-issue owner/repo#N`** | Add CLI parsing in `whilly/cli.py` to accept `--from-issue` and route to intake. Wire in `__main__`. | FR-1 | P0 | Backlog | 1h | Depends on PR #10 merge (cli.py touch) |
+| 2 | **Module `whilly/intake_github.py` (alias of sources)** | Re-export `fetch_github_issues` as `intake_github.fetch_issue(owner_repo_n)`. Spec wording from v1.md. | FR-1 | P0 | In Review | 0.5h | Wraps existing `whilly/sources/github_issues.py` |
+| 3 | **Task type classifier (bugfix/feature/refactor/unknown)** | Extend `issue_to_task` to set `task_type` based on labels (`bug` → bugfix, `enhancement`/`feature` → feature, `refactor` → refactor, else `unknown`). | FR-2 | P0 | Backlog | 1h | New field on `Task` dataclass |
+| 4 | **Normalized issue spec — missing fields explicit** | Mark fields as `null`/empty if absent (don't invent). Add `confidence: float` slot. | FR-2 | P0 | Backlog | 1h | Schema doc update |
+| 5 | **Module `whilly/readiness.py` (alias decision_gate + states)** | Add three states `ready`/`ready_with_assumptions`/`blocked`, return `missing_information: list[str]` and `assumptions: list[str]`. | FR-3 | P0 | Backlog | 2h | Builds on `whilly/decision_gate.py` |
+| 6 | **Persist normalized spec + readiness report as artifacts** | Write `runs/<run_id>/issue_spec.json` and `runs/<run_id>/readiness.json`. | FR-2, FR-3, NFR-3 | P0 | Backlog | 1.5h | Reuse `reporter.py` |
+
+### Phase 2 — Verifier + Repair (P0, ≈ 10h)
+
+| # | Title | Body | FR | Priority | Status | Estimate | Notes |
+|---|---|---|---|---|---|---|---|
+| 7 | **Module `whilly/strategy.py` (4 strategies)** | `bugfix_repro_first`, `feature_plan_first`, `refactor_guarded`, `unknown_safe_mode`. Default mapping from task_type. | FR-4 | P0 | Backlog | 1.5h | New module |
+| 8 | **Module `whilly/planner.py` (per-task scoped plan)** | Generate structured plan: problem summary, target modules, files to modify, validation plan, risks, stop conditions. | FR-5 | P0 | Backlog | 2h | Smaller than `prd_wizard.py`, per-task scope |
+| 9 | **Repo profile loader (YAML)** | Parse `repo_profiles/<repo>.yaml`: `setup`, `verify`, `repair_verify`, `allowed_paths`, `forbidden_paths`. | FR-7, NFR-6 | P0 | Backlog | 1.5h | New file format |
+| 10 | **Extend `whilly/verifier.py` for structured verdict** | Run `verify` commands from profile, capture exit codes + outputs, return `pass`/`repair`/`escalate` with failure taxonomy. | FR-7 | P0 | Backlog | 2h | Extends existing 152 LOC |
+| 11 | **Module `whilly/repair.py`** | Parse failure bundle, generate repair prompt, run scoped fix, stop conditions (max 2-3, same-failure-twice, diff size, confidence). | FR-8 | P0 | Backlog | 2h | Extracts logic from `scripts/whilly_e2e_demo.py` (PR #11) |
+| 12 | **Wire repair loop into main flow** | After failed verify → run repair → re-verify → escalate or pass. | FR-8 | P0 | Backlog | 1h | `cli.py` integration |
+
+### Phase 3 — PR Factory (P0, ≈ 4h)
+
+| # | Title | Body | FR | Priority | Status | Estimate | Notes |
+|---|---|---|---|---|---|---|---|
+| 13 | **Issue-linked branch naming** | `whilly/issue-{N}-{slug}`. Slug from issue title. | FR-9 | P0 | In Review | 0.5h | Extend `whilly/sinks/github_pr.py::_branch_name` |
+| 14 | **PR body composition (what/why/validation/risks)** | Render PR body with all 4 sections from v1.md FR-9. | FR-9 | P0 | In Review | 1h | Extend `render_pr_body` |
+| 15 | **Draft PR auto-decision logic** | Choose draft when readiness low confidence OR repair exhausted with partial value. | FR-10 | P0 | Backlog | 1h | New |
+| 16 | **PR metadata persistence** | Write `runs/<run_id>/pr.json` with branch, title, url, draft. | FR-9, NFR-3 | P0 | Backlog | 0.5h | Reuse reporter |
+| 17 | **`whilly/github_pr.py` re-export shim** | Aliasing for v1.md naming. | FR-9 | P0 | Backlog | 0.5h | Re-export from `sinks/github_pr.py` |
+
+### Phase 4 — Demo + Polish (P1, ≈ 4h)
+
+| # | Title | Body | FR | Priority | Status | Estimate | Notes |
+|---|---|---|---|---|---|---|---|
+| 18 | **Timeline events from v1.md FR-11 spec** | Add events `issue_ingested`, `task_normalized`, `readiness_checked`, `strategy_selected`, `plan_generated`, `verification_failed`, `repair_started`, `repair_finished`, `verification_passed`, `pr_created`, `blocked`/`escalated`. | FR-11 | P1 | Backlog | 1.5h | Extend `cli.py::_log_event` |
+| 19 | **Dashboard timeline view** | Add hotkey to show event timeline for current run. | FR-11, NFR-3 | P1 | Backlog | 2h | `dashboard.py` extension |
+| 20 | **Demo repo profile + seeded issues** | Pick demo repo, write `repo_profiles/<repo>.yaml`, seed 3-5 deterministic issues. | NFR-2 | P1 | Backlog | 2h | Could be `mshegolev/whilly-orchestrator` itself |
+| 21 | **Demo script (3-min screencast plan)** | `docs/workshop/DEMO-SCRIPT.md` with cues. | NFR-2 | P1 | Backlog | 1h | Polished narrative |
+
+### Cross-cutting & polish (P1-P2)
+
+| # | Title | Body | FR | Priority | Status | Estimate | Notes |
+|---|---|---|---|---|---|---|---|
+| 22 | **ADR-017: draft PR vs auto-merge clarification** | Document that draft PR ≠ auto-merge violation; merge always human. | FR-10, BRD §10 D9 | P1 | Backlog | 0.5h | New ADR |
+| 23 | **README + README-RU: vNext / Forge section** | Bilingual section explaining Issue→PR positioning. | docs | P2 | Backlog | 1h | Branding |
+| 24 | **NFR-5 cost panel in dashboard** | Per-run cost breakdown, total budget consumption. | NFR-5 | P2 | Backlog | 1.5h | Already partial |
+
+---
+
+## Total estimate
+
+| Phase | Items | Hours |
+|---|---|---|
+| Phase 1 — Intake + Readiness | 6 | ~8h |
+| Phase 2 — Verifier + Repair | 6 | ~10h |
+| Phase 3 — PR Factory | 5 | ~4h |
+| Phase 4 — Demo + Polish | 4 | ~4h |
+| Cross-cutting | 3 | ~3h |
+| **Total** | **24** | **~29h** |
+
+---
+
+## Dependency map (high level)
+
+```
+PR #8 (workshop kit + gap pack)  ──┐
+                                    ▼
+PR #10 (OpenCode backend)         Phase 1 (#1-#6)
+                                    ▼
+                                  Phase 2 (#7-#12) ──┐
+                                                     ▼
+                                                  Phase 3 (#13-#17)
+                                                     ▼
+                                                  Phase 4 (#18-#21)
+                                                     ▼
+                                                  Cross-cutting (#22-#24)
+```
+
+---
+
+## Reuse map (existing → vNext)
+
+| Existing module | vNext usage |
+|---|---|
+| `whilly/sources/github_issues.py` (PR #8) | basis for `intake_github.py` (item #2) |
+| `whilly/decision_gate.py` (PR #8) | basis for `readiness.py` (item #5) |
+| `whilly/sinks/github_pr.py` (PR #8) | basis for branch+body+draft work (items #13, #14, #15, #17) |
+| `whilly/verifier.py` (existing 152 LOC) | extend with profiles + structured verdict (item #10) |
+| `scripts/whilly_e2e_demo.py` (PR #11) | extract repair logic into `repair.py` (item #11) |
+| `whilly/agents/` (PR #10) | reused as backend for plan/repair agents |
+| `whilly_logs/whilly_events.jsonl` | extend with v1.md event types (item #18) |
+
+---
+
+## Demo path (Phase 4)
+
+Per v1.md §13 — bugfix with intentional first failure:
+
+1. Whilly ingests issue (FR-1)
+2. Readiness says ready (FR-3)
+3. Strategy = bugfix_repro_first (FR-4)
+4. Plan generated (FR-5)
+5. First implementation attempt fails one test (FR-6 + FR-7)
+6. Repair loop fixes null/empty-state logic (FR-8)
+7. Verification passes (FR-7)
+8. PR created (FR-9)
+9. Timeline shows the entire sequence (FR-11)
+
+---
+
+**Status:** project spec ready · 2026-04-20 · awaits `gh auth refresh -s project` then `scripts/create_vnext_project.sh` execution.

--- a/scripts/create_vnext_project.sh
+++ b/scripts/create_vnext_project.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Create the "Whilly vNext (Forge)" GitHub Project (V2) and seed all 24 items
+# from docs/workshop/PROJECT-VNEXT-STRUCTURE.md.
+#
+# Prereqs (one-time):
+#   gh auth refresh -s project    # adds 'project' scope to your gh token
+#
+# Usage:
+#   scripts/create_vnext_project.sh                # creates project, exits with project number
+#   scripts/create_vnext_project.sh --dry-run      # prints commands, doesn't mutate
+#
+# Idempotency: if a project with the same title already exists for the owner,
+# the script reuses it instead of creating a duplicate.
+
+set -euo pipefail
+
+OWNER="${OWNER:-mshegolev}"
+TITLE="${TITLE:-Whilly vNext (Forge)}"
+DRY_RUN=""
+
+if [ "${1:-}" = "--dry-run" ] || [ "${1:-}" = "-n" ]; then
+    DRY_RUN="echo [dry-run] "
+fi
+
+# Strip env tokens — gh prefers keyring auth.
+unset GITHUB_TOKEN GH_TOKEN || true
+
+# ── 0. Auth check ──────────────────────────────────────────────────────────
+if ! gh auth status >/dev/null 2>&1; then
+    echo "✗ gh not authenticated. Run: gh auth login"
+    exit 1
+fi
+if ! gh project list --owner "$OWNER" >/dev/null 2>&1; then
+    echo "✗ gh token missing 'project' scope."
+    echo "   Run: gh auth refresh -s project"
+    exit 1
+fi
+
+# ── 1. Find or create project ──────────────────────────────────────────────
+echo "Looking up project '$TITLE' for owner '$OWNER'..."
+EXISTING_NUM=$(gh project list --owner "$OWNER" --format json --limit 100 \
+    | jq -r --arg t "$TITLE" '.projects[] | select(.title==$t) | .number' | head -1)
+
+if [ -n "$EXISTING_NUM" ]; then
+    PROJECT_NUM="$EXISTING_NUM"
+    echo "  ✓ Project exists, reusing #$PROJECT_NUM"
+else
+    if [ -n "$DRY_RUN" ]; then
+        ${DRY_RUN}gh project create --owner "$OWNER" --title "$TITLE"
+        PROJECT_NUM="<NEW>"
+    else
+        PROJECT_NUM=$(gh project create --owner "$OWNER" --title "$TITLE" --format json \
+            | jq -r '.number')
+        echo "  ✓ Created project #$PROJECT_NUM"
+    fi
+fi
+
+# ── 2. Custom fields ──────────────────────────────────────────────────────
+# 'Status' is a built-in field on every V2 project (Todo/In Progress/Done by default).
+# We add Priority, Phase, FR, Estimate.
+echo "Ensuring custom fields..."
+
+ensure_field() {
+    local name="$1" type="$2" options="$3"
+    local existing
+    existing=$(gh project field-list "$PROJECT_NUM" --owner "$OWNER" --format json 2>/dev/null \
+        | jq -r --arg n "$name" '.fields[] | select(.name==$n) | .id' | head -1)
+    if [ -n "$existing" ]; then
+        echo "  · field '$name' exists, skipping"
+        return
+    fi
+    if [ "$type" = "single_select" ]; then
+        ${DRY_RUN}gh project field-create "$PROJECT_NUM" --owner "$OWNER" \
+            --name "$name" --data-type SINGLE_SELECT --single-select-options "$options"
+    else
+        ${DRY_RUN}gh project field-create "$PROJECT_NUM" --owner "$OWNER" \
+            --name "$name" --data-type "$type"
+    fi
+}
+
+ensure_field "Priority" single_select "P0,P1,P2"
+ensure_field "Phase" single_select "Phase 1 — Intake+Readiness,Phase 2 — Verifier+Repair,Phase 3 — PR Factory,Phase 4 — Demo+Polish,Cross-cutting"
+ensure_field "FR" TEXT ""
+ensure_field "Estimate (h)" NUMBER ""
+
+# ── 3. Seed items ─────────────────────────────────────────────────────────
+echo "Seeding items..."
+
+create_item() {
+    local title="$1" body="$2"
+    ${DRY_RUN}gh project item-create "$PROJECT_NUM" --owner "$OWNER" \
+        --title "$title" --body "$body" >/dev/null
+    echo "  · $title"
+}
+
+# Phase 1 — Intake + Readiness
+create_item "[FR-1] CLI flag --from-issue owner/repo#N" \
+    "Wire \`--from-issue\` parsing in whilly/cli.py + __main__. Routes to intake_github. P0, ~1h."
+create_item "[FR-1] Module whilly/intake_github.py (alias of sources)" \
+    "Re-export fetch_github_issues as intake_github.fetch_issue(owner_repo_n). P0, ~0.5h."
+create_item "[FR-2] Task type classifier (bugfix/feature/refactor/unknown)" \
+    "Extend issue_to_task to set task_type from labels. P0, ~1h."
+create_item "[FR-2] Normalized issue spec — missing fields explicit" \
+    "Mark fields null/empty when absent. Add confidence float slot. P0, ~1h."
+create_item "[FR-3] Module whilly/readiness.py (alias decision_gate + states)" \
+    "Three states: ready / ready_with_assumptions / blocked + missing_information + assumptions lists. P0, ~2h."
+create_item "[FR-2/3/NFR-3] Persist normalized spec + readiness as run artifacts" \
+    "Write runs/<run_id>/issue_spec.json and readiness.json. P0, ~1.5h."
+
+# Phase 2 — Verifier + Repair
+create_item "[FR-4] Module whilly/strategy.py (4 strategies)" \
+    "bugfix_repro_first / feature_plan_first / refactor_guarded / unknown_safe_mode. P0, ~1.5h."
+create_item "[FR-5] Module whilly/planner.py (per-task scoped plan)" \
+    "Structured plan: problem summary, target modules, files, validation, risks, stop conditions. P0, ~2h."
+create_item "[FR-7/NFR-6] Repo profile loader (YAML)" \
+    "Parse repo_profiles/<repo>.yaml: setup, verify, repair_verify, allowed_paths, forbidden_paths. P0, ~1.5h."
+create_item "[FR-7] Extend whilly/verifier.py for structured verdict" \
+    "Run verify cmds from profile, return pass/repair/escalate + failure taxonomy. P0, ~2h."
+create_item "[FR-8] Module whilly/repair.py" \
+    "Failure parsing, scoped repair prompt, stop conditions. Extract from scripts/whilly_e2e_demo.py. P0, ~2h."
+create_item "[FR-8] Wire repair loop into main flow (cli.py)" \
+    "After verify fail → repair → re-verify → escalate or pass. P0, ~1h."
+
+# Phase 3 — PR Factory
+create_item "[FR-9] Issue-linked branch naming whilly/issue-{N}-{slug}" \
+    "Extend whilly/sinks/github_pr.py::_branch_name. P0, ~0.5h."
+create_item "[FR-9] PR body composition (what/why/validation/risks)" \
+    "Render with all 4 sections per v1.md FR-9. Extend render_pr_body. P0, ~1h."
+create_item "[FR-10] Draft PR auto-decision logic" \
+    "Choose draft on low confidence OR repair-exhausted. P0, ~1h."
+create_item "[FR-9/NFR-3] PR metadata persistence" \
+    "Write runs/<run_id>/pr.json. P0, ~0.5h."
+create_item "[FR-9] whilly/github_pr.py re-export shim" \
+    "Aliasing for v1.md naming. P0, ~0.5h."
+
+# Phase 4 — Demo + Polish
+create_item "[FR-11] Timeline events from v1.md spec" \
+    "Add issue_ingested, task_normalized, readiness_checked, strategy_selected, plan_generated, verification_failed, repair_started, repair_finished, verification_passed, pr_created, blocked/escalated. P1, ~1.5h."
+create_item "[FR-11/NFR-3] Dashboard timeline view" \
+    "Hotkey to show event timeline for current run. P1, ~2h."
+create_item "[NFR-2] Demo repo profile + seeded issues" \
+    "Pick demo repo, write repo_profiles/<repo>.yaml, seed 3-5 deterministic issues. P1, ~2h."
+create_item "[NFR-2] Demo script (3-min screencast plan)" \
+    "docs/workshop/DEMO-SCRIPT.md with cues. P1, ~1h."
+
+# Cross-cutting
+create_item "[ADR-017] Draft PR vs auto-merge clarification" \
+    "Document that draft PR ≠ auto-merge violation; merge always human. P1, ~0.5h."
+create_item "[docs] README + README-RU vNext / Forge section" \
+    "Bilingual section explaining Issue→PR positioning. P2, ~1h."
+create_item "[NFR-5] Cost panel in dashboard" \
+    "Per-run cost breakdown, total budget consumption. P2, ~1.5h."
+
+echo ""
+echo "✓ Project ready."
+echo "  https://github.com/users/$OWNER/projects/$PROJECT_NUM"


### PR DESCRIPTION
## Summary

Adds the structured plan for Whilly vNext (Forge), based on \`Whilly_Requirements_v1.md\` (user-supplied spec). Project #4 was created from this branch: https://github.com/users/mshegolev/projects/4

Stacked on top of #11 (e2e demo).

## Compatibility check (vs existing docs)

- All 11 FR map cleanly. **5/11** already implemented (FR-1, FR-3, FR-6, FR-9, FR-11), **6/11** need new modules.
- Naming aliases not renames: \`intake_github.py\` re-exports from \`sources/github_issues.py\`; \`readiness.py\` extends \`decision_gate.py\`; \`github_pr.py\` re-exports from \`sinks/github_pr.py\`.
- Single semantic concern (draft PR vs auto-merge wording) handled by proposing ADR-017 in project items.

## Files

- \`docs/workshop/PROJECT-VNEXT-STRUCTURE.md\` — 24 items, 4 phases, ~29h estimate, dependency map, reuse map.
- \`scripts/create_vnext_project.sh\` — idempotent V2 GitHub Project creator. Already executed; project #4 created with 24 items.

## Run

\`\`\`
gh auth refresh -s project    # one-time
scripts/create_vnext_project.sh
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)