### PR TITLE
GH-6: Workshop kit section in README (+ whilly .gitignore hygiene)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,17 @@ ralph_logs/
 .ralph_workspaces/
 ralph_events.jsonl
 
+# Whilly runtime artifacts
+whilly.log
+whilly_tasks.log
+whilly_*_tasks.log
+whilly_logs/
+.whilly_workspaces/
+.whilly_worktrees/
+whilly_events.jsonl
+.whilly_state.json
+.planning/reports/
+
 # Tests
 .pytest_cache/
 .coverage
@@ -38,3 +49,4 @@ htmlcov/
 
 # PRD wizard state
 .ralph_prd_state.json
+.whilly_prd_state.json

--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ See `docs/Whilly-Usage.md` for the full CLI reference.
 - [Whilly-Usage.md](docs/Whilly-Usage.md) — CLI reference and flag catalog
 - [Whilly-Interfaces-and-Tasks.md](docs/Whilly-Interfaces-and-Tasks.md) — task file format, state store schema, agent output contract
 
+## Workshop kit
+
+Running HackSprint1 or a self-paced walkthrough? The full workshop kit (BRD, PRD, ADRs, tutorial, roadmap) lives under [docs/workshop/INDEX.md](docs/workshop/INDEX.md).
+
 ## Development
 
 ```bash


### PR DESCRIPTION
Closes #6. Replaces #13 (closed due to agent artifact contamination — 2133 additions across 16 files).

## Summary
- README.md: adds `## Workshop kit` section with link to `docs/workshop/INDEX.md` and mention of HackSprint1.
- .gitignore: adds entries for `whilly_*` runtime artifacts (logs, `.whilly_workspaces/`, `.whilly_worktrees/`, state files, `.planning/reports/`) — defence against future agent runs leaking junk into PRs.

## Acceptance (from #6)
- [x] README.md has `## Workshop kit` heading
- [x] Section ≤ 8 lines
- [x] Relative link to `docs/workshop/INDEX.md`
- [x] Mentions HackSprint1 by name

## Test
```bash
grep -q '## Workshop kit' README.md
grep -q 'docs/workshop/INDEX.md' README.md
grep -q 'HackSprint1' README.md
```

All three pass.