### PR TITLE
feat: post-merge Jira transition + docs catch-up for all new flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,59 @@ See [docs/Whilly-Usage.md](docs/Whilly-Usage.md) for the full config guide (TOML
 | `WHILLY_OPENCODE_SAFE` | `0` | `1` → drop `--dangerously-skip-permissions` for OpenCode |
 | `WHILLY_OPENCODE_SERVER_URL` | _(unset)_ | Optional remote OpenCode server URL |
 
-Key CLI flags: `--all`, `--headless`, `--timeout N`, `--resume`, `--reset PLAN.json`, `--init "desc" [--plan] [--go]`, `--plan PRD.md`, `--prd-wizard`, `--no-worktree`, `--agent {claude,opencode}`.
+Key CLI flags: `--all`, `--headless`, `--timeout N`, `--resume`, `--reset PLAN.json`, `--init "desc" [--plan] [--go]`, `--plan PRD.md`, `--prd-wizard`, `--no-worktree`, `--agent {claude,opencode,claude_handoff}`.
+
+### Task sources (pull issues into plans)
+
+```bash
+whilly --from-github whilly:ready --go          # all open issues with label
+whilly --from-github all --go                   # every open issue, no label filter
+whilly --from-issue owner/repo/42 --go          # one GitHub issue (slash form — shell-safe)
+whilly --from-issue 'owner/repo#42' --go        # same, with '#' (quote in zsh/bash)
+whilly --from-jira ABC-123 --go                 # one Jira ticket
+whilly --from-project <project-v2-url> --go     # GitHub Projects v2 board
+whilly --from-issues-project <url> --repo owner/name   # board-filtered issues
+```
+
+### Lifecycle sync (live board updates as whilly works)
+
+Enable in `whilly.toml`:
+```toml
+[project_board]                                  # GitHub Projects v2
+url = "https://github.com/users/you/projects/4"
+default_repo = "you/your-repo"
+
+[jira]                                           # Jira transitions (complements auto-close)
+server_url = "https://company.atlassian.net"
+username   = "you@example.com"
+token      = "keyring:whilly/jira"
+enable_board_sync = true
+```
+
+Task status → column mapping is identical for both: `pending → Todo/To Do`, `in_progress → In Progress`, `done → In Review`, `merged → Done`, `failed → Failed`, `skipped → Refused/Cancelled`, `blocked → On Hold/Blocked`, `human_loop → Human Loop/Waiting for Customer`. Override per-section via `[project_board.status_mapping]` / `[jira.status_mapping]`.
+
+One-off helpers:
+```bash
+whilly --ensure-board-statuses             # create any missing Status columns
+whilly --post-merge <plan.json>            # after an external merge, flush cards to Done
+python3 scripts/populate_board.py …        # bulk-add issues onto a Projects v2 board
+```
+
+### Human-in-the-loop backend (`claude_handoff`)
+
+```bash
+WHILLY_AGENT_BACKEND=claude_handoff whilly --from-issue alice/repo/42 --go
+```
+
+Each task's prompt lands in `.whilly/handoff/<task_id>/prompt.md`; whilly blocks until you write `result.json`. Three companion commands:
+
+```bash
+whilly --handoff-list                                  # see pending handoffs
+whilly --handoff-show GH-42                            # read the prompt
+whilly --handoff-complete GH-42 --status complete --message "done"
+```
+
+Accepted statuses: `complete` / `failed` / `blocked` / `human_loop` / `partial`. `blocked` and `human_loop` map to extra whilly statuses + board columns so tickets needing a decision land in a dedicated column instead of being misreported as failed.
 
 Exit codes in headless mode: `0` success, `1` some tasks failed, `2` budget exceeded, `3` timeout.
 

--- a/docs/Whilly-Usage.md
+++ b/docs/Whilly-Usage.md
@@ -26,7 +26,94 @@ whilly --all
 
 # Pull open GitHub issues as tasks and start immediately
 whilly --from-github whilly:ready --go
+
+# One specific issue or Jira ticket
+whilly --from-issue owner/repo/42 --go           # slash form — shell-safe
+whilly --from-issue 'owner/repo#42' --go         # '#' form, quote in zsh/bash
+whilly --from-jira ABC-123 --go                  # single Jira ticket
 ```
+
+## Task sources
+
+| Flag | Source | Notes |
+|------|--------|-------|
+| `--from-github <label>` | GitHub issues by label | `all`/`*`/`-` = no filter |
+| `--from-issue <ref>` | one GitHub issue | `owner/repo/N`, `owner/repo#N`, or URL |
+| `--from-jira <key>` | one Jira ticket | `ABC-123` or browse URL; auth via `[jira]` |
+| `--from-project <url>` | GitHub Projects v2 board | full board items |
+| `--from-issues-project <url> --repo o/r` | Projects board filtered by issue repo | |
+
+Every source writes to an idempotent plan file (`tasks-…json`); re-running refreshes description/priority/labels without losing status.
+
+## Lifecycle sync
+
+Two integrations drive cards/tickets automatically as whilly task statuses change. Enable one or both in `whilly.toml`.
+
+### GitHub Projects v2
+```toml
+[project_board]
+url = "https://github.com/users/you/projects/4"
+enabled = true
+default_repo = "you/your-repo"
+
+[project_board.status_mapping]    # optional
+in_progress = "Doing"
+```
+Requires `gh auth refresh -s project` once.
+
+### Jira
+```toml
+[jira]
+server_url = "https://company.atlassian.net"
+username   = "you@example.com"
+token      = "keyring:whilly/jira"
+enabled    = true
+enable_board_sync = true
+
+[jira.status_mapping]             # optional
+in_progress = "Doing"
+done        = "Review"
+```
+Drives Jira transitions via REST v3. Uses `urllib` stdlib — no extra deps.
+
+### Status mapping (defaults)
+
+| whilly | GitHub column | Jira transition |
+|---|---|---|
+| `pending` | Todo | To Do |
+| `in_progress` | In Progress | In Progress |
+| `done` (PR open) | In Review | In Review |
+| `merged` | Done | Done |
+| `failed` | Failed | Failed |
+| `skipped` | Refused | Cancelled |
+| `blocked` | On Hold | Blocked |
+| `human_loop` | Human Loop | Waiting for Customer |
+
+## Companion commands
+
+```bash
+whilly --config show                           # merged config, secrets redacted
+whilly --config path                           # OS-native user config location
+whilly --config migrate                        # legacy .env → whilly.toml + keyring
+whilly --ensure-board-statuses                 # create missing Projects v2 columns
+whilly --post-merge <plan.json>                # after an out-of-band merge: flush cards/tickets to Done
+```
+
+## Human-in-the-loop backend
+
+`claude_handoff` pauses each task and waits for an external operator (or an interactive Claude session) to do the work:
+
+```bash
+WHILLY_AGENT_BACKEND=claude_handoff whilly --from-issue alice/repo/42 --go
+# whilly writes .whilly/handoff/GH-42/prompt.md and blocks
+
+whilly --handoff-list
+whilly --handoff-show GH-42
+whilly --handoff-complete GH-42 --status complete --message "done"
+#                              ^^^^^^^^ complete / failed / blocked / human_loop / partial
+```
+
+`blocked` and `human_loop` signal "task can't finish without help" — they land in the corresponding board column without being misreported as failed.
 
 ## Configuration
 

--- a/whilly/cli.py
+++ b/whilly/cli.py
@@ -399,12 +399,15 @@ def _run_post_merge(plan_path: str) -> int:
         return 3
     tm = TaskManager(plan_p)
     _wire_project_board_sync(tm, config)
-    if getattr(tm, "project_board", None) is None:
-        print("Project board not configured — nothing to do.", file=sys.stderr)
-        print("Set [project_board] in whilly.toml to enable.", file=sys.stderr)
+    has_board = getattr(tm, "project_board", None) is not None
+    has_jira = getattr(tm, "jira_board", None) is not None
+    if not (has_board or has_jira):
+        print("Neither GitHub Projects board nor Jira configured — nothing to do.", file=sys.stderr)
+        print("Set [project_board] and/or [jira] in whilly.toml to enable.", file=sys.stderr)
         return 4
     moved = _finalise_project_board(tm)
-    print(f"Moved {moved} card(s) to Done.")
+    jira_moved = _finalise_jira_board(tm)
+    print(f"Moved {moved} card(s) to Done, {jira_moved} Jira ticket(s) transitioned.")
     return 0
 
 
@@ -430,6 +433,35 @@ def _finalise_project_board(task_manager: "TaskManager") -> int:
     if moved:
         _ansi(f"{D}Project board: {moved} card(s) moved to Done{R}")
     return moved
+
+
+def _finalise_jira_board(task_manager: "TaskManager") -> int:
+    """Symmetric Jira equivalent: transition every ``done`` JIRA task to the ``merged`` mapping.
+
+    Reads the stashed ``JiraBoardClient`` that ``_wire_project_board_sync``
+    attached. Exceptions are swallowed — advisory, never kills the loop.
+    """
+    client = getattr(task_manager, "jira_board", None)
+    if client is None:
+        return 0
+    moved = 0
+    for task in task_manager.tasks:
+        if getattr(task, "status", None) != "done":
+            continue
+        try:
+            if client.set_task_status(task, "merged"):
+                moved += 1
+        except Exception:
+            log.exception("post-merge Jira transition failed for task %s", task.id)
+    if moved:
+        _ansi(f"{D}Jira: {moved} ticket(s) transitioned to Done{R}")
+    return moved
+
+
+def _finalise_external_trackers(task_manager: "TaskManager") -> None:
+    """Run both post-merge hooks (GitHub Projects + Jira)."""
+    _finalise_project_board(task_manager)
+    _finalise_jira_board(task_manager)
 
 
 def _task_title_for_notify(task: object | None) -> str | None:
@@ -1826,7 +1858,7 @@ def _run_automated_merge(workspace, tm) -> None:
         _ansi(f"{RD}Push failed: {push.stderr.strip()}{R}")
         return
     _ansi(f"{GR}✓ Branch pushed{R}")
-    _finalise_project_board(tm)
+    _finalise_external_trackers(tm)
     _ansi(f"\n{CY}📝 Создать MR → merge нужно вручную через gitlab UI или gh CLI{R}")
     _ansi(f"{D}Autoбранч: {workspace.branch} → master{R}")
     _ansi(f"{D}Подсказка: запустите выбранный скрипт/CI для ожидания pipeline и merge{R}")
@@ -1870,7 +1902,7 @@ def _run_claude_merge(workspace, tm) -> None:
         # Best-effort: if the user confirmed the merge in Claude's TUI, sync the
         # board. When merge didn't actually happen, the mutation just re-affirms
         # the card's current column — no damage done.
-        _finalise_project_board(tm)
+        _finalise_external_trackers(tm)
 
 
 # ── Argument parsing & main ───────────────────────────────────


### PR DESCRIPTION
## Post-merge Jira symmetry
New `_finalise_jira_board` mirrors `_finalise_project_board` — both fire from `_run_automated_merge` / `_run_claude_merge` / `whilly --post-merge` via a thin `_finalise_external_trackers` wrapper. `--post-merge` now accepts plans with **either** Projects v2 OR Jira configured (previously required a project board).

## Docs
README + docs/Whilly-Usage.md were stale. Added every new CLI flag, the `[project_board]` and `[jira]` config sections, the side-by-side status mapping table, and the claude_handoff workflow.

643 passing. Ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)