### PR TITLE
feat: --from-github --go + strip stale GITHUB_TOKEN on gh Projects calls

### DIFF
--- a/whilly/cli.py
+++ b/whilly/cli.py
@@ -1751,12 +1751,19 @@ def main(argv: list[str] | None = None) -> int:
             tasks_path = generate_tasks_from_github(output_path=output_file, filter_labels=labels, prd_file=prd_file)
             _ansi(f"{GR}Tasks generated: {tasks_path}{R}")
 
-            # Ask user if they want to run the tasks immediately
-            if sys.stdin.isatty():
+            # --go / --yes → skip the confirmation prompt and execute immediately
+            auto_go = "--go" in args or "--yes" in args
+            if auto_go:
+                _ansi(f"{CY}{B}--go: auto-starting Whilly orchestrator...{R}")
+                args = [a for a in args if a not in ("--go", "--yes", "--from-github")]
+                if labels_arg and args and args[0] == labels_arg:
+                    args = args[1:]
+                args = [str(tasks_path)] + args
+            elif sys.stdin.isatty():
                 choice = input("\nRun tasks immediately? [Y/n]: ").lower()
                 if choice in ("", "y", "yes"):
                     _ansi(f"{CY}{B}Starting Whilly orchestrator...{R}")
-                    args = [str(tasks_path)]  # Set args to run the generated tasks
+                    args = [str(tasks_path)]
                 else:
                     _ansi(f"{YL}Run later with: whilly {tasks_path}{R}")
                     return 0

--- a/whilly/github_projects.py
+++ b/whilly/github_projects.py
@@ -5,6 +5,7 @@ Supports status-oriented workflows with incremental sync and monitoring.
 """
 
 import json
+import os
 import re
 import subprocess
 import time
@@ -14,6 +15,14 @@ from pathlib import Path
 from typing import List, Optional, Dict, Any, Set
 
 from whilly.config import WhillyConfig
+
+
+def _gh_env() -> dict[str, str]:
+    """Return os.environ copy with stale GITHUB_TOKEN removed — `gh` CLI prefers its keyring."""
+    env = dict(os.environ)
+    env.pop("GITHUB_TOKEN", None)
+    env.pop("GH_TOKEN", None)
+    return env
 
 
 @dataclass
@@ -112,7 +121,7 @@ class GitHubProjectsConverter:
     def _check_gh_cli(self):
         """Verify GitHub CLI is available and authenticated."""
         try:
-            result = subprocess.run(["gh", "auth", "status"], capture_output=True, text=True, check=True)
+            result = subprocess.run(["gh", "auth", "status"], capture_output=True, text=True, check=True, env=_gh_env())
             if "Logged in to github.com" not in result.stdout:
                 raise RuntimeError("GitHub CLI not authenticated. Run: gh auth login")
         except subprocess.CalledProcessError:
@@ -237,7 +246,7 @@ class GitHubProjectsConverter:
                 f"number={project_info['project_number']}",
             ]
 
-            result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+            result = subprocess.run(cmd, capture_output=True, text=True, check=True, env=_gh_env())
             data = json.loads(result.stdout)
 
             items = self._parse_project_items(data, include_updated_at)
@@ -352,7 +361,7 @@ class GitHubProjectsConverter:
             label,
         ]
 
-        result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        result = subprocess.run(cmd, capture_output=True, text=True, check=True, env=_gh_env())
         issue_url = result.stdout.strip()
 
         # Extract issue number from URL


### PR DESCRIPTION
## Summary
- `--from-github all --go` (or `--yes`) skips the "Run tasks immediately?" prompt so the import → execute flow is fully autonomous (mirrors existing `--from-project --go`).
- `whilly/github_projects.py` now strips `GITHUB_TOKEN` / `GH_TOKEN` from subprocess env before every `gh` call. Stale shell-level tokens were leaking into `gh api` and causing `HTTP 401 Bad credentials` on `--from-project`.

## Repro for the 401 fix
```
export GITHUB_TOKEN=ghp_expired_xxx
whilly --from-project https://github.com/users/<you>/projects/<n> --repo <owner>/<repo>
# before: gh: Bad credentials (HTTP 401)
# after: works; gh uses its keyring auth instead
```

## Test plan
- [x] `python3 -m ruff check whilly/` — clean
- [x] `python3 -m ruff format --check whilly/` — clean
- [x] `pytest -q` — 490 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)