### PR TITLE
feat: Unified GitHub Issues+Project source + fix tuple bug in interactive import

### DIFF
--- a/whilly/cli.py
+++ b/whilly/cli.py
@@ -1784,6 +1784,66 @@ def main(argv: list[str] | None = None) -> int:
             _ansi(f"{RD}GitHub to tasks conversion failed: {e}{R}")
             return 1
 
+    # --from-issues-project: unified source (Project v2 board filters which issues to materialise)
+    if "--from-issues-project" in args:
+        from whilly.sources import fetch_issues_and_project
+
+        idx = args.index("--from-issues-project")
+        if idx + 1 >= len(args):
+            _ansi(f"{RD}Usage: whilly --from-issues-project <project_url> --repo owner/name [--status Todo,Ready]{R}")
+            return 1
+        project_url = args[idx + 1]
+
+        repo_spec = None
+        if "--repo" in args:
+            repo_idx = args.index("--repo")
+            if repo_idx + 1 < len(args):
+                repo_spec = args[repo_idx + 1]
+        if not repo_spec or "/" not in repo_spec:
+            _ansi(f"{RD}Missing or malformed --repo. Expected owner/name.{R}")
+            return 1
+
+        statuses_raw = None
+        if "--status" in args:
+            sidx = args.index("--status")
+            if sidx + 1 < len(args) and not args[sidx + 1].startswith("-"):
+                statuses_raw = args[sidx + 1]
+        statuses = {s.strip() for s in statuses_raw.split(",")} if statuses_raw else None
+
+        out_file = f"tasks-{repo_spec.replace('/', '-')}-from-project.json"
+        _ansi(f"{CY}{B}Unified GitHub Issues + Project source...{R}")
+        _ansi(f"Project: {project_url}")
+        _ansi(f"Repository: {repo_spec}")
+        _ansi(f"Statuses: {sorted(statuses) if statuses else ['Todo']}")
+        try:
+            plan_path, stats = fetch_issues_and_project(
+                repo=repo_spec, project_url=project_url, target_statuses=statuses, out_path=out_file
+            )
+            _ansi(f"{GR}Tasks generated: {plan_path}{R}")
+            _ansi(f"{D}   new={stats.new}  updated={stats.updated}  closed_externally={stats.closed_externally}{R}")
+
+            if stats.total_open == 0:
+                _ansi(f"{YL}No matching items — nothing to run.{R}")
+                return 0
+
+            auto_go = "--go" in args or "--yes" in args
+            if auto_go:
+                _ansi(f"{CY}{B}--go: auto-starting Whilly orchestrator...{R}")
+                args = [str(plan_path)]
+            elif sys.stdin.isatty():
+                choice = input("\nRun tasks immediately? [Y/n]: ").strip().lower()
+                if choice in ("", "y", "yes"):
+                    args = [str(plan_path)]
+                else:
+                    _ansi(f"{YL}Run later with: whilly {plan_path}{R}")
+                    return 0
+            else:
+                _ansi(f"{YL}Run with: whilly {plan_path}{R}")
+                return 0
+        except Exception as e:
+            _ansi(f"{RD}Unified GitHub source failed: {e}{R}")
+            return 1
+
     # --from-project: generate tasks from GitHub Project board
     if "--from-project" in args:
         from whilly.github_projects import GitHubProjectsConverter

--- a/whilly/github_interactive.py
+++ b/whilly/github_interactive.py
@@ -226,14 +226,16 @@ def _import_issues_workflow(config: WhillyConfig) -> Optional[str]:
     print(f"\n🚀 Создаем план задач: {output_file}")
 
     try:
-        stats = fetch_github_issues(repo, label=label, out_path=output_file)
+        plan_path, stats = fetch_github_issues(repo, label=label, out_path=output_file)
 
         print("✅ Импорт завершен!")
+        print(f"   Найдено открытых: {stats.total_open}")
         print(f"   Новых задач: {stats.new}")
         print(f"   Обновлено: {stats.updated}")
-        print(f"   Файл плана: {output_file}")
+        print(f"   Закрыто внешне: {stats.closed_externally}")
+        print(f"   Файл плана: {plan_path}")
 
-        return output_file
+        return str(plan_path)
 
     except Exception as e:
         print(f"❌ Ошибка импорта: {e}")

--- a/whilly/sources/__init__.py
+++ b/whilly/sources/__init__.py
@@ -1,5 +1,6 @@
 """Source adapters: convert external task trackers (GitHub Issues, etc.) into tasks.json."""
 
 from whilly.sources.github_issues import GitHubIssuesSource, fetch_github_issues
+from whilly.sources.github_issues_and_project import fetch_issues_and_project
 
-__all__ = ["GitHubIssuesSource", "fetch_github_issues"]
+__all__ = ["GitHubIssuesSource", "fetch_github_issues", "fetch_issues_and_project"]

--- a/whilly/sources/github_issues_and_project.py
+++ b/whilly/sources/github_issues_and_project.py
@@ -1,0 +1,145 @@
+"""Unified GitHub Issues + Project v2 board source.
+
+Combines a repository's issues with a Project v2 board so the project's
+``Status`` field (Todo / In Progress / Review / …) drives which issues become
+whilly tasks, while the issue body still supplies description, acceptance
+criteria, and priority labels.
+
+Each project item in the target statuses is mapped back to its backing issue
+(``projectV2Item.content`` in the GraphQL response); issues outside the project
+are ignored, draft items without a backing issue are skipped with a warning.
+
+CLI entry point: ``whilly --from-issues-project <project_url> --repo owner/repo``
+Programmatic entry point: :func:`fetch_issues_and_project`.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Iterable
+
+from whilly.github_projects import GitHubProjectsConverter
+from whilly.sources.github_issues import (
+    GitHubIssuesSource,
+    _run_gh,
+    merge_into_plan,
+    FetchStats,
+)
+
+log = logging.getLogger("whilly")
+
+
+DEFAULT_STATUSES: set[str] = {"Todo"}
+
+
+def _fetch_issue_json(repo: str, number: int, timeout: int = 30) -> dict | None:
+    """Fetch a single issue by number via ``gh issue view``. Returns None on failure."""
+    args = [
+        "issue",
+        "view",
+        str(number),
+        "--repo",
+        repo,
+        "--json",
+        "number,title,body,labels,url,createdAt,updatedAt,state",
+    ]
+    proc = _run_gh(args, timeout=timeout)
+    if proc.returncode != 0:
+        err = (proc.stderr or proc.stdout or "").strip()
+        log.warning("gh issue view %s#%d failed: %s", repo, number, err)
+        return None
+    try:
+        return json.loads(proc.stdout or "null")
+    except json.JSONDecodeError as exc:
+        log.warning("gh returned non-JSON for issue %d: %s", number, exc)
+        return None
+
+
+def _project_status_to_priority_label(status: str, existing_labels: list[dict]) -> list[dict]:
+    """Synthesise a priority:* label from project Status unless one is already set."""
+    names = {(label.get("name") or "").lower() for label in existing_labels}
+    if any(n.startswith("priority:") for n in names):
+        return existing_labels
+
+    mapping = {
+        "In Progress": "priority:high",
+        "Review": "priority:high",
+        "Todo": "priority:medium",
+        "Ready": "priority:medium",
+        "Backlog": "priority:low",
+    }
+    synthetic = mapping.get(status)
+    if not synthetic:
+        return existing_labels
+    return [*existing_labels, {"name": synthetic}]
+
+
+def fetch_issues_and_project(
+    repo: str,
+    project_url: str,
+    target_statuses: Iterable[str] | None = None,
+    out_path: str | Path = "tasks.json",
+    limit: int = 100,
+    timeout: int = 30,
+) -> tuple[Path, FetchStats]:
+    """Fetch project items filtered by status, enrich with issue content, write plan.
+
+    Args:
+        repo: ``'owner/repo'``.
+        project_url: Full GitHub Project v2 board URL (users/orgs/repo variants).
+        target_statuses: Project Status values to include. Default ``{"Todo"}``.
+        out_path: Plan file to upsert into (merge is idempotent).
+        limit: Maximum issues to materialise (project fetch also page-limits).
+        timeout: ``gh`` subprocess timeout per call.
+
+    Returns:
+        ``(plan_path, stats)`` mirroring :func:`fetch_github_issues`.
+    """
+    if "/" not in repo:
+        raise ValueError(f"repo must be 'owner/repo', got {repo!r}")
+    owner, repo_name = repo.split("/", 1)
+    statuses = set(target_statuses) if target_statuses else set(DEFAULT_STATUSES)
+
+    log.info("Fetching project board: %s (statuses=%s)", project_url, sorted(statuses))
+    converter = GitHubProjectsConverter()
+    project_items = converter.fetch_project_items(project_url, filter_statuses=statuses, include_updated_at=True)
+    log.info("Project returned %d items in target statuses", len(project_items))
+
+    enriched_issues: list[dict] = []
+    for item in project_items[:limit]:
+        if not item.issue_number:
+            log.info("Skipping draft project item without backing issue: %s", item.title)
+            continue
+        issue = _fetch_issue_json(repo, item.issue_number, timeout=timeout)
+        if issue is None:
+            continue
+        if issue.get("state") and issue["state"].upper() != "OPEN":
+            log.info("Skipping #%s — not open (state=%s)", issue.get("number"), issue.get("state"))
+            continue
+        issue["labels"] = _project_status_to_priority_label(item.status, issue.get("labels") or [])
+        issue["_project_status"] = item.status
+        issue["_project_item_id"] = item.id
+        enriched_issues.append(issue)
+
+    log.info("Converting %d issues to whilly tasks", len(enriched_issues))
+
+    source = GitHubIssuesSource(owner=owner, repo=repo_name, label=",".join(sorted(statuses)) or "project", limit=limit)
+    plan_path = Path(out_path).resolve()
+    stats = merge_into_plan(enriched_issues, source, plan_path)
+
+    log.info(
+        "GitHub issues+project source: %d issues materialised (new=%d, updated=%d, closed_externally=%d)",
+        stats.total_open,
+        stats.new,
+        stats.updated,
+        stats.closed_externally,
+    )
+    for warning in stats.secret_warnings:
+        log.warning("Secret-like pattern in issue body: %s", warning)
+
+    return plan_path, stats
+
+
+__all__ = ["fetch_issues_and_project", "DEFAULT_STATUSES"]


### PR DESCRIPTION
## Summary
- **New:** `whilly/sources/github_issues_and_project.py` + CLI flag `--from-issues-project`. Lets a GitHub Project v2 board drive which repo issues become whilly tasks, filtered by Project Status.
- **Fix:** `'tuple' object has no attribute 'new'` during the interactive `g → import issues` flow — the caller expected a single stats object, but `fetch_github_issues` returns `tuple[Path, FetchStats]`.

## Usage
```bash
whilly --from-issues-project https://github.com/users/mshegolev/projects/4 \
       --repo mshegolev/whilly-orchestrator \
       --status Todo,Ready \
       --go
```

Flow: fetch Project V2 items → keep only target statuses → resolve each project item back to its backing Issue via `gh issue view --json …` → merge into plan file with idempotent upsert (`merge_into_plan`). Draft-only items without an issue are skipped with a warning.

## Test plan
- [x] `python3 -m ruff check whilly/` — clean
- [x] `python3 -m ruff format --check whilly/` — clean
- [x] `pytest -q` — 490 passed
- [x] Manual: `from whilly.sources import fetch_issues_and_project` resolves without errors
- [x] Manual: interactive menu tuple fix prints `new/updated/closed_externally/total_open`

🤖 Generated with [Claude Code](https://claude.com/claude-code)