### PR TITLE
docs: TOML-first config guide + .env.example deprecation banner

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,15 @@
 # Whilly Orchestrator — local environment overrides
 #
+# ─── DEPRECATED ────────────────────────────────────────────────────────────
+# Prefer `whilly.example.toml` + keyring-backed secrets. The `.env` loader
+# still works for back-compat but emits a warning on every run. Migrate with:
+#
+#     whilly --config migrate
+#
+# This template is kept only so existing setups keep building. New projects
+# should start from `whilly.example.toml`.
+# ───────────────────────────────────────────────────────────────────────────
+#
 # Copy this file to `.env` and uncomment the variables you want to override.
 # `whilly` loads `.env` from the current working directory on startup.
 # Real shell environment variables always win — .env is a fallback only.

--- a/README.md
+++ b/README.md
@@ -144,7 +144,25 @@ See [Self-Healing Guide](docs/Self-Healing-Guide.md) for complete documentation.
 
 ## Configuration
 
-Configuration is done via environment variables (prefix `WHILLY_`). A few CLI flags exist for one-shot overrides — see `whilly --help`.
+Whilly resolves config through layers (last wins):
+
+```
+defaults → user TOML → ./whilly.toml → .env → shell env (WHILLY_*) → CLI flags
+```
+
+Start from the committed template (works cross-platform — macOS / Linux / Windows):
+
+```bash
+cp whilly.example.toml whilly.toml           # project-local
+# or place settings at the OS-native user path:
+whilly --config path                         # shows the location
+whilly --config edit                         # opens it in $EDITOR
+
+# legacy .env users: one-shot migration that moves tokens into the OS keyring
+whilly --config migrate
+```
+
+See [docs/Whilly-Usage.md](docs/Whilly-Usage.md) for the full config guide (TOML fields, secret schemes, user-config paths per OS). The env-var table below is kept as a reference — every `WHILLY_*` variable has an equivalent TOML field of the same name.
 
 | Variable | Default | Purpose |
 |---|---|---|

--- a/docs/Whilly-Usage.md
+++ b/docs/Whilly-Usage.md
@@ -5,28 +5,140 @@ Python-based task orchestrator that runs Claude CLI agents to execute tasks from
 ## Quick Start
 
 ```bash
-# Run with specific plan
-./whilly.py .planning/my_tasks.json
+# Install (pipx works on macOS/Linux/Windows)
+pipx install whilly-orchestrator
 
-# Auto-discover plans
-./whilly.py
+# First run: let whilly tell you where your user config lives
+whilly --config path
 
-# Run all discovered plans
-./whilly.py --all
+# Either migrate a legacy .env, or copy the template:
+whilly --config migrate                           # if you have an old .env
+cp whilly.example.toml whilly.toml                # or start fresh from template
+
+# Run with a specific plan
+whilly .planning/my_tasks.json
+
+# Auto-discover plans in the current directory
+whilly
+
+# Run all discovered plans sequentially
+whilly --all
+
+# Pull open GitHub issues as tasks and start immediately
+whilly --from-github whilly:ready --go
 ```
 
-## Configuration (Environment Variables)
+## Configuration
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| WHILLY_MAX_ITERATIONS | 0 (unlimited) | Max work iterations per plan |
-| WHILLY_MAX_PARALLEL | 3 | Concurrent agents (1=sequential) |
-| WHILLY_USE_TMUX | 1 | Use tmux for agent isolation |
-| WHILLY_MODEL | claude-opus-4-6[1m] | LLM model |
-| WHILLY_LOG_DIR | whilly_logs | Directory for per-task logs |
-| WHILLY_ORCHESTRATOR | file | Orchestration: "file" or "llm" |
-| WHILLY_VOICE | 1 | macOS voice notifications |
-| WHILLY_DECOMPOSE_EVERY | 5 | Re-plan every N completed tasks |
+Whilly reads its config through five layers, last wins:
+
+```
+defaults (dataclass)
+  ↓
+user TOML    — OS-native per-user config
+  ↓
+repo TOML    — ./whilly.toml  (project-local overrides)
+  ↓
+.env         — legacy, loads with a deprecation warning
+  ↓
+shell env    — WHILLY_* variables
+  ↓
+CLI flags    — highest precedence
+```
+
+### User config location
+
+`whilly --config path` prints the OS-native location:
+
+| OS       | Path                                                         |
+|----------|--------------------------------------------------------------|
+| macOS    | `~/Library/Application Support/whilly/config.toml`           |
+| Linux    | `$XDG_CONFIG_HOME/whilly/config.toml` (default `~/.config/whilly/config.toml`) |
+| Windows  | `%APPDATA%\whilly\config.toml`                               |
+
+### Inspect the merged config
+
+```bash
+whilly --config show          # merged result, secrets redacted
+whilly --config edit          # open user config in $EDITOR
+```
+
+### Example `whilly.toml`
+
+```toml
+# Core loop
+MAX_PARALLEL = 1             # concurrent agents (1 = sequential)
+MAX_ITERATIONS = 0           # 0 = unlimited
+BUDGET_USD = 0               # 0 = unlimited; warns at 80 %, kills at 100 %
+
+# Agent backend
+AGENT_BACKEND = "claude"
+MODEL = "claude-opus-4-7[1m]"
+
+# Workspace + tmux
+USE_WORKSPACE = true
+USE_TMUX = false
+
+# Logging
+LOG_DIR = "whilly_logs"
+VOICE = false
+
+# External integrations
+CLOSE_EXTERNAL_TASKS = true
+GITHUB_AUTO_CLOSE = true
+
+# GitHub auth — cross-platform secrets
+# Schemes: env:NAME, keyring:service/user, file:/path, literal
+[github]
+token = "keyring:whilly/github"
+
+# Jira (optional)
+[jira]
+# server_url = "https://jira.example.com"
+# username   = "you@example.com"
+# token      = "keyring:whilly/jira"
+```
+
+Store secrets once, per OS:
+
+```bash
+python3 -c "import keyring; keyring.set_password('whilly', 'github', 'ghp_xxx')"
+```
+
+### GitHub auth resolution order
+
+Used by `whilly/gh_utils.py::gh_subprocess_env()` when invoking `gh`:
+
+1. `WHILLY_GH_TOKEN`              → overrides everything, just for whilly's subprocesses
+2. `WHILLY_GH_PREFER_KEYRING=1`   → strips env tokens, forces `gh` to use its own keyring
+3. `[github].token` in `whilly.toml` → resolved via `env:` / `keyring:` / `file:` schemes
+4. Ambient `GITHUB_TOKEN` / `GH_TOKEN` — passed through unchanged (cross-platform default)
+
+### Full env var reference (back-compat)
+
+| Variable                          | Default                | Description |
+|-----------------------------------|------------------------|-------------|
+| `WHILLY_MAX_ITERATIONS`           | `0` (unlimited)        | Max work iterations per plan |
+| `WHILLY_MAX_PARALLEL`             | `3`                    | Concurrent agents (1 = sequential) |
+| `WHILLY_MAX_TASK_RETRIES`         | `5`                    | Retries before a task is skipped/failed |
+| `WHILLY_BUDGET_USD`               | `0`                    | `0` = unlimited; warns at 80 %, kills at 100 % |
+| `WHILLY_TIMEOUT`                  | `0`                    | Wall-clock seconds per plan (`0` = unlimited) |
+| `WHILLY_AGENT_BACKEND`            | `claude`               | `claude` or `opencode` |
+| `WHILLY_MODEL`                    | `claude-opus-4-6[1m]`  | LLM model |
+| `WHILLY_USE_TMUX`                 | `0`                    | Run each agent in its own tmux session |
+| `WHILLY_USE_WORKSPACE`            | `1`                    | Plan-level git worktree workspace |
+| `WHILLY_LOG_DIR`                  | `whilly_logs`          | Directory for per-task logs |
+| `WHILLY_ORCHESTRATOR`             | `file`                 | `file` (key-files collisions) or `llm` (LLM batching) |
+| `WHILLY_VOICE`                    | `1`                    | macOS voice notifications |
+| `WHILLY_HEADLESS`                 | `0`                    | JSON stdout, no TUI (auto when stdout is not a TTY) |
+| `WHILLY_DECOMPOSE_EVERY`          | `5`                    | Re-plan oversized pending tasks every N iterations |
+| `WHILLY_AUTO_MERGE`               | `ask`                  | `ask` / `yes` / `claude` / `no` on plan completion |
+| `WHILLY_GH_TOKEN`                 | *(unset)*              | Whilly-only GitHub token (overrides ambient) |
+| `WHILLY_GH_PREFER_KEYRING`        | `0`                    | Force `gh` keyring auth even when `GITHUB_TOKEN` is set |
+| `WHILLY_SUPPRESS_DOTENV_WARNING`  | `0`                    | Silence the legacy `.env` deprecation warning |
+
+Every `WHILLY_*` variable corresponds to an equivalent `whilly.toml` field (same name, any case).
+See `whilly.example.toml` for the complete template.
 
 ## Keyboard Shortcuts
 
@@ -37,6 +149,8 @@ Python-based task orchestrator that runs Claude CLI agents to execute tasks from
 | l | Log viewer (last 30 lines) |
 | t | All tasks overview |
 | h | Help screen |
+
+(Windows: key listener is disabled; the dashboard itself still renders.)
 
 ## Task Plan JSON Format
 
@@ -63,22 +177,27 @@ Python-based task orchestrator that runs Claude CLI agents to execute tasks from
 ## Architecture
 
 ```
-whilly.py              Entry point + main loop
+whilly.py                    Entry point + main loop
 whilly/
-  config.py           Config from WHILLY_* env vars
-  task_manager.py     JSON plan CRUD, dependency resolution
-  agent_runner.py     Claude CLI subprocess + JSON parsing
-  tmux_runner.py      Tmux session isolation
-  orchestrator.py     File-based + LLM task batching
-  dashboard.py        Rich Live TUI + keyboard handler
-  reporter.py         JSON + Markdown cost reports
-  decomposer.py       Task decomposition via LLM
-  notifications.py    macOS voice alerts
+  config.py                 Layered config (defaults → TOML → .env → env)
+  secrets.py                env:/keyring:/file:/literal resolver
+  gh_utils.py               Central gh CLI subprocess env resolution
+  task_manager.py           JSON plan CRUD, dependency resolution
+  agent_runner.py           Claude/OpenCode subprocess + JSON parsing
+  tmux_runner.py            Tmux session isolation
+  orchestrator.py           File-based + LLM task batching
+  dashboard.py              Rich Live TUI + keyboard handler
+  reporter.py               JSON + Markdown cost reports
+  decomposer.py             Task decomposition via LLM
+  notifications.py          macOS voice alerts
+  sources/                  Input adapters (GitHub Issues, Project v2, unified)
+  sinks/                    Output adapters (PR creation, etc.)
+  agents/                   Pluggable backends (claude, opencode)
 ```
 
-## Tmux Setup
+## Tmux Setup (optional)
 
-Agents run in isolated tmux sessions when `WHILLY_USE_TMUX=1`:
+When `USE_TMUX = true`, each agent runs in its own tmux session:
 
 ```bash
 # View running agent sessions
@@ -87,7 +206,7 @@ tmux ls | grep whilly-
 # Attach to a specific agent
 tmux attach -t whilly-TASK-001
 
-# Kill all whilly sessions
+# Kill a session
 tmux kill-session -t whilly-TASK-001
 ```
 
@@ -95,8 +214,10 @@ tmux kill-session -t whilly-TASK-001
 
 | Problem | Solution |
 |---------|----------|
-| Dashboard doesn't render | Check terminal supports Rich (try `python3 -c "from rich import print; print('[bold]test[/]')"`) |
-| Agent auth errors (403) | Check Claude CLI authentication: `claude --version` |
-| Tmux not found | Install: `brew install tmux` or set `WHILLY_USE_TMUX=0` |
+| Dashboard doesn't render | Check Rich works: `python3 -c "from rich import print; print('[bold]test[/]')"` |
+| Agent auth errors (403) | Check Claude CLI: `claude --version` |
+| `gh` returns 401 / not found | `unset GITHUB_TOKEN && gh auth status`; set `WHILLY_GH_PREFER_KEYRING=1` on macOS |
+| Tmux not found | `brew install tmux` or set `USE_TMUX = false` |
 | Tasks stuck in_progress | Whilly resets stale tasks on startup |
-| Too many API errors | Whilly pauses 60s after 5+ consecutive failures |
+| Too many API errors | Whilly pauses 60 s after 5+ consecutive failures |
+| Legacy `.env` warning on every run | Run `whilly --config migrate`, or silence with `WHILLY_SUPPRESS_DOTENV_WARNING=1` |


### PR DESCRIPTION
## Summary
Documentation catch-up for #178/#179/#180. The code says TOML is the primary surface — the docs now match.

### docs/Whilly-Usage.md
- Rewrites **Configuration** as a layered pipeline (defaults → user TOML → repo TOML → .env → env → CLI).
- Adds a **User config location** table per OS (macOS / Linux / Windows).
- Documents `whilly --config {show, path, edit, migrate}`.
- Shows an example `whilly.toml` with `[github]` / `[jira]` sections and the keyring-backed secret scheme.
- Keeps the full `WHILLY_*` env-var table as back-compat reference.

### README.md
- Leads with the TOML + migration story, keeps the env-var table underneath.

### .env.example
- DEPRECATED banner at the top pointing at `whilly --config migrate` and `whilly.example.toml`. File preserved so existing setups still build.

No code changes; 518 tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)