### PR TITLE
fix: --from-github all fetches every open issue (not defaults)

### DIFF
--- a/whilly/cli.py
+++ b/whilly/cli.py
@@ -1738,7 +1738,7 @@ def main(argv: list[str] | None = None) -> int:
         labels_arg = args[idx + 1] if idx + 1 < len(args) and not args[idx + 1].startswith("-") else None
         # "all" / "*" / "-" → fetch every open issue without label filter
         if labels_arg and labels_arg.lower() in ("all", "*", "-"):
-            labels: list[str] | None = None
+            labels: list[str] = []  # explicit empty list = "no label filter"
         else:
             labels = labels_arg.split(",") if labels_arg else ["workshop", "whilly:ready"]
 
@@ -1750,6 +1750,15 @@ def main(argv: list[str] | None = None) -> int:
         try:
             tasks_path = generate_tasks_from_github(output_path=output_file, filter_labels=labels, prd_file=prd_file)
             _ansi(f"{GR}Tasks generated: {tasks_path}{R}")
+
+            # Nothing to run if no open issues matched — bail early.
+            try:
+                generated = json.loads(Path(tasks_path).read_text())
+                if not generated.get("tasks"):
+                    _ansi(f"{YL}No tasks were generated — nothing to run.{R}")
+                    return 0
+            except Exception:
+                pass  # fall through; downstream loop will report a clearer error
 
             # --go / --yes → skip the confirmation prompt and execute immediately
             auto_go = "--go" in args or "--yes" in args

--- a/whilly/github_converter.py
+++ b/whilly/github_converter.py
@@ -282,15 +282,25 @@ def generate_tasks_from_github(
     """
     output_path = Path(output_path)
 
+    # Semantics:
+    #   filter_labels is None  → apply default labels (workshop, whilly:ready)
+    #   filter_labels == []    → no label filter (all open issues)
+    #   non-empty list         → filter by exactly those labels
     if filter_labels is None:
         filter_labels = ["workshop", "whilly:ready"]
 
-    log.info("Fetching GitHub Issues with labels: %s", filter_labels)
+    if filter_labels:
+        log.info("Fetching GitHub Issues with labels: %s", filter_labels)
+    else:
+        log.info("Fetching all open GitHub Issues (no label filter)")
     issues = fetch_github_issues(filter_labels)
     log.info("Found %d issues", len(issues))
 
     if not issues:
-        log.warning("No GitHub Issues found with labels: %s", filter_labels)
+        if filter_labels:
+            log.warning("No GitHub Issues found with labels: %s", filter_labels)
+        else:
+            log.warning("No open GitHub Issues found in the current repository")
         return output_path
 
     log.info("Converting issues to Whilly tasks...")


### PR DESCRIPTION
## Summary
`whilly --from-github all` was still fetching 0 issues on repos that don't use the default `workshop` / `whilly:ready` label combo — the CLI passed `None` to the converter, which silently re-applied those defaults.

- CLI now passes an explicit empty list when the user writes `all` / `*` / `-`.
- `generate_tasks_from_github` distinguishes `None` (apply defaults) from `[]` (no filter) and logs accordingly.
- Bail early with a clear message when zero issues matched, instead of offering to run an empty plan.

## Test plan
- [x] `python3 -m ruff check whilly/` — clean
- [x] `pytest -q` — 490 passed
- [x] Manual: against `mshegolev/whilly-orchestrator` (147 open, none tagged `workshop`) the default labels returned 0; `--from-github all` now returns 100 (gh page limit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)