### PR TITLE
fix: avoid f-string double-quote clash in CI heredoc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,12 +170,12 @@ jobs:
           from whilly.agents import AgentBackend, available_backends, get_backend
           from whilly.agents.base import AgentResult, AgentUsage
           names = available_backends()
-          # `claude_handoff` is an optional, operator-driven backend. The other
+          # 'claude_handoff' is an optional, operator-driven backend. The other
           # two are the production subprocess backends covered by the rest of
           # this job's assertions.
           required = {'claude', 'opencode'}
           missing = required - set(names)
-          assert not missing, f"Missing production backends: {missing} (have {names})"
+          assert not missing, 'Missing production backends: ' + str(missing) + ' (have ' + str(names) + ')'
           for n in names:
               b = get_backend(n)
               assert b.name == n


### PR DESCRIPTION
Hot-fix for #188. The inner `f""` inside `python -c "..."` was confusing bash's parser. Simple string concat keeps the assertion message without nested double quotes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)