### PR TITLE
feat: Centralise gh auth — WHILLY_GH_TOKEN / WHILLY_GH_PREFER_KEYRING

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,6 +73,23 @@
 # WHILLY_GH_BIN=gh                     # Path to the GitHub CLI
 # WHILLY_PROJECT_URL=                  # GitHub Project URL (for workflow/sync.py)
 
+# ─── GitHub auth (whilly runs `gh` as a subprocess) ──────────────────────────
+# Resolution order used by whilly.gh_utils.gh_subprocess_env():
+#   1. WHILLY_GH_TOKEN          — whilly-only token; injected as GITHUB_TOKEN
+#                                 for the subprocess without touching your shell
+#   2. WHILLY_GH_PREFER_KEYRING=1 — strip ambient GITHUB_TOKEN / GH_TOKEN to
+#                                 force `gh` to use its keyring auth (macOS Keychain
+#                                 / libsecret / Windows Credential Manager)
+#   3. otherwise, GITHUB_TOKEN / GH_TOKEN are passed through unchanged —
+#      the cross-platform default that just works on Linux / Windows / CI
+#
+# Linux/Windows/CI users: usually set GITHUB_TOKEN below (or outside .env) and
+# leave WHILLY_GH_* unset.
+# macOS + `gh auth login` users: set WHILLY_GH_PREFER_KEYRING=1 so whilly ignores
+# any stale GITHUB_TOKEN your shell inherited and prefers the keyring token.
+# WHILLY_GH_TOKEN=
+# WHILLY_GH_PREFER_KEYRING=0
+
 # ─── External integrations: GitHub Issues ────────────────────────────────────
 # WHILLY_CLOSE_EXTERNAL_TASKS=1        # 0 = never close external tasks on done
 # WHILLY_GITHUB_AUTO_CLOSE=1

--- a/whilly/decision_gate.py
+++ b/whilly/decision_gate.py
@@ -241,12 +241,11 @@ def label_flip_for_gh_task(
     ]
 
     if runner is None:
-        import os as _os
         import subprocess
 
-        env = dict(_os.environ)
-        env.pop("GITHUB_TOKEN", None)
-        env.pop("GH_TOKEN", None)
+        from whilly.gh_utils import gh_subprocess_env
+
+        env = gh_subprocess_env()
         proc = subprocess.run(["gh", *args], capture_output=True, text=True, env=env, check=False)
         if proc.returncode != 0:
             log.warning("gh issue edit (label flip) failed for %s: %s", task.id, proc.stderr.strip())

--- a/whilly/external_integrations.py
+++ b/whilly/external_integrations.py
@@ -54,11 +54,9 @@ class GitHubIntegration(ExternalIntegration):
     def is_available(self) -> bool:
         """Проверяет что GitHub CLI доступен и авторизован."""
         try:
-            # Убираем проблемный GITHUB_TOKEN
-            env = os.environ.copy()
-            env.pop("GITHUB_TOKEN", None)
+            from whilly.gh_utils import gh_subprocess_env
 
-            result = subprocess.run(["gh", "auth", "status"], capture_output=True, text=True, env=env)
+            result = subprocess.run(["gh", "auth", "status"], capture_output=True, text=True, env=gh_subprocess_env())
             return result.returncode == 0
         except FileNotFoundError:
             log.warning("GitHub CLI not found in PATH")
@@ -76,15 +74,13 @@ class GitHubIntegration(ExternalIntegration):
                 comment = self._build_completion_comment(whilly_task_id, commit_sha)
                 self.add_comment(task_ref, comment)
 
-            # Закрываем issue
-            env = os.environ.copy()
-            env.pop("GITHUB_TOKEN", None)
+            from whilly.gh_utils import gh_subprocess_env
 
             result = subprocess.run(
                 ["gh", "issue", "close", task_ref.task_id, "--reason", "completed"],
                 capture_output=True,
                 text=True,
-                env=env,
+                env=gh_subprocess_env(),
             )
 
             if result.returncode == 0:
@@ -104,11 +100,13 @@ class GitHubIntegration(ExternalIntegration):
             return False
 
         try:
-            env = os.environ.copy()
-            env.pop("GITHUB_TOKEN", None)
+            from whilly.gh_utils import gh_subprocess_env
 
             result = subprocess.run(
-                ["gh", "issue", "comment", task_ref.task_id, "--body", comment], capture_output=True, text=True, env=env
+                ["gh", "issue", "comment", task_ref.task_id, "--body", comment],
+                capture_output=True,
+                text=True,
+                env=gh_subprocess_env(),
             )
 
             if result.returncode == 0:

--- a/whilly/gh_utils.py
+++ b/whilly/gh_utils.py
@@ -1,0 +1,44 @@
+"""Helpers for invoking the GitHub CLI (`gh`) from whilly.
+
+Centralises how we build the subprocess environment so every caller
+agrees on the auth source. Resolution order (first match wins):
+
+1. ``WHILLY_GH_TOKEN`` — whilly-specific token. Placed into ``GITHUB_TOKEN``
+   for the subprocess only, so users with a broken ambient ``GITHUB_TOKEN``
+   can override it without touching the rest of their shell.
+2. ``WHILLY_GH_PREFER_KEYRING=1`` — explicitly strip ``GITHUB_TOKEN`` /
+   ``GH_TOKEN`` and force ``gh`` to use its keyring auth. Useful on macOS
+   when the ambient ``GITHUB_TOKEN`` is stale but ``gh auth login`` was run.
+3. Otherwise, ``GITHUB_TOKEN`` / ``GH_TOKEN`` pass through unchanged —
+   the cross-platform default that works on Linux, Windows, and CI.
+"""
+
+from __future__ import annotations
+
+import os
+
+_TRUTHY = ("1", "true", "yes", "on")
+
+
+def gh_subprocess_env() -> dict[str, str]:
+    """Return an ``os.environ`` copy prepared for a ``gh`` CLI subprocess.
+
+    Consult the module docstring for the full resolution order.
+    """
+    env = dict(os.environ)
+
+    whilly_token = (env.get("WHILLY_GH_TOKEN") or "").strip()
+    if whilly_token:
+        env["GITHUB_TOKEN"] = whilly_token
+        env.pop("GH_TOKEN", None)
+        return env
+
+    prefer_keyring = (env.get("WHILLY_GH_PREFER_KEYRING") or "").strip().lower() in _TRUTHY
+    if prefer_keyring:
+        env.pop("GITHUB_TOKEN", None)
+        env.pop("GH_TOKEN", None)
+
+    return env
+
+
+__all__ = ["gh_subprocess_env"]

--- a/whilly/github_converter.py
+++ b/whilly/github_converter.py
@@ -196,13 +196,9 @@ def fetch_github_issues(filter_labels: list[str] | None = None) -> list[GitHubIs
             cmd.extend(["--label", label])
 
     try:
-        # Используем текущее окружение, но без проблемного GITHUB_TOKEN
-        import os
+        from whilly.gh_utils import gh_subprocess_env
 
-        env = os.environ.copy()
-        env.pop("GITHUB_TOKEN", None)  # Убираем проблемный токен если есть
-
-        result = subprocess.run(cmd, capture_output=True, text=True, env=env, check=True)
+        result = subprocess.run(cmd, capture_output=True, text=True, env=gh_subprocess_env(), check=True)
         issues_data = json.loads(result.stdout)
 
         return [GitHubIssue.from_gh_json(issue) for issue in issues_data]

--- a/whilly/github_interactive.py
+++ b/whilly/github_interactive.py
@@ -3,21 +3,13 @@
 
 from __future__ import annotations
 
-import os
 import subprocess
 from typing import Optional
 
 from whilly.config import WhillyConfig
+from whilly.gh_utils import gh_subprocess_env as _gh_env
 from whilly.sources.github_issues import fetch_github_issues
 from whilly.external_integrations import create_integration_manager
-
-
-def _gh_env() -> dict[str, str]:
-    """Return os.environ copy with stale GITHUB_TOKEN / GH_TOKEN removed — `gh` CLI prefers its keyring."""
-    env = dict(os.environ)
-    env.pop("GITHUB_TOKEN", None)
-    env.pop("GH_TOKEN", None)
-    return env
 
 
 def _run_command(cmd: list[str]) -> tuple[bool, str]:

--- a/whilly/github_projects.py
+++ b/whilly/github_projects.py
@@ -5,7 +5,6 @@ Supports status-oriented workflows with incremental sync and monitoring.
 """
 
 import json
-import os
 import re
 import subprocess
 import time
@@ -15,14 +14,7 @@ from pathlib import Path
 from typing import List, Optional, Dict, Any, Set
 
 from whilly.config import WhillyConfig
-
-
-def _gh_env() -> dict[str, str]:
-    """Return os.environ copy with stale GITHUB_TOKEN removed — `gh` CLI prefers its keyring."""
-    env = dict(os.environ)
-    env.pop("GITHUB_TOKEN", None)
-    env.pop("GH_TOKEN", None)
-    return env
+from whilly.gh_utils import gh_subprocess_env as _gh_env
 
 
 @dataclass

--- a/whilly/sinks/github_pr.py
+++ b/whilly/sinks/github_pr.py
@@ -72,13 +72,14 @@ class GitHubPRSink:
 
 
 def _strip_env_tokens() -> dict:
-    """Return os.environ copy with GH/GITHUB tokens removed (prefer keyring auth)."""
-    import os as _os
+    """Return a subprocess env prepared by the centralised whilly helper.
 
-    env = dict(_os.environ)
-    env.pop("GITHUB_TOKEN", None)
-    env.pop("GH_TOKEN", None)
-    return env
+    See :mod:`whilly.gh_utils` for how `WHILLY_GH_TOKEN` / `WHILLY_GH_PREFER_KEYRING`
+    / ambient `GITHUB_TOKEN` interact.
+    """
+    from whilly.gh_utils import gh_subprocess_env
+
+    return gh_subprocess_env()
 
 
 def _run(cmd: list[str], cwd: Path, timeout: int = 60) -> subprocess.CompletedProcess:

--- a/whilly/sources/github_issues.py
+++ b/whilly/sources/github_issues.py
@@ -119,19 +119,16 @@ def _gh_bin() -> str:
 
 
 def _run_gh(args: list[str], timeout: int = 30) -> subprocess.CompletedProcess:
-    """Run `gh` with GITHUB_TOKEN unset to prefer the user's keyring auth.
+    """Run `gh` with the centrally-resolved whilly auth env.
 
-    GITHUB_TOKEN env is sometimes set to expired CI tokens; gh prefers that env over the keyring,
-    which causes spurious 401s. We unset it explicitly for this subprocess only.
+    See :mod:`whilly.gh_utils` — ``WHILLY_GH_TOKEN`` overrides the ambient token,
+    ``WHILLY_GH_PREFER_KEYRING=1`` strips env tokens to force `gh` keyring auth,
+    and otherwise ``GITHUB_TOKEN`` / ``GH_TOKEN`` pass through unchanged.
     """
-    import os as _os
-
-    env = dict(_os.environ)
-    env.pop("GITHUB_TOKEN", None)
-    env.pop("GH_TOKEN", None)
+    from whilly.gh_utils import gh_subprocess_env
 
     cmd = [_gh_bin(), *args]
-    return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout, env=env, check=False)
+    return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout, env=gh_subprocess_env(), check=False)
 
 
 def _gh_issue_list(source: GitHubIssuesSource, timeout: int = 30) -> list[dict]:


### PR DESCRIPTION
## Summary
Before: seven modules each manually popped `GITHUB_TOKEN` / `GH_TOKEN` from every `gh` subprocess env, hard-coding mac-specific keyring-wins behaviour. On Linux / Windows / CI — where `GITHUB_TOKEN` is the legitimate primary auth — whilly silently discarded it.

New central helper `whilly/gh_utils.py::gh_subprocess_env()` with a documented resolution order:

1. `WHILLY_GH_TOKEN` — whilly-only token, injected as `GITHUB_TOKEN` for the subprocess without touching your shell.
2. `WHILLY_GH_PREFER_KEYRING=1` — strip env tokens so `gh` uses its keyring (mac/libsecret/Windows Credential Manager).
3. Otherwise — `GITHUB_TOKEN` / `GH_TOKEN` pass through unchanged (cross-platform default).

Replaced the seven ad-hoc sites and documented the knobs in `.env.example`.

## Cross-platform behaviour
- **Linux / Windows / CI** (most common): set `GITHUB_TOKEN` like you always do — now whilly actually uses it.
- **macOS + `gh auth login`**: put `WHILLY_GH_PREFER_KEYRING=1` in `.env` to get the previous behaviour (ignore stale shell `GITHUB_TOKEN`, use keyring).
- **Mixed**: put a fresh token in `WHILLY_GH_TOKEN` to override per-whilly without polluting the rest of your shell.

## Test plan
- [x] `python3 -m ruff check --fix whilly/` — clean
- [x] `python3 -m ruff format whilly/` — clean
- [x] `pytest -q` — 490 passed
- [x] Matrix of 5 cases for `gh_subprocess_env()` verified in-process (empty env, plain passthrough, `WHILLY_GH_PREFER_KEYRING=1` stripping, `WHILLY_GH_TOKEN` override, empty-string `WHILLY_GH_TOKEN` ignored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)