### PR TITLE
fix: Strip stale GITHUB_TOKEN in interactive GitHub menu

### DIFF
--- a/whilly/github_interactive.py
+++ b/whilly/github_interactive.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import os
 import subprocess
 from typing import Optional
 
@@ -11,10 +12,18 @@ from whilly.sources.github_issues import fetch_github_issues
 from whilly.external_integrations import create_integration_manager
 
 
+def _gh_env() -> dict[str, str]:
+    """Return os.environ copy with stale GITHUB_TOKEN / GH_TOKEN removed — `gh` CLI prefers its keyring."""
+    env = dict(os.environ)
+    env.pop("GITHUB_TOKEN", None)
+    env.pop("GH_TOKEN", None)
+    return env
+
+
 def _run_command(cmd: list[str]) -> tuple[bool, str]:
     """Запускает команду и возвращает (success, output)."""
     try:
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=30, env=_gh_env())
         return result.returncode == 0, result.stdout.strip() or result.stderr.strip()
     except Exception as e:
         return False, str(e)


### PR DESCRIPTION
## Summary
The interactive `g` menu (`whilly` → `g`) was running `gh` without stripping the user's ambient `GITHUB_TOKEN`. When that token is stale (common — `gh` now uses a keyring), every `gh issue list` / `gh repo list` silently returned nothing, and the menu reported \"Issues с меткой 'whilly:ready' не найдены\" even for repos with many matching issues.

Matches the fix already in `github_converter.py`, `github_projects.py`, and `external_integrations.py`.

## Test plan
- [x] `python3 -m ruff check whilly/` — clean
- [x] `pytest -q` — 490 passed
- [x] Manual: `gh issue list --label whilly:ready --repo mshegolev/whilly-orchestrator` with stripped token returns 30, with leaked token returns 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)