### PR TITLE
docs: GitHub Pages site via Jekyll (just-the-docs theme)

### DIFF
--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -1,3 +1,8 @@
+---
+title: Getting Started
+nav_order: 2
+---
+
 # Whilly — Getting Started
 
 Step-by-step walkthroughs for the most common flows. If you want the full flag/config reference, see [`Whilly-Usage.md`](./Whilly-Usage.md).

--- a/docs/GitHub-Integration-Guide.md
+++ b/docs/GitHub-Integration-Guide.md
@@ -1,3 +1,8 @@
+---
+title: GitHub Integration
+nav_order: 4
+---
+
 # GitHub Integration Guide
 
 Whilly предоставляет несколько способов интеграции с GitHub для автоматизации работы с Issues и Projects.

--- a/docs/Whilly-Interfaces-and-Tasks.md
+++ b/docs/Whilly-Interfaces-and-Tasks.md
@@ -1,3 +1,8 @@
+---
+title: Interfaces & Tasks
+nav_order: 5
+---
+
 # Whilly v2: Интерфейсы, стек, задачи
 
 ## 1. Технический стек

--- a/docs/Whilly-Usage.md
+++ b/docs/Whilly-Usage.md
@@ -1,3 +1,8 @@
+---
+title: Full Usage Reference
+nav_order: 3
+---
+
 # Whilly — Task Orchestrator
 
 Python-based task orchestrator that runs Claude CLI agents to execute tasks from a JSON plan file.

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,49 @@
+title: Whilly Orchestrator
+description: Python task orchestrator that runs Claude CLI agents on a JSON plan — loopable, resumable, budget-capped.
+remote_theme: just-the-docs/just-the-docs
+url: https://mshegolev.github.io
+baseurl: /whilly-orchestrator
+
+plugins:
+  - jekyll-remote-theme
+  - jekyll-seo-tag
+  - jekyll-sitemap
+
+# ── Just-the-Docs theme settings ────────────────────────────────────────────
+color_scheme: dark
+search_enabled: true
+heading_anchors: true
+back_to_top: true
+back_to_top_text: "↑ top"
+
+aux_links:
+  "GitHub repo":
+    - "https://github.com/mshegolev/whilly-orchestrator"
+  "Latest release":
+    - "https://github.com/mshegolev/whilly-orchestrator/releases/latest"
+
+footer_content: >-
+  Source on
+  <a href="https://github.com/mshegolev/whilly-orchestrator">GitHub</a>
+  · MIT licensed · Built with
+  <a href="https://pmarsceill.github.io/just-the-docs/">Just the Docs</a>
+
+callouts:
+  note:
+    title: Note
+    color: blue
+  warning:
+    title: Warning
+    color: yellow
+
+# Things outside the docs tree should not be rendered.
+exclude:
+  - "*.json"
+  - "*.log"
+  - workshop/
+  - tests/
+
+# Kramdown / syntax highlighter — default is fine; explicit for clarity.
+markdown: kramdown
+kramdown:
+  syntax_highlighter: rouge

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,64 @@
+---
+title: Home
+layout: default
+nav_order: 1
+description: "Whilly Orchestrator — task orchestrator that runs Claude CLI agents on a JSON plan."
+permalink: /
+---
+
+# Whilly Orchestrator
+{: .fs-9 }
+
+Task orchestrator that runs coding-agent CLIs on a JSON plan — loopable, resumable, budget-capped, and happy to hand tasks back to a human when it hits a wall.
+{: .fs-5 .fw-300 }
+
+[Getting Started]({{ site.baseurl }}/Getting-Started){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
+[View on GitHub](https://github.com/mshegolev/whilly-orchestrator){: .btn .fs-5 .mb-4 .mb-md-0 }
+
+---
+
+## What whilly does
+
+- **Pulls tasks** from a GitHub repo (`--from-github`, `--from-issue`), a Projects v2 board (`--from-project`), or a Jira project (`--from-jira`).
+- **Runs agents** — Claude CLI by default, OpenCode, or `claude_handoff` (file-based RPC to you).
+- **Tracks lifecycle** on your Projects v2 board *and* your Jira ticket in real time: `Todo → In Progress → In Review → Done`, plus `On Hold` and `Human Loop` for anything that needs a human.
+- **Stays safe** — hard budget cap, wall-clock timeout, automatic task resume, idempotent plan files.
+- **Works everywhere** — pure Python 3.10+, stdlib-only for Jira, tested on Linux / macOS / Windows.
+
+## One-liner demo
+
+```bash
+pipx install whilly-orchestrator
+whilly --config path            # where to drop your config
+whilly --from-issue you/repo/42 --go
+```
+
+That fetches issue 42, generates a one-task plan, spawns an agent, and exits `0` when the agent reports complete.
+
+## Read next
+
+| Page | When to read |
+|---|---|
+| **[Getting Started]({{ site.baseurl }}/Getting-Started)** | First time here — eight practical walkthroughs |
+| **[Full Usage Reference]({{ site.baseurl }}/Whilly-Usage)** | Every CLI flag, env var, and config field |
+| **[GitHub Integration Guide]({{ site.baseurl }}/GitHub-Integration-Guide)** | Setting up Projects v2 + board sync |
+| **[Interfaces & Tasks]({{ site.baseurl }}/Whilly-Interfaces-and-Tasks)** | Module contracts + the JSON plan schema |
+| **[Architecture Decisions]({{ site.baseurl }}/workshop/adr/)** | Why things are the way they are (if published) |
+
+## Under the hood
+
+```
+CLI  ──▶  TaskManager  ──▶  AgentBackend  ──▶  Claude / OpenCode / claude_handoff
+                ↓
+   on_status_change hook  ──▶  Projects v2 (GraphQL)  +  Jira (REST)
+                ↓
+         Dashboard, Reporter, Budget + Resource guards
+```
+
+Full module map lives in [`Whilly-Interfaces-and-Tasks`]({{ site.baseurl }}/Whilly-Interfaces-and-Tasks).
+
+## Current status
+
+- **643 tests**, cross-OS CI (Linux / macOS / Windows) on every PR.
+- Layered config — `whilly.toml` + OS keyring, migrates from legacy `.env` with one command.
+- [Latest release](https://github.com/mshegolev/whilly-orchestrator/releases/latest) · [Open issues](https://github.com/mshegolev/whilly-orchestrator/issues) · [Changelog](https://github.com/mshegolev/whilly-orchestrator/commits/main)


### PR DESCRIPTION
Adds `docs/_config.yml` + `docs/index.md` + nav front-matter on four primary pages. Uses the `just-the-docs` remote theme — no Gemfile, no Action, no build step.

**One-time publish step (you need to click):**

1. Go to repo **Settings → Pages**
2. Source: **Deploy from a branch**
3. Branch: `main` · Folder: `/docs`
4. Save. First build ≈30 s.

Site will be at: https://mshegolev.github.io/whilly-orchestrator/

🤖 Generated with [Claude Code](https://claude.com/claude-code)