### PR TITLE
fix: Include whilly.* subpackages in distribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,8 +41,9 @@ Documentation = "https://github.com/mshegolev/whilly-orchestrator/blob/main/docs
 [project.scripts]
 whilly = "whilly.cli:main"
 
-[tool.setuptools]
-packages = ["whilly"]
+[tool.setuptools.packages.find]
+include = ["whilly", "whilly.*"]
+exclude = ["tests*"]
 
 [tool.setuptools.package-data]
 whilly = ["py.typed"]


### PR DESCRIPTION
## Summary
`pyproject.toml` only declared the top-level `whilly` package, so `pipx install` shipped a broken distribution:

```
ModuleNotFoundError: No module named 'whilly.agents'
```

Switched to `[tool.setuptools.packages.find]` with `include = ["whilly", "whilly.*"]` so `agents/`, `sources/`, `sinks/`, `workflow/`, `classifier/`, `hierarchy/`, and `quality/` ship correctly.

## Test plan
- [x] `pipx install --force .` → `whilly --help` runs clean
- [x] `python3 -m ruff check whilly/` — clean
- [x] `pytest -q` — 490 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)