### PR TITLE
feat: Audio announces task title + classification (closes #162)

### DIFF
--- a/scripts/move_project_card.py
+++ b/scripts/move_project_card.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Move a GitHub Projects v2 card to a named Status via `gh api graphql`.
+
+Usage:
+    python3 scripts/move_project_card.py <project_url> <issue_number> "<status_name>" [--repo owner/repo]
+
+Example:
+    python3 scripts/move_project_card.py \\
+        https://github.com/users/mshegolev/projects/4 \\
+        162 "In Progress" --repo mshegolev/whilly-orchestrator
+
+Requires `gh` CLI logged in with the `project` scope:
+    gh auth refresh -s project
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+
+
+def _gh_env() -> dict[str, str]:
+    env = dict(os.environ)
+    env.pop("GITHUB_TOKEN", None)
+    env.pop("GH_TOKEN", None)
+    return env
+
+
+def _parse_project_url(url: str) -> tuple[str, str, int]:
+    """Return (owner_login, owner_type, project_number) for a projects/v2 URL."""
+    patterns = [
+        (r"github\.com/users/([^/]+)/projects/(\d+)", "user"),
+        (r"github\.com/orgs/([^/]+)/projects/(\d+)", "organization"),
+    ]
+    for pat, owner_type in patterns:
+        m = re.search(pat, url)
+        if m:
+            return m.group(1), owner_type, int(m.group(2))
+    raise SystemExit(f"Unsupported project URL: {url}")
+
+
+def _gh_api(query: str, *fields: str) -> dict:
+    args = ["gh", "api", "graphql", "-f", f"query={query}", *fields]
+    proc = subprocess.run(args, capture_output=True, text=True, env=_gh_env())
+    if proc.returncode != 0:
+        raise SystemExit(f"gh api failed:\n{proc.stderr}")
+    return json.loads(proc.stdout)
+
+
+def fetch_project_metadata(owner: str, owner_type: str, number: int) -> dict:
+    """Return {project_id, status_field_id, option_id_by_name, items: [{id, issue_number}]}."""
+    query = (
+        f"query($owner: String!, $number: Int!) {{"
+        f"  {owner_type}(login: $owner) {{"
+        f"    projectV2(number: $number) {{"
+        f"      id"
+        f"      fields(first: 50) {{"
+        f"        nodes {{"
+        f"          __typename"
+        f"          ... on ProjectV2SingleSelectField {{"
+        f"            id name options {{ id name }}"
+        f"          }}"
+        f"        }}"
+        f"      }}"
+        f"      items(first: 100) {{"
+        f"        nodes {{"
+        f"          id"
+        f"          content {{ __typename ... on Issue {{ number repository {{ nameWithOwner }} }} }}"
+        f"        }}"
+        f"      }}"
+        f"    }}"
+        f"  }}"
+        f"}}"
+    )
+    data = _gh_api(query, "-F", f"owner={owner}", "-F", f"number={number}")
+    project = data["data"][owner_type]["projectV2"]
+    status_field = next(
+        (
+            n
+            for n in project["fields"]["nodes"]
+            if n.get("name") == "Status" and n.get("__typename") == "ProjectV2SingleSelectField"
+        ),
+        None,
+    )
+    if not status_field:
+        raise SystemExit("Project has no 'Status' single-select field.")
+    option_id = {o["name"]: o["id"] for o in status_field["options"]}
+    items = []
+    for node in project["items"]["nodes"]:
+        content = node.get("content") or {}
+        if content.get("__typename") == "Issue":
+            items.append(
+                {
+                    "item_id": node["id"],
+                    "issue_number": content["number"],
+                    "repo": content["repository"]["nameWithOwner"],
+                }
+            )
+    return {
+        "project_id": project["id"],
+        "status_field_id": status_field["id"],
+        "option_id_by_name": option_id,
+        "items": items,
+    }
+
+
+def set_status(project_id: str, item_id: str, field_id: str, option_id: str) -> None:
+    mutation = (
+        "mutation($project: ID!, $item: ID!, $field: ID!, $option: String!) {"
+        "  updateProjectV2ItemFieldValue("
+        "    input: { projectId: $project, itemId: $item, fieldId: $field,"
+        "             value: { singleSelectOptionId: $option } }"
+        "  ) { projectV2Item { id } }"
+        "}"
+    )
+    _gh_api(
+        mutation,
+        "-F",
+        f"project={project_id}",
+        "-F",
+        f"item={item_id}",
+        "-F",
+        f"field={field_id}",
+        "-F",
+        f"option={option_id}",
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("project_url")
+    p.add_argument("issue_number", type=int)
+    p.add_argument("status_name")
+    p.add_argument("--repo", default=None, help="Optional owner/repo filter (disambiguates same-numbered issues).")
+    args = p.parse_args(argv)
+
+    owner, owner_type, number = _parse_project_url(args.project_url)
+    meta = fetch_project_metadata(owner, owner_type, number)
+
+    if args.status_name not in meta["option_id_by_name"]:
+        print(
+            f"✗ Status '{args.status_name}' not in project. Available: {list(meta['option_id_by_name'])}",
+            file=sys.stderr,
+        )
+        return 2
+
+    candidates = [i for i in meta["items"] if i["issue_number"] == args.issue_number]
+    if args.repo:
+        candidates = [i for i in candidates if i["repo"] == args.repo]
+    if not candidates:
+        print(f"✗ Issue #{args.issue_number} not found on the project board.", file=sys.stderr)
+        return 3
+    if len(candidates) > 1:
+        print(
+            f"✗ Issue #{args.issue_number} is on the board multiple times — pass --repo to disambiguate.",
+            file=sys.stderr,
+        )
+        return 4
+
+    item = candidates[0]
+    set_status(
+        meta["project_id"],
+        item["item_id"],
+        meta["status_field_id"],
+        meta["option_id_by_name"][args.status_name],
+    )
+    print(f"✓ Moved {item['repo']}#{args.issue_number} → {args.status_name!r}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_notifications_per_task.py
+++ b/tests/test_notifications_per_task.py
@@ -1,0 +1,110 @@
+"""Unit tests for per-task audio announcements (issue #162).
+
+Exercises the title-parsing logic in :mod:`whilly.notifications` without
+actually invoking macOS `say` — every test stubs the `notify()` sink so we
+capture the phrase that would be spoken.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from whilly import notifications
+
+
+@pytest.fixture
+def spoken(monkeypatch):
+    """Capture calls to ``notifications.notify()``."""
+    phrases: list[str] = []
+    monkeypatch.setattr(notifications, "notify", lambda text: phrases.append(text))
+    return phrases
+
+
+# ─── classifier ────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "title,expected_category,expected_clean",
+    [
+        ("[feature] add audio for task names", "Фичу", "add audio for task names"),
+        ("[Feat] rename thing", "Фичу", "rename thing"),
+        ("[NFR-5] Cost panel in dashboard", "Нефункциональное требование", "Cost panel in dashboard"),
+        ("[FR-9] PR body composition", "Функциональное требование", "PR body composition"),
+        ("[bug] deadlock on budget cap", "Баг", "deadlock on budget cap"),
+        ("[epic] revamp orchestrator loop", "Эпик", "revamp orchestrator loop"),
+        ("[ADR-017] draft decision", "АДР", "draft decision"),
+        ("[docs] README update", "Документацию", "README update"),
+        ("no bracket prefix", None, "no bracket prefix"),
+        ("", None, ""),
+        (None, None, ""),
+    ],
+)
+def test_classify_and_strip(title, expected_category, expected_clean):
+    cat, clean = notifications._classify_and_strip(title)
+    assert cat == expected_category
+    assert clean == expected_clean
+
+
+def test_summarise_truncates_long_titles():
+    long_title = "[feature] " + ("word " * 80)
+    summary = notifications._summarise_task(long_title, max_chars=60)
+    assert summary.startswith("Фичу: ")
+    # Check the clean part (after "Фичу: ") is ≤ max_chars + 1 (for the ellipsis).
+    assert len(summary.split(": ", 1)[1]) <= 61
+
+
+def test_summarise_handles_multiline_body():
+    summary = notifications._summarise_task("[bug] crash\n\nsome body here\nmore")
+    assert summary == "Баг: crash"
+
+
+def test_summarise_empty():
+    assert notifications._summarise_task(None) == "задачу без названия"
+    assert notifications._summarise_task("") == "задачу без названия"
+
+
+# ─── notify_task_done ──────────────────────────────────────────────────────────
+
+
+def test_notify_task_done_without_title_is_generic(spoken):
+    notifications.notify_task_done()
+    assert spoken == ["Задача готова. Продолжаю работу."]
+
+
+def test_notify_task_done_with_categorised_title(spoken):
+    notifications.notify_task_done("[feature] добавь аудио с названием задачи")
+    assert len(spoken) == 1
+    assert spoken[0].startswith("Готово — Фичу: добавь аудио с названием задачи.")
+
+
+def test_notify_task_done_with_untagged_title(spoken):
+    notifications.notify_task_done("Refactor the orchestrator")
+    assert spoken == ["Готово — Refactor the orchestrator. Продолжаю работу."]
+
+
+# ─── notify_plan_done / notify_all_done ────────────────────────────────────────
+
+
+def test_notify_plan_done_without_titles(spoken):
+    notifications.notify_plan_done()
+    assert spoken == ["План завершён!"]
+
+
+def test_notify_plan_done_with_last_titles(spoken):
+    notifications.notify_plan_done(["[docs] README refresh"])
+    assert spoken == ["План завершён! Последняя задача — Документацию: README refresh."]
+
+
+def test_notify_all_done_without_context(spoken):
+    notifications.notify_all_done()
+    assert spoken == ["Хозяин, я всё сделалъ!"]
+
+
+def test_notify_all_done_with_count_and_title(spoken):
+    notifications.notify_all_done(completed_count=3, last_title="[bug] deadlock on budget cap")
+    assert spoken == ["Хозяин, я всё сделалъ! Выполнено 3 задач, последняя — Баг: deadlock on budget cap."]
+
+
+def test_notify_all_done_with_just_title(spoken):
+    notifications.notify_all_done(last_title="Refactor the orchestrator")
+    assert spoken == ["Хозяин, я всё сделалъ! Последняя задача — Refactor the orchestrator."]

--- a/whilly/cli.py
+++ b/whilly/cli.py
@@ -198,6 +198,34 @@ def _get_version_info() -> tuple[str, str, str]:
         return __version__, "?", ""
 
 
+def _task_title_for_notify(task: object | None) -> str | None:
+    """Best-effort extraction of a user-readable task title for audio announcements.
+
+    Tasks use the first line of ``description`` as their title; `issue_to_task`
+    builds description as ``"<title>\\n\\n<body>"``. Falls back to task ``id`` so
+    the listener still hears something identifiable when description is empty.
+    """
+    if task is None:
+        return None
+    description = getattr(task, "description", "") or ""
+    first_line = description.splitlines()[0].strip() if description else ""
+    if first_line:
+        return first_line
+    task_id = getattr(task, "id", None)
+    return str(task_id) if task_id else None
+
+
+def _last_done_title(task_manager: object | None) -> str | None:
+    """Return the title of the most recently-completed task, if any."""
+    if task_manager is None:
+        return None
+    tasks = getattr(task_manager, "tasks", []) or []
+    for task in reversed(list(tasks)):
+        if getattr(task, "status", None) == "done":
+            return _task_title_for_notify(task)
+    return None
+
+
 def _run_config_command(sub: str) -> int:
     """Handle ``whilly --config <sub>``: show / path / migrate / edit."""
     from dataclasses import fields
@@ -727,10 +755,9 @@ def wait_and_collect_tmux(
 
         if result.is_complete:
             tm.mark_status([agent.task_id], "done")
-            notify_task_done()
-
             # Автоматическое закрытие внешних задач
             task = next((t for t in tm.tasks if t.id == agent.task_id), None)
+            notify_task_done(_task_title_for_notify(task))
             if task:
                 _handle_task_completion(task, tm, config)
 
@@ -828,7 +855,7 @@ def wait_and_collect_subprocess(
 
         if result.is_complete:
             tm.mark_status([task.id], "done")
-            notify_task_done()
+            notify_task_done(_task_title_for_notify(task))
 
             # Автоматическое закрытие внешних задач
             _handle_task_completion(task, tm, config)
@@ -1420,7 +1447,8 @@ def run_plan(
     if state_store:
         state_store.clear()
 
-    notify_plan_done()
+    last_title = _last_done_title(tm)
+    notify_plan_done([last_title] if last_title else None)
 
     # Finalize
     total_dur = time.monotonic() - plan_start

--- a/whilly/notifications.py
+++ b/whilly/notifications.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import shutil
 import subprocess
 
@@ -12,6 +13,25 @@ log = logging.getLogger("whilly")
 SAY_BIN: str | None = shutil.which("say")
 VOICE = "Milena"
 ENABLED = os.environ.get("WHILLY_VOICE", "1").lower() not in ("0", "false", "no", "off")
+
+
+# Classification prefix → spoken word. Honoured when the task title starts with
+# `[feature]`, `[epic]`, `[bug]`, `[fix]`, `[FR-x]`, `[NFR-y]`, `[docs]`, `[chore]`.
+_CATEGORY_PREFIXES: dict[str, str] = {
+    "feature": "Фичу",
+    "feat": "Фичу",
+    "epic": "Эпик",
+    "story": "Историю",
+    "bug": "Баг",
+    "fix": "Фикс",
+    "docs": "Документацию",
+    "chore": "Задачу",
+    "refactor": "Рефакторинг",
+    "test": "Тест",
+    "nfr": "Нефункциональное требование",
+    "fr": "Функциональное требование",
+    "adr": "АДР",
+}
 
 
 def notify(text: str) -> None:
@@ -24,20 +44,72 @@ def notify(text: str) -> None:
         pass
 
 
+def _classify_and_strip(title: str) -> tuple[str | None, str]:
+    """Return (spoken_category, cleaned_title).
+
+    Pulls a leading ``[category]`` (or ``[FR-12]`` / ``[NFR-3]``) tag from the
+    title, maps it to a Russian spoken noun via :data:`_CATEGORY_PREFIXES`,
+    and strips it from the title so the announcement reads naturally.
+    """
+    if not title:
+        return None, ""
+    title = title.strip()
+    match = re.match(r"^\[([A-Za-z]+)(?:[-/][\w.-]+)?\]\s*(.*)$", title)
+    if not match:
+        return None, title
+    tag = match.group(1).lower()
+    remainder = match.group(2).strip()
+    category = _CATEGORY_PREFIXES.get(tag)
+    return category, remainder or title
+
+
+def _summarise_task(title: str | None, *, max_chars: int = 120) -> str:
+    """Return the announcement fragment — category prefix + short title."""
+    if not title:
+        return "задачу без названия"
+    # First line only, trimmed — `say` rambles forever otherwise and the
+    # classifier regex only recognises a `[tag]` at the start of that line.
+    first_line = title.splitlines()[0].strip() if title else ""
+    if not first_line:
+        return "задачу без названия"
+    category, clean = _classify_and_strip(first_line)
+    if len(clean) > max_chars:
+        clean = clean[: max_chars - 1].rstrip() + "…"
+    if category:
+        return f"{category}: {clean}"
+    return clean
+
+
 def notify_decompose(count: int) -> None:
     notify(f"Декомпозиция: добавлено {count} задач.")
 
 
-def notify_task_done() -> None:
-    notify("Задача готова. Продолжаю работу.")
+def notify_task_done(task_title: str | None = None) -> None:
+    """Announce a single task completion. Speaks the task title when given."""
+    if task_title:
+        notify(f"Готово — {_summarise_task(task_title)}. Продолжаю работу.")
+    else:
+        notify("Задача готова. Продолжаю работу.")
 
 
-def notify_plan_done() -> None:
+def notify_plan_done(last_titles: list[str] | None = None) -> None:
+    """Announce plan completion. Mentions up to two trailing task titles when given."""
+    if last_titles:
+        sample = [_summarise_task(t) for t in last_titles[-2:] if t]
+        if sample:
+            notify(f"План завершён! Последняя задача — {sample[-1]}.")
+            return
     notify("План завершён!")
 
 
-def notify_all_done() -> None:
-    notify("Хозяин, я всё сделалъ!")
+def notify_all_done(completed_count: int | None = None, last_title: str | None = None) -> None:
+    """Announce everything-is-done. Mentions the last completed task when given."""
+    if completed_count is not None and last_title:
+        notify(f"Хозяин, я всё сделалъ! Выполнено {completed_count} задач, последняя — {_summarise_task(last_title)}.")
+    elif last_title:
+        notify(f"Хозяин, я всё сделалъ! Последняя задача — {_summarise_task(last_title)}.")
+    else:
+        notify("Хозяин, я всё сделалъ!")
 
 
 def notify_budget_warning(pct: int) -> None:


### PR DESCRIPTION
Closes #162

## Problem
When whilly finished a task it just said «Задача готова» / «Хозяин, я всё сделалъ!» — you couldn't hear WHICH task was done.

## Fix
`whilly.notifications` now extracts a `[feature] / [bug] / [NFR-5] / …` tag from the task title, maps it to a Russian spoken noun («Фичу» / «Баг» / «Нефункциональное требование» / …), strips the tag, and speaks the first line of the cleaned title.

- `notify_task_done(task_title)` → «Готово — Фичу: \<title\>. Продолжаю работу.»
- `notify_plan_done([last_titles])` → «План завершён! Последняя задача — …»
- `notify_all_done(count, last_title)` → «Хозяин, я всё сделалъ! Выполнено N задач, последняя — …»

Call sites in `cli.py` pass the completed task's title via the new `_task_title_for_notify()` helper.

## Bonus: board automation helper
Ships `scripts/move_project_card.py` — standalone wrapper around the `updateProjectV2ItemFieldValue` GraphQL mutation. Lets you (and, later, whilly itself) move a Projects v2 card to a named Status without hand-rolling GraphQL. Requires `gh auth refresh -s project`.

## Tests
+22 unit tests in `tests/test_notifications_per_task.py` covering category parsing, multiline / empty / long-title edges, and the three `notify_*` helpers. **540 passed** (up from 518). Ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)