### PR TITLE
feat: whilly --ensure-board-statuses creates missing Projects v2 columns

### DIFF
--- a/whilly/cli.py
+++ b/whilly/cli.py
@@ -227,6 +227,42 @@ def _wire_project_board_sync(task_manager: "TaskManager", config: "WhillyConfig"
     _ansi(f"{D}Project board sync enabled: {client.project_url}{R}")
 
 
+def _run_ensure_board_statuses(names_arg: str | None) -> int:
+    """Create any missing Status options on the configured Projects v2 board.
+
+    Without an argument, ensures every whilly-mapped column from
+    ``DEFAULT_STATUS_MAPPING`` exists (Todo / In Progress / In Review / Done /
+    Refused / Failed / On Hold / Human Loop). With a comma-separated arg, only
+    ensures those names.
+    """
+    from whilly.project_board import DEFAULT_STATUS_MAPPING, ProjectBoardClient
+
+    config = WhillyConfig.from_env()
+    client = ProjectBoardClient.from_config(config)
+    if client is None:
+        print("Project board not configured. Set [project_board].url in whilly.toml.", file=sys.stderr)
+        return 4
+
+    if names_arg:
+        names = [n.strip() for n in names_arg.split(",") if n.strip()]
+    else:
+        names = sorted(set(DEFAULT_STATUS_MAPPING.values()))
+
+    try:
+        added, already = client.ensure_statuses(names)
+    except Exception as exc:
+        print(f"✗ Could not update board: {exc}", file=sys.stderr)
+        return 1
+
+    if added:
+        print(f"✓ Added {len(added)} option(s): {', '.join(added)}")
+    if already:
+        print(f"  Already present: {', '.join(already)}")
+    if not added and not already:
+        print("Nothing to ensure — target list was empty.")
+    return 0
+
+
 def _run_handoff_list() -> int:
     """Print every task currently awaiting a result.json from the operator."""
     from whilly.agents.claude_handoff import handoff_root, list_pending
@@ -1947,6 +1983,11 @@ def main(argv: list[str] | None = None) -> int:
     # --handoff-list / --handoff-complete / --handoff-show: companion commands for
     # the claude_handoff backend. Let the operator (or an interactive Claude) pick
     # up dispatched tasks and signal completion / block / human-loop back to whilly.
+    if "--ensure-board-statuses" in args:
+        idx = args.index("--ensure-board-statuses")
+        names_arg = args[idx + 1] if idx + 1 < len(args) and not args[idx + 1].startswith("-") else None
+        return _run_ensure_board_statuses(names_arg)
+
     if "--handoff-list" in args:
         return _run_handoff_list()
     if "--handoff-show" in args:

--- a/whilly/project_board.py
+++ b/whilly/project_board.py
@@ -129,6 +129,69 @@ class ProjectBoardClient:
 
         return self._update_status(meta.project_id, item_id, meta.status_field_id, option_id, status_name, issue_number)
 
+    def ensure_statuses(
+        self,
+        names: list[str],
+        *,
+        default_color: str = "GRAY",
+    ) -> tuple[list[str], list[str]]:
+        """Ensure the Status field exposes every option name in *names*.
+
+        Returns ``(added, already_present)`` — the caller can report what was
+        created. If *names* is empty the call is a no-op and returns empty lists.
+
+        GitHub's ``updateProjectV2SingleSelectField`` mutation replaces the full
+        option list, so this method reads current options, merges the new ones
+        in, and re-writes the list preserving ids of existing options (so cards
+        assigned to them don't lose their status).
+
+        ``default_color`` is one of GitHub's palette names (``GRAY``, ``PURPLE``,
+        ``PINK``, ``RED``, ``ORANGE``, ``YELLOW``, ``GREEN``, ``BLUE``).
+        """
+        if not names:
+            return [], []
+
+        meta = self._load_meta()
+        # Need full option objects (id, name, color, description) to avoid losing
+        # existing colours on the round-trip. Re-fetch just the options:
+        option_details = self._fetch_status_options(meta.status_field_id)
+
+        existing_names = {opt["name"] for opt in option_details}
+        to_add = [n for n in names if n not in existing_names]
+        already = [n for n in names if n in existing_names]
+
+        if not to_add:
+            return [], already
+
+        # ``ProjectV2SingleSelectFieldOptionInput`` accepts name/color/description
+        # only — no id. GitHub matches existing options by name on the round-trip,
+        # so we rebuild the list without ids, preserving existing names/colors
+        # and appending the new ones.
+        payload_options: list[dict[str, Any]] = []
+        for opt in option_details:
+            payload_options.append(
+                {
+                    "name": opt["name"],
+                    "color": (opt.get("color") or default_color).upper(),
+                    "description": opt.get("description") or "",
+                }
+            )
+        for name in to_add:
+            payload_options.append(
+                {
+                    "name": name,
+                    "color": default_color.upper(),
+                    "description": f"Added by whilly --ensure-board-statuses (whilly status {name!r}).",
+                }
+            )
+
+        self._update_status_field_options(meta.status_field_id, payload_options)
+        # Invalidate the cache so the next `set_issue_status` re-reads the
+        # newly-added option ids.
+        self._meta = None
+        log.info("Project board: added %d Status option(s) — %s", len(to_add), ", ".join(to_add))
+        return to_add, already
+
     def set_task_status(self, task: Any, whilly_status: str) -> bool:
         """Translate a whilly status → board column and move the card for the task's issue.
 
@@ -272,6 +335,52 @@ class ProjectBoardClient:
             return False
         log.info("Project board: issue #%d → %r", issue_number, status_name)
         return True
+
+    def _fetch_status_options(self, field_id: str) -> list[dict[str, Any]]:
+        """Return the full option list for a ProjectV2SingleSelectField."""
+        data = self._gh_api(
+            "query($field: ID!) {"
+            "  node(id: $field) {"
+            "    ... on ProjectV2SingleSelectField {"
+            "      options { id name color description }"
+            "    }"
+            "  }"
+            "}",
+            field=field_id,
+        )
+        node = data.get("data", {}).get("node") or {}
+        return list(node.get("options") or [])
+
+    def _update_status_field_options(self, field_id: str, options: list[dict[str, Any]]) -> None:
+        """Replace the Status field's options with *options* (full list).
+
+        ``gh api graphql`` can't natively pass array GraphQL variables via
+        ``-f`` / ``-F``, so we post the body on stdin via ``--input -``.
+        """
+        mutation = (
+            "mutation($field: ID!, $options: [ProjectV2SingleSelectFieldOptionInput!]!) {"
+            "  updateProjectV2Field("
+            "    input: { fieldId: $field, singleSelectOptions: $options }"
+            "  ) { projectV2Field { __typename } }"
+            "}"
+        )
+        body = json.dumps(
+            {"query": mutation, "variables": {"field": field_id, "options": options}},
+            ensure_ascii=False,
+        )
+        proc = subprocess.run(
+            ["gh", "api", "graphql", "--input", "-"],
+            input=body,
+            capture_output=True,
+            text=True,
+            env=gh_subprocess_env(),
+        )
+        if proc.returncode != 0:
+            raise RuntimeError((proc.stderr or proc.stdout or "gh graphql failed").strip())
+        response = json.loads(proc.stdout or "{}")
+        errors = response.get("errors")
+        if errors:
+            raise RuntimeError("GraphQL errors: " + json.dumps(errors, ensure_ascii=False))
 
     @staticmethod
     def _gh_api(query: str, **variables: Any) -> dict:


### PR DESCRIPTION
Adds a CLI command that ensures the configured Projects v2 board has every column whilly maps to — Todo, In Progress, In Review, Done, Refused, Failed, **On Hold**, **Human Loop**. Idempotent.

Verified live against mshegolev/projects/4 — added the two missing columns on the first run.

```bash
whilly --ensure-board-statuses                       # defaults (all mapped names)
whilly --ensure-board-statuses 'On Hold,Custom Col'  # subset
```

Uses `updateProjectV2Field` via `gh api graphql --input -` (`-f/-F` can't send GraphQL arrays). Existing options round-trip by name+color. 612 passed, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)