### PR TITLE
feat: `whilly --from-issue owner/repo#N` single-issue entry point (closes #164)

### DIFF
--- a/tests/test_from_issue.py
+++ b/tests/test_from_issue.py
@@ -1,0 +1,182 @@
+"""Unit tests for `--from-issue owner/repo#N` (issue #164).
+
+Exercises the parser in :func:`whilly.sources.github_issues.parse_issue_ref`
+and a stubbed end-to-end ``fetch_single_issue`` run that never talks to the
+real ``gh`` CLI.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from whilly.sources import fetch_single_issue, parse_issue_ref
+
+
+# ─── parse_issue_ref ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "ref,expected",
+    [
+        ("alice/myrepo#42", ("alice/myrepo", 42)),
+        ("  alice/myrepo#42  ", ("alice/myrepo", 42)),  # whitespace tolerated
+        ("alice/myrepo/42", ("alice/myrepo", 42)),  # slash variant
+        ("https://github.com/alice/myrepo/issues/42", ("alice/myrepo", 42)),
+        ("https://github.com/alice/myrepo/issues/42/", ("alice/myrepo", 42)),  # trailing slash
+        (
+            "https://github.com/alice/myrepo/issues/42?source=email",
+            ("alice/myrepo", 42),
+        ),
+        (
+            "https://github.com/alice/myrepo/issues/42#issuecomment-9",
+            ("alice/myrepo", 42),
+        ),
+        ("org-name/repo.with.dots#7", ("org-name/repo.with.dots", 7)),
+    ],
+)
+def test_parse_issue_ref_accepts_canonical_forms(ref, expected):
+    assert parse_issue_ref(ref) == expected
+
+
+@pytest.mark.parametrize(
+    "ref",
+    [
+        "",
+        None,
+        "just-a-word",
+        "alice/myrepo",  # missing number
+        "alice#42",  # missing repo
+        "alice/myrepo#abc",  # non-numeric
+        "https://github.com/alice/myrepo/pull/42",  # PR, not issue
+        "https://gitlab.com/alice/myrepo/issues/42",  # non-github host
+        "/leading-slash/repo#1",
+    ],
+)
+def test_parse_issue_ref_rejects_bad_input(ref):
+    with pytest.raises(ValueError):
+        parse_issue_ref(ref)
+
+
+# ─── fetch_single_issue (stubbed gh) ──────────────────────────────────────────
+
+
+_FAKE_ISSUE = {
+    "number": 42,
+    "title": "[feature] the single-issue demo",
+    "body": "## Problem\nreal body here.\n\n## Acceptance\n- thing works\n- other thing",
+    "labels": [{"name": "whilly:ready"}],
+    "url": "https://github.com/alice/myrepo/issues/42",
+    "createdAt": "2024-01-01T00:00:00Z",
+    "updatedAt": "2024-01-02T00:00:00Z",
+    "state": "OPEN",
+}
+
+
+def test_fetch_single_issue_writes_plan_file(tmp_path, monkeypatch):
+    from whilly.sources import github_issues as gi
+
+    class _Proc:
+        returncode = 0
+        stdout = json.dumps(_FAKE_ISSUE)
+        stderr = ""
+
+    monkeypatch.setattr(gi, "_run_gh", lambda args, timeout=30: _Proc())
+
+    out_path = tmp_path / "tasks-issue.json"
+    plan_path, stats = fetch_single_issue("alice/myrepo#42", out_path=out_path)
+
+    assert plan_path == out_path.resolve()
+    assert out_path.is_file()
+    assert stats.new == 1
+    assert stats.updated == 0
+
+    data = json.loads(out_path.read_text(encoding="utf-8"))
+    assert len(data["tasks"]) == 1
+    task = data["tasks"][0]
+    assert task["id"] == "GH-42"
+    assert task["status"] == "pending"
+    assert "the single-issue demo" in task["description"]
+    assert task["acceptance_criteria"] == ["thing works", "other thing"]
+
+
+def test_fetch_single_issue_idempotent_on_rerun(tmp_path, monkeypatch):
+    from whilly.sources import github_issues as gi
+
+    class _Proc:
+        returncode = 0
+        stdout = json.dumps(_FAKE_ISSUE)
+        stderr = ""
+
+    monkeypatch.setattr(gi, "_run_gh", lambda args, timeout=30: _Proc())
+
+    out_path = tmp_path / "tasks-issue.json"
+    _, first = fetch_single_issue("alice/myrepo#42", out_path=out_path)
+    _, second = fetch_single_issue("alice/myrepo#42", out_path=out_path)
+
+    assert first.new == 1 and first.updated == 0
+    assert second.new == 0 and second.updated == 1
+
+
+def test_fetch_single_issue_propagates_gh_errors(tmp_path, monkeypatch):
+    from whilly.sources import github_issues as gi
+
+    class _Proc:
+        returncode = 1
+        stdout = ""
+        stderr = "gh: issue not found"
+
+    monkeypatch.setattr(gi, "_run_gh", lambda args, timeout=30: _Proc())
+
+    with pytest.raises(RuntimeError, match="gh issue view"):
+        fetch_single_issue("alice/myrepo#999", out_path=tmp_path / "plan.json")
+
+
+def test_fetch_single_issue_accepts_url_reference(tmp_path, monkeypatch):
+    from whilly.sources import github_issues as gi
+
+    class _Proc:
+        returncode = 0
+        stdout = json.dumps(_FAKE_ISSUE)
+        stderr = ""
+
+    captured: list[list[str]] = []
+
+    def fake_run(args, timeout=30):
+        captured.append(args)
+        return _Proc()
+
+    monkeypatch.setattr(gi, "_run_gh", fake_run)
+
+    fetch_single_issue(
+        "https://github.com/alice/myrepo/issues/42",
+        out_path=tmp_path / "plan.json",
+    )
+    # Ensure we called gh with the right owner/repo and number.
+    args = captured[0]
+    assert "issue" in args and "view" in args
+    assert "42" in args
+    assert "alice/myrepo" in args
+
+
+def test_fetch_single_issue_warns_on_closed_issue(tmp_path, monkeypatch, caplog):
+    from whilly.sources import github_issues as gi
+
+    closed = dict(_FAKE_ISSUE, state="CLOSED")
+
+    class _Proc:
+        returncode = 0
+        stdout = json.dumps(closed)
+        stderr = ""
+
+    monkeypatch.setattr(gi, "_run_gh", lambda args, timeout=30: _Proc())
+
+    with caplog.at_level("WARNING", logger="whilly"):
+        plan_path, stats = fetch_single_issue("alice/myrepo#42", out_path=tmp_path / "plan.json")
+
+    assert stats.new == 1
+    assert any("not open" in rec.message for rec in caplog.records)
+    # Plan still written — the merge logic decides whether to skip-on-next-run.
+    assert Path(plan_path).is_file()

--- a/tests/test_project_board.py
+++ b/tests/test_project_board.py
@@ -105,6 +105,7 @@ _FAKE_METADATA = {
                     ]
                 },
                 "items": {
+                    "pageInfo": {"hasNextPage": False, "endCursor": None},
                     "nodes": [
                         {
                             "id": "ITEM_1",
@@ -122,7 +123,7 @@ _FAKE_METADATA = {
                                 "repository": {"nameWithOwner": "alice/other"},
                             },
                         },
-                    ]
+                    ],
                 },
             }
         }

--- a/whilly/cli.py
+++ b/whilly/cli.py
@@ -2026,6 +2026,53 @@ def main(argv: list[str] | None = None) -> int:
         config = WhillyConfig.from_env()
         return run_prd_wizard(slug=slug, model=config.MODEL)
 
+    # --from-issue: generate a single-task plan from one GitHub issue reference
+    if "--from-issue" in args:
+        from whilly.sources import fetch_single_issue, parse_issue_ref
+
+        idx = args.index("--from-issue")
+        ref = args[idx + 1] if idx + 1 < len(args) and not args[idx + 1].startswith("-") else None
+        if not ref:
+            _ansi(f"{RD}Usage: whilly --from-issue owner/repo#N [--go]{R}")
+            return 2
+        try:
+            repo, number = parse_issue_ref(ref)
+        except ValueError as exc:
+            _ansi(f"{RD}{exc}{R}")
+            return 2
+
+        output_file = f"tasks-issue-{repo.replace('/', '-')}-{number}.json"
+        _ansi(f"{CY}{B}Fetching {repo}#{number} → {output_file}{R}")
+        try:
+            plan_path, stats = fetch_single_issue(ref, out_path=output_file)
+        except Exception as exc:
+            _ansi(f"{RD}Failed to fetch {ref}: {exc}{R}")
+            return 1
+        _ansi(f"{GR}Tasks generated: {plan_path}{R}")
+
+        try:
+            generated = json.loads(Path(plan_path).read_text())
+            if not generated.get("tasks"):
+                _ansi(f"{YL}No task generated — issue may not exist or is not accessible.{R}")
+                return 0
+        except Exception:
+            pass
+
+        auto_go = "--go" in args or "--yes" in args
+        if auto_go:
+            _ansi(f"{CY}{B}--go: auto-starting Whilly orchestrator...{R}")
+            args = [str(plan_path)]
+        elif sys.stdin.isatty():
+            choice = input("\nRun task immediately? [Y/n]: ").strip().lower()
+            if choice in ("", "y", "yes"):
+                args = [str(plan_path)]
+            else:
+                _ansi(f"{YL}Run later with: whilly {plan_path}{R}")
+                return 0
+        else:
+            _ansi(f"{YL}Run with: whilly {plan_path}{R}")
+            return 0
+
     # --from-github: generate tasks from GitHub Issues
     if "--from-github" in args:
         from whilly.github_converter import generate_tasks_from_github

--- a/whilly/project_board.py
+++ b/whilly/project_board.py
@@ -168,10 +168,21 @@ class ProjectBoardClient:
         return None, None
 
     def _load_meta(self) -> _ProjectMeta:
+        """Fetch project id, Status field metadata, and item→issue mapping.
+
+        Paginates the ``items`` connection in 100-card chunks (GitHub's hard cap
+        per page) so boards of any size are handled. Results are cached so every
+        subsequent transition is one mutation call.
+        """
         if self._meta is not None:
             return self._meta
-        data = self._gh_api(
-            (
+        project_id: str | None = None
+        status_field: dict[str, Any] | None = None
+        item_map: dict[tuple[str, int], str] = {}
+        cursor: str | None = None
+        while True:
+            after = f', after: "{cursor}"' if cursor else ""
+            query = (
                 "query($owner: String!, $number: Int!) {"
                 f"  {self._owner_type}(login: $owner) {{"
                 "    projectV2(number: $number) {"
@@ -182,7 +193,8 @@ class ProjectBoardClient:
                 "          ... on ProjectV2SingleSelectField { id name options { id name } }"
                 "        }"
                 "      }"
-                "      items(first: 200) {"
+                f"      items(first: 100{after}) {{"
+                "        pageInfo { hasNextPage endCursor }"
                 "        nodes {"
                 "          id"
                 "          content {"
@@ -194,31 +206,35 @@ class ProjectBoardClient:
                 "    }"
                 "  }"
                 "}"
-            ),
-            owner=self._owner,
-            number=self._number,
-        )
-        project = data["data"][self._owner_type]["projectV2"]
-        status_field = next(
-            (
-                n
-                for n in project["fields"]["nodes"]
-                if n.get("name") == "Status" and n.get("__typename") == "ProjectV2SingleSelectField"
-            ),
-            None,
-        )
+            )
+            data = self._gh_api(query, owner=self._owner, number=self._number)
+            project = data["data"][self._owner_type]["projectV2"]
+            project_id = project["id"]
+            # Status field + options only need reading on the first page.
+            if status_field is None:
+                status_field = next(
+                    (
+                        n
+                        for n in project["fields"]["nodes"]
+                        if n.get("name") == "Status" and n.get("__typename") == "ProjectV2SingleSelectField"
+                    ),
+                    None,
+                )
+            for node in project["items"]["nodes"]:
+                content = node.get("content") or {}
+                if content.get("__typename") != "Issue":
+                    continue
+                repo = content["repository"]["nameWithOwner"]
+                item_map[(repo, content["number"])] = node["id"]
+            page = project["items"]["pageInfo"]
+            if not page["hasNextPage"]:
+                break
+            cursor = page["endCursor"]
         if not status_field:
             raise RuntimeError("Project has no 'Status' single-select field")
         option_id_by_name = {opt["name"]: opt["id"] for opt in status_field["options"]}
-        item_map: dict[tuple[str, int], str] = {}
-        for node in project["items"]["nodes"]:
-            content = node.get("content") or {}
-            if content.get("__typename") != "Issue":
-                continue
-            repo = content["repository"]["nameWithOwner"]
-            item_map[(repo, content["number"])] = node["id"]
         self._meta = _ProjectMeta(
-            project_id=project["id"],
+            project_id=project_id,  # type: ignore[arg-type]
             status_field_id=status_field["id"],
             option_id_by_name=option_id_by_name,
             item_id_by_key=item_map,

--- a/whilly/sources/__init__.py
+++ b/whilly/sources/__init__.py
@@ -1,6 +1,17 @@
 """Source adapters: convert external task trackers (GitHub Issues, etc.) into tasks.json."""
 
-from whilly.sources.github_issues import GitHubIssuesSource, fetch_github_issues
+from whilly.sources.github_issues import (
+    GitHubIssuesSource,
+    fetch_github_issues,
+    fetch_single_issue,
+    parse_issue_ref,
+)
 from whilly.sources.github_issues_and_project import fetch_issues_and_project
 
-__all__ = ["GitHubIssuesSource", "fetch_github_issues", "fetch_issues_and_project"]
+__all__ = [
+    "GitHubIssuesSource",
+    "fetch_github_issues",
+    "fetch_issues_and_project",
+    "fetch_single_issue",
+    "parse_issue_ref",
+]

--- a/whilly/sources/github_issues.py
+++ b/whilly/sources/github_issues.py
@@ -369,6 +369,101 @@ def merge_into_plan(
 # ── Top-level convenience function ─────────────────────────────────────────────
 
 
+def parse_issue_ref(ref: str) -> tuple[str, int]:
+    """Parse a single-issue reference into ``("owner/repo", number)``.
+
+    Accepted forms::
+
+        owner/repo#42
+        owner/repo/42                     # forward-slash variant
+        https://github.com/owner/repo/issues/42
+
+    Returns the owner+repo and the issue number. Raises :class:`ValueError`
+    for anything else — callers can surface the message verbatim.
+    """
+    if not ref or not isinstance(ref, str):
+        raise ValueError(f"Issue reference must be a non-empty string, got {ref!r}")
+    s = ref.strip()
+
+    # Allow GitHub issue URLs as shorthand.
+    url_match = re.match(
+        r"^https?://github\.com/([^/]+)/([^/]+)/issues/(\d+)/?(?:\?.*)?(?:#.*)?$",
+        s,
+    )
+    if url_match:
+        return f"{url_match.group(1)}/{url_match.group(2)}", int(url_match.group(3))
+
+    # Canonical owner/repo#N or owner/repo/N.
+    short_match = re.match(r"^([^/\s]+)/([^/#\s]+)[#/](\d+)$", s)
+    if short_match:
+        return f"{short_match.group(1)}/{short_match.group(2)}", int(short_match.group(3))
+
+    raise ValueError(
+        f"Cannot parse issue reference {ref!r}. Expected 'owner/repo#N', 'owner/repo/N', or a GitHub issue URL."
+    )
+
+
+def _gh_issue_view(repo: str, number: int, timeout: int = 30) -> dict | None:
+    """Fetch a single issue JSON via ``gh issue view``. Returns None on failure."""
+    args = [
+        "issue",
+        "view",
+        str(number),
+        "--repo",
+        repo,
+        "--json",
+        "number,title,body,labels,url,createdAt,updatedAt,state",
+    ]
+    proc = _run_gh(args, timeout=timeout)
+    if proc.returncode != 0:
+        msg = (proc.stderr or proc.stdout or "no output").strip()
+        raise RuntimeError(f"gh issue view {repo}#{number} failed (exit {proc.returncode}): {msg}")
+    try:
+        return json.loads(proc.stdout or "null")
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"gh returned non-JSON for issue {repo}#{number}: {exc}") from exc
+
+
+def fetch_single_issue(
+    ref: str,
+    out_path: str | Path = "tasks.json",
+    timeout: int = 30,
+) -> tuple[Path, FetchStats]:
+    """Fetch one GitHub issue by reference and merge it into a one-task plan.
+
+    Uses the same :class:`GitHubIssuesSource` plumbing as :func:`fetch_github_issues`
+    so the idempotent upsert semantics stay identical: re-running keeps status,
+    refreshes description/labels/etc.
+    """
+    repo, number = parse_issue_ref(ref)
+    owner, repo_name = repo.split("/", 1)
+    source = GitHubIssuesSource(owner=owner, repo=repo_name, label=f"#{number}", limit=1)
+
+    issue = _gh_issue_view(repo, number, timeout=timeout)
+    if issue is None:
+        plan_path = Path(out_path).resolve()
+        log.warning("Issue %s#%d not found", repo, number)
+        return plan_path, FetchStats(total_open=0)
+    if (issue.get("state") or "").upper() != "OPEN":
+        log.warning("Issue %s#%d is not open (state=%s)", repo, number, issue.get("state"))
+
+    plan_path = Path(out_path).resolve()
+    stats = merge_into_plan([issue], source, plan_path)
+
+    log.info(
+        "GitHub single-issue source: %s#%d fetched (new=%d, updated=%d)",
+        repo,
+        number,
+        stats.new,
+        stats.updated,
+    )
+    if stats.secret_warnings:
+        for warning in stats.secret_warnings:
+            log.warning("Secret-like pattern detected in issue body: %s", warning)
+
+    return plan_path, stats
+
+
 def fetch_github_issues(
     repo: str,
     label: str = DEFAULT_LABEL,


### PR DESCRIPTION
Closes #164

## --from-issue
New CLI flag that takes one issue reference and wires it through the existing `GitHubIssuesSource → merge_into_plan` pipeline:

```bash
whilly --from-issue alice/myrepo#42 --go
whilly --from-issue https://github.com/alice/myrepo/issues/42
whilly --from-issue alice/myrepo/42        # slash variant
```

Output plan lands at `tasks-issue-<owner>-<repo>-<N>.json` (idempotent on rerun — same upsert rules as `--from-github`). `--go` / `--yes` skip the confirm prompt.

## Plumbing
- `whilly.sources.github_issues.parse_issue_ref(ref)` — URL / `owner/repo#N` / `owner/repo/N` parser.
- `whilly.sources.github_issues.fetch_single_issue(ref, out_path, timeout)` — fetches via a new `_gh_issue_view` helper and writes a one-task plan through the existing `merge_into_plan`. Warns (does not fail) on closed issues.

## Drive-by fix: paginated project metadata
`ProjectBoardClient._load_meta` was asking for `items(first: 200)` — GitHub caps at 100. Now paginates in 100-chunks so boards with 100+ cards don't trip the hook. **This was blocking every status-change transition on the board right after we bulk-populated it** — without it live sync would silently fail.

## Tests (+22)
`tests/test_from_issue.py` — parser accepts canonical / URL / slash / whitespace / query-string / fragment forms; rejects bad input. Stubbed `_run_gh` exercises the fetch end-to-end: plan write, idempotency on rerun, gh error propagation, closed-issue warning.

`tests/test_project_board.py` — updated fake GraphQL fixture to include `pageInfo` so the paginated code path is covered.

**585 passed** (up from 563). Ruff clean on all 3 OSes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)