### PR TITLE
chore: gitignore whilly.toml + .env.bak (personal state, not shared)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,10 @@ env/
 # Local env overrides (use .env.example as the template)
 .env
 .env.local
+.env.bak
+
+# Local whilly config — personal, use whilly.example.toml as the template
+whilly.toml
 
 # Editor / OS
 .vscode/


### PR DESCRIPTION
## Summary
Finish the config-split begun in #178/#179: treat per-user `whilly.toml` the same way `.env` is treated — ignored by git, with `whilly.example.toml` as the committed template.

- `whilly.toml` → ignored. Users run `whilly --config migrate` (or hand-write) to produce their own.
- `.env.bak` → ignored. Auto-generated by the migration command as a safety net.

Without this ignore rule, anyone running `whilly --config migrate` on a clean checkout ends up with their personal preferences showing as untracked in `git status` and risks committing them.

## Test plan
- [x] `git check-ignore whilly.toml .env.bak` confirms both are matched.
- [x] Existing `.env` / `.env.example` relationship is unchanged — only extended to the new file pair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)