### PR TITLE
docs: Documents section + Task Execution Phases page (+ whilly-auto.sh base-branch sync)

### DIFF
--- a/docs/documents.md
+++ b/docs/documents.md
@@ -1,0 +1,22 @@
+---
+title: Documents
+layout: default
+nav_order: 5
+has_children: true
+permalink: /documents/
+description: "Deep-dive technical documentation for Whilly Orchestrator — internals, phase flows, and design decisions."
+---
+
+# Documents
+
+Deep-dive technical documentation that goes beyond the reference pages. Where the usage reference tells you *what* flags to pass, this section explains *why* things work the way they do and *what* happens inside Whilly at each step.
+
+These pages are written for contributors, integrators, and operators who need to understand the internals — not just the surface API.
+
+---
+
+## Pages in this section
+
+| Page | What it covers |
+|---|---|
+| [Task Execution Phases]({{ site.baseurl }}/documents/task-execution-phases) | The 8 internal phases Whilly walks through from `--from-issue` to exit code `0` — workspace isolation, agent dispatch, retry logic, and live board sync |

--- a/docs/documents/task-execution-phases.md
+++ b/docs/documents/task-execution-phases.md
@@ -1,0 +1,262 @@
+---
+title: Task Execution Phases
+layout: default
+parent: Documents
+nav_order: 1
+description: "Eight phases Whilly walks through when it picks up a GitHub issue and merges the result."
+---
+
+# Task Execution Phases
+{: .fs-9 }
+
+What happens inside Whilly from the moment it fetches a GitHub issue to the moment it exits `0`.
+{: .fs-5 .fw-300 }
+
+---
+
+**TL;DR** — Whilly orchestrates. The Claude CLI agent writes the code. Whilly handles workspace isolation, retry logic, budget enforcement, and board sync; the agent handles everything inside the editor.
+{: .fs-3 }
+
+---
+
+## Overview
+
+Running `whilly --from-issue REPO#N --go --headless` triggers a linear sequence of 8 internal phases. The sequence is deterministic: each phase either succeeds and advances, or fails with a logged reason and a non-zero exit code. No phase is optional; no phase is re-ordered.
+
+The diagram below shows the happy path. The branch at phase 6 is not a fork — both the plan file update and the Projects v2 board sync happen in that single phase before control continues to phase 7.
+
+```
+ ┌─────────────────────────────────────────────────────────┐
+ │  whilly --from-issue REPO#N --go --headless             │
+ └──────────────────────┬──────────────────────────────────┘
+                        │
+                        ▼
+ ┌──────────────────────────────────────────┐
+ │  Phase 1 — Fetch issue                   │
+ │  gh api /repos/.../issues/N              │
+ └──────────────────────┬───────────────────┘
+                        │
+                        ▼
+ ┌──────────────────────────────────────────┐
+ │  Phase 2 — Generate plan                 │
+ │  tasks-issue-{repo}-{N}.json             │
+ └──────────────────────┬───────────────────┘
+                        │
+                        ▼
+ ┌──────────────────────────────────────────┐
+ │  Phase 3 — Workspace                     │
+ │  git worktree add .whilly_workspaces/    │
+ └──────────────────────┬───────────────────┘
+                        │
+                        ▼
+ ┌──────────────────────────────────────────┐
+ │  Phase 4 — Agent runs          [code]    │
+ │  claude CLI in tmux session              │
+ │  status: Todo → In Progress              │
+ └──────────────────────┬───────────────────┘
+                        │
+                        ▼
+ ┌──────────────────────────────────────────┐
+ │  Phase 5 — Parse result                  │
+ │  AgentResult: exit_code, cost, complete  │
+ └──────────────────────┬───────────────────┘
+                        │
+                        ▼
+ ┌──────────────────────────────────────────┐
+ │  Phase 6 — Mark done + live sync         │
+ │  status: In Progress → In Review         │
+ │  ├── plan JSON updated                   │
+ │  └── Projects v2 card moved              │
+ └──────────────────────┬───────────────────┘
+                        │
+                        ▼
+ ┌──────────────────────────────────────────┐
+ │  Phase 7 — Commit                        │
+ │  agent: git add + git commit             │
+ └──────────────────────┬───────────────────┘
+                        │
+                        ▼
+ ┌──────────────────────────────────────────┐
+ │  Phase 8 — Exit 0                        │
+ │  run_plan returns → caller continues     │
+ └──────────────────────────────────────────┘
+```
+
+---
+
+## Phase table
+
+| # | Phase | Code location | What happens |
+|---|---|---|---|
+| 1 | Fetch issue | `whilly/sources/fetch_single_issue` | `gh api /repos/.../issues/N` pulls title, body, and labels |
+| 2 | Generate plan | `whilly/cli.py` ~L2300 | Writes `tasks-issue-{repo}-{N}.json`; extracts acceptance criteria from body checklists |
+| 3 | Workspace | `worktree_runner.create_plan_workspace` | `git worktree add .whilly_workspaces/{slug}/ -b whilly/workspace/{slug}` |
+| 4 | Agent runs | `cli.py::run_plan` + `agent_runner` + `tmux_runner` | Spawns `claude` CLI in tmux session `whilly-{task_id}`; waits for completion signal |
+| 5 | Parse result | `agent_runner.collect_result` | Reads Claude CLI JSON → `AgentResult(exit_code, usage.cost_usd, is_complete)` |
+| 6 | Mark done + live sync | `task_manager.TaskManager.mark_status` + `project_board` | `status: done` in JSON; Projects v2 card moves to "In Review" |
+| 7 | Commit | agent itself | Agent runs `git add` + `git commit` inside the worktree; commits land on `whilly/workspace/{slug}` |
+| 8 | Exit | `cli.py::run_plan` returns `0` | Control returns to the caller (`whilly-auto.sh`, another script, or the user's shell) |
+
+**Whilly does not write code.** Phase 4 delegates entirely to the Claude CLI agent. Whilly's only job is to construct the prompt, launch the process, and interpret the result.
+{: .note }
+
+---
+
+## Phase 2 — Generate plan
+
+The plan file is a single-task JSON document written to the current working directory (or the workspace root if `USE_WORKSPACE` is on):
+
+```
+tasks-issue-{owner}-{repo}-{N}.json
+```
+
+Minimum fields the orchestrator cares about:
+
+| Field | Value |
+|---|---|
+| `id` | `issue-{N}` |
+| `status` | `pending` |
+| `description` | Issue title + full body |
+| `acceptance_criteria` | Extracted from `- [ ]` checklists in the issue body |
+| `priority` | Inferred from labels; defaults to `medium` |
+| `dependencies` | `[]` for single-issue plans |
+| `key_files` | `[]` initially; agent may populate on retry |
+
+The schema is validated by `cli.validate_schema` before the plan is accepted. Note that `validate_schema` checks only the first 3 tasks — plans larger than 3 tasks pass structural validation with only partial coverage.
+
+---
+
+## Phase 3 — Workspace isolation
+
+Whilly creates (or reuses) a git worktree so the agent works on an isolated copy of the repository. The worktree branch name is deterministic:
+
+```
+whilly/workspace/{slug}
+```
+
+where `{slug}` is derived from the plan filename. The main repo's working tree is never touched by the agent during execution.
+
+The `run_plan` function `chdir`s into the worktree before dispatching any agents. The plan file itself is resolved to an absolute path *before* the chdir so the orchestrator always reads and writes the canonical JSON in the main repo, not the worktree copy.
+
+If you kill Whilly mid-run, the worktree remains on disk. On the next `--resume`, Whilly reuses it. To clean up manually:
+
+```bash
+git worktree remove .whilly_workspaces/{slug}/ --force
+```
+
+### Base branch freshness
+
+The worktree branches from the current `HEAD` of the checkout that runs Whilly. If your local `main` is behind `origin/main`, the agent works on outdated code and the eventual PR diff will be wrong. Whilly itself does not fetch — the caller is responsible for keeping the base branch current.
+
+Always `git fetch origin && git pull --ff-only` the base branch before running Whilly, or let `scripts/whilly-auto.sh` do it automatically (it runs the equivalent of `git fetch + git checkout main + git pull --ff-only` before phase 1, and supports `SKIP_SYNC=1` for offline runs).
+{: .warning }
+
+---
+
+## Phase 4 — Agent runs
+
+This is the only phase where code is written, and Whilly does not do the writing.
+
+### What Whilly does
+
+1. Marks the task `in_progress` in the plan JSON and on the Projects v2 board (`Todo → In Progress`).
+2. Builds a prompt via `cli.build_task_prompt` that references `@tasks.json` and `@progress.txt`, pins the agent to a single `task_id`, and requires `make lint` / `make test` to pass before signalling completion.
+3. Spawns the Claude CLI in a named tmux session `whilly-{task_id}`:
+   ```
+   tmux new-session -d -s whilly-{task_id} 'claude --task-id ... --output-format json ...'
+   ```
+4. Polls the session output file and the plan JSON until it sees either the completion signal or an error exit code.
+
+### Completion signal
+
+The agent must emit the following literal string anywhere in its reply output for Whilly to treat the task as done:
+
+```
+<promise>COMPLETE</promise>
+```
+
+If this string is absent, Whilly treats the run as incomplete and retries.
+
+If `<promise>COMPLETE</promise>` is missing from the agent output, Whilly retries up to `MAX_TASK_RETRIES` (default: 5) times with exponential backoff (5 / 10 / 20 / 40 / 60 seconds). After 5 failures, the task is marked `failed`.
+{: .note }
+
+### Retry and deadlock detection
+
+| Condition | What Whilly does |
+|---|---|
+| API error (5xx, network) | Retry with backoff; up to `MAX_TASK_RETRIES` |
+| Auth error (401/403) | Mark `failed` immediately; no retry |
+| Missing completion signal | Retry with backoff |
+| Task `in_progress` for ≥ 3 iterations without progress | Force-mark `skipped` |
+
+A task stuck `in_progress` for 3 or more consecutive iterations without any other task completing is treated as a deadlock and force-marked `skipped`. This prevents Whilly from hanging indefinitely on a task the agent cannot finish.
+{: .warning }
+
+`WHILLY_BUDGET_USD` — if total spend reaches 100% of the configured budget, Whilly kills all active tmux sessions and exits immediately with code `2`. An 80% spend triggers a logged warning but does not stop execution.
+{: .warning }
+
+---
+
+## Phase 6 — Mark done and live sync
+
+Phase 6 is two writes in sequence:
+
+1. `TaskManager.mark_status(task, "done")` — atomically writes `status: done` to the plan JSON on disk. The file is the source of truth; the orchestrator re-reads it after every write.
+2. `project_board.set_task_status(task, "in_review")` — moves the corresponding Projects v2 card from "In Progress" to "In Review" via GraphQL.
+
+### Status transition summary
+
+| Phase | Transition | Trigger |
+|---|---|---|
+| Phase 4 start | `Todo → In Progress` | Agent launched |
+| Phase 6 | `In Progress → In Review` | Agent reported complete |
+| After PR merge | `In Review → Done` | `whilly --post-merge <plan>` |
+
+`In Review → Done` does **not** happen inside this 8-phase flow. It is triggered separately by `whilly --post-merge <plan>` after the pull request actually merges. See [GitHub Integration Guide]({{ site.baseurl }}/GitHub-Integration-Guide) for the full lifecycle.
+
+---
+
+## Try it
+
+```bash
+whilly --from-issue mshegolev/whilly-orchestrator#160 --go
+```
+
+Without `--headless`, Whilly displays the Rich TUI dashboard during execution. The dashboard shows active tmux sessions, per-task token and cost counters, and iteration progress. Hotkeys:
+
+| Key | Action |
+|---|---|
+| `q` | Quit (graceful) |
+| `d` | Detail view for the focused task |
+| `l` | Live log tail |
+| `t` | Task list |
+| `h` | Help overlay |
+
+Add `--headless` to suppress the TUI and emit structured JSON on stdout instead. Exit codes: `0` = all done, `1` = some tasks failed, `2` = budget exceeded, `3` = timeout.
+
+---
+
+## Relation to `whilly-auto.sh`
+
+The 8 phases described on this page correspond to **step 2** of the outer pipeline defined in `scripts/whilly-auto.sh`. The full pipeline is:
+
+```
+Step 1 — validate inputs + branch guard
+Step 2 — whilly --from-issue ... --go --headless   ← phases 1–8 documented here
+Step 3 — git push origin whilly/workspace/{slug}
+Step 4 — gh pr create ...
+Step 5 — gh pr merge --auto ...
+Step 6 — whilly --post-merge <plan>                ← In Review → Done
+```
+
+Phases 1–8 are self-contained: Whilly exits `0` after phase 8 and returns control to the script, which then handles the push, PR creation, merge, and post-merge status update. The worktree is left intact so the push in step 3 can read the commits made in phase 7.
+
+See [`scripts/whilly-auto.sh`](https://github.com/mshegolev/whilly-orchestrator/blob/main/scripts/whilly-auto.sh) in the repository for the complete outer loop.
+
+---
+
+## See also
+
+- [Full Usage Reference]({{ site.baseurl }}/Whilly-Usage) — every CLI flag, env var, and config field, including all `WHILLY_*` variables referenced on this page
+- [Interfaces and Tasks]({{ site.baseurl }}/Whilly-Interfaces-and-Tasks) — module contracts and the full JSON plan schema
+- [GitHub Integration Guide]({{ site.baseurl }}/GitHub-Integration-Guide) — Projects v2 setup, board sync, and the post-merge lifecycle

--- a/scripts/whilly-auto.sh
+++ b/scripts/whilly-auto.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+# whilly-auto.sh — "First issue → merged to main" end-to-end pipeline.
+#
+# Picks the first open GitHub issue matching $LABEL, runs whilly on it, pushes
+# the workspace branch, opens a PR, merges into $BASE_BRANCH, then runs the
+# whilly post-merge hook so the Projects v2 card lands in Done.
+#
+# Prerequisites:
+#   * whilly installed and on $PATH (pip install whilly-orchestrator)
+#   * gh authenticated (gh auth login) with repo + project scopes
+#   * CLAUDE_BIN reachable (whilly spawns the Claude CLI for the actual work)
+#
+# Usage:
+#   scripts/whilly-auto.sh                          # first whilly:ready issue in current repo
+#   LABEL=bug scripts/whilly-auto.sh                # first issue with label "bug"
+#   REPO=owner/name scripts/whilly-auto.sh          # override repo
+#   MERGE_METHOD=merge scripts/whilly-auto.sh       # merge commit instead of squash
+#   DRY_RUN=1 scripts/whilly-auto.sh                # print the plan, make no changes
+#
+# Exit codes:
+#   0  merged
+#   1  no matching issue / precondition missing
+#   2  whilly run failed (task not completed)
+#   3  PR create / push / merge failed
+#
+# Status transitions handled automatically:
+#   Todo → In Progress → In Review   (live sync during `whilly --from-issue --go`)
+#   In Review → Done                 (this script, after `gh pr merge` succeeds)
+
+set -euo pipefail
+
+# ── Config ─────────────────────────────────────────────────────────────────────
+
+LABEL="${LABEL:-whilly:ready}"
+BASE_BRANCH="${BASE_BRANCH:-main}"
+MERGE_METHOD="${MERGE_METHOD:-squash}"   # squash | merge | rebase
+REPO="${REPO:-}"
+DRY_RUN="${DRY_RUN:-0}"
+
+# gh often fights GITHUB_TOKEN when it's set; prefer the authenticated user.
+unset GITHUB_TOKEN 2>/dev/null || true
+
+die()  { echo "error: $*" >&2; exit "${2:-1}"; }
+info() { echo "→ $*"; }
+run()  { [[ "$DRY_RUN" == "1" ]] && echo "[dry-run] $*" || eval "$@"; }
+
+# ── 0. Preconditions ───────────────────────────────────────────────────────────
+
+command -v whilly >/dev/null || die "whilly not on PATH — pip install whilly-orchestrator" 1
+command -v gh >/dev/null     || die "gh CLI not on PATH" 1
+command -v jq >/dev/null     || die "jq not on PATH (used to parse gh output)" 1
+
+if [[ -z "$REPO" ]]; then
+    REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null) \
+        || die "cannot detect repo (pass REPO=owner/name)" 1
+fi
+
+# ── 0.1. Sync base branch with origin ──────────────────────────────────────────
+# Whilly's workspace worktree branches from the current HEAD of the base branch.
+# If the local checkout is stale, the agent works against outdated code and the
+# PR diff is wrong. Skip with SKIP_SYNC=1 for air-gapped / offline use.
+
+if [[ "${SKIP_SYNC:-0}" != "1" ]]; then
+    info "Syncing $BASE_BRANCH with origin"
+    if [[ "$DRY_RUN" != "1" ]]; then
+        # Stash any uncommitted changes on the current branch before switching.
+        STASHED=0
+        if [[ -n "$(git status --porcelain)" ]]; then
+            git stash push -u -m "whilly-auto autosync $(date +%s)" >/dev/null \
+                && STASHED=1
+        fi
+        CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+        git fetch origin "$BASE_BRANCH" --quiet \
+            || die "git fetch origin $BASE_BRANCH failed" 1
+        git checkout "$BASE_BRANCH" --quiet \
+            || die "git checkout $BASE_BRANCH failed (uncommitted changes?)" 1
+        git pull --ff-only origin "$BASE_BRANCH" --quiet \
+            || die "git pull --ff-only origin $BASE_BRANCH failed (local diverged)" 1
+        info "On $BASE_BRANCH @ $(git rev-parse --short HEAD)"
+        # Best-effort restore: switch back + pop stash only if we moved.
+        if [[ "$CURRENT_BRANCH" != "$BASE_BRANCH" ]]; then
+            git checkout "$CURRENT_BRANCH" --quiet 2>/dev/null || true
+        fi
+        [[ "$STASHED" == "1" ]] && git stash pop --quiet 2>/dev/null || true
+    fi
+fi
+
+# ── 1. Pick first ready issue ──────────────────────────────────────────────────
+
+FIRST=$(gh issue list --repo "$REPO" --label "$LABEL" --state open --limit 1 \
+        --json number,title,url 2>/dev/null)
+NUMBER=$(jq -r '.[0].number // empty' <<<"$FIRST")
+TITLE=$(jq -r  '.[0].title  // empty' <<<"$FIRST")
+URL=$(jq -r    '.[0].url    // empty' <<<"$FIRST")
+
+[[ -n "$NUMBER" ]] || die "no open issues with label '$LABEL' in $REPO" 1
+
+info "Picked #$NUMBER: $TITLE"
+info "        $URL"
+
+# ── 2. Run whilly (live status sync Todo → In Progress → In Review) ────────────
+
+# Snapshot existing worktrees so we can identify the one whilly creates.
+BEFORE=$(git worktree list --porcelain | awk '/^worktree /{print $2}' | sort)
+
+PLAN="tasks-issue-${REPO//\//-}-${NUMBER}.json"
+info "Running: whilly --from-issue ${REPO}#${NUMBER} --go --headless"
+if [[ "$DRY_RUN" != "1" ]]; then
+    whilly --from-issue "${REPO}#${NUMBER}" --go --headless \
+        || die "whilly run failed — check whilly_logs/ and $PLAN" 2
+fi
+
+# ── 3. Locate the workspace worktree and its branch ────────────────────────────
+
+AFTER=$(git worktree list --porcelain | awk '/^worktree /{print $2}' | sort)
+NEW_WT=$(comm -13 <(echo "$BEFORE") <(echo "$AFTER") | head -1 || true)
+
+if [[ -z "${NEW_WT:-}" ]]; then
+    # Workspace was reused — fall back to the canonical whilly/workspace/* match.
+    NEW_WT=$(git worktree list --porcelain \
+        | awk '
+            /^worktree / {wt=$2}
+            /^branch refs\/heads\/whilly\/workspace\// {print wt; exit}
+          ')
+fi
+[[ -n "${NEW_WT:-}" && -d "$NEW_WT" ]] \
+    || die "could not locate whilly workspace worktree" 3
+
+BRANCH=$(git -C "$NEW_WT" rev-parse --abbrev-ref HEAD)
+info "Workspace: $NEW_WT (branch $BRANCH)"
+
+if ! git -C "$NEW_WT" log -1 --format='%H' "${BASE_BRANCH}..HEAD" -- >/dev/null 2>&1 \
+        || [[ -z "$(git -C "$NEW_WT" log "${BASE_BRANCH}..HEAD" --oneline 2>/dev/null)" ]]; then
+    die "branch $BRANCH has no commits ahead of $BASE_BRANCH — nothing to merge" 2
+fi
+
+# ── 4. Push & open PR ──────────────────────────────────────────────────────────
+
+run "git -C '$NEW_WT' push -u origin '$BRANCH'" \
+    || die "git push failed for $BRANCH" 3
+
+PR_BODY=$(cat <<EOF
+Closes #${NUMBER}
+
+Automated run by Whilly Orchestrator.
+Plan: \`$PLAN\`
+Workspace: \`$NEW_WT\`
+
+🤖 Generated with [Whilly](https://github.com/mshegolev/whilly-orchestrator)
+EOF
+)
+
+if [[ "$DRY_RUN" == "1" ]]; then
+    echo "[dry-run] gh pr create --base $BASE_BRANCH --head $BRANCH --title \"$TITLE\""
+    PR_URL="https://example.invalid/dry-run"
+else
+    PR_URL=$(gh pr create \
+        --repo "$REPO" \
+        --base "$BASE_BRANCH" \
+        --head "$BRANCH" \
+        --title "$TITLE" \
+        --body "$PR_BODY" 2>&1) \
+        || die "gh pr create failed: $PR_URL" 3
+fi
+info "PR: $PR_URL"
+
+# ── 5. Merge (waits for required checks when branch protection is on) ──────────
+
+# --auto is a no-op when branch protection is off (merges immediately) and the
+# right thing to do when it is on (merges once all required checks pass).
+if [[ "$DRY_RUN" != "1" ]]; then
+    gh pr merge "$PR_URL" --"$MERGE_METHOD" --delete-branch --auto \
+        || die "gh pr merge failed" 3
+
+    # Poll until actually merged so the post-merge hook runs after the card
+    # is truly ready to move to Done. Cap at 30 minutes to avoid hanging CI.
+    info "Waiting for merge..."
+    for _ in $(seq 1 180); do
+        STATE=$(gh pr view "$PR_URL" --json state -q .state 2>/dev/null || echo "")
+        [[ "$STATE" == "MERGED" ]] && break
+        [[ "$STATE" == "CLOSED" ]] && die "PR closed without merge" 3
+        sleep 10
+    done
+    [[ "$STATE" == "MERGED" ]] || die "PR not merged after 30 minutes" 3
+    info "Merged"
+fi
+
+# ── 6. Post-merge: In Review → Done on the Projects v2 board ──────────────────
+
+if [[ -f "$PLAN" ]]; then
+    info "Running: whilly --post-merge $PLAN"
+    run "whilly --post-merge '$PLAN'" || echo "warn: post-merge hook non-zero (board sync is advisory)"
+else
+    echo "warn: plan file '$PLAN' missing — skipping post-merge board sync"
+fi
+
+info "Done · issue #$NUMBER merged into $BASE_BRANCH"


### PR DESCRIPTION
## Summary

- New **Documents** section on the GitHub Pages site (left-nav `nav_order: 5`, `has_children: true`)
- New page **Task Execution Phases** — 8-phase walkthrough (fetch → plan → worktree → agent → parse → mark/sync → commit → exit) with ASCII flow, phase table, per-phase elaboration, retry/deadlock/budget callouts
- `scripts/whilly-auto.sh` gets a pre-flight step (0.1) that syncs `$BASE_BRANCH` with `origin` before phase 1, so workspace worktrees always branch from the latest code. `SKIP_SYNC=1` opts out for offline runs
- Phase 3 docs now warn that Whilly itself does not fetch — caller is responsible, or use `whilly-auto.sh`

## Visual

Styled with just-the-docs callouts (`{: .note }` / `{: .warning }`) and typography utilities (`.fs-9` hero, `.fs-5 .fw-300` subtitle, `.fs-3` TL;DR). Dark theme, no emojis, matches existing site voice.

## Test plan

- [x] `bash -n scripts/whilly-auto.sh` — syntax OK
- [x] `DRY_RUN=1 scripts/whilly-auto.sh` — prints new "Syncing main with origin" step
- [ ] After merge, verify on https://mshegolev.github.io/whilly-orchestrator/ that "Documents" appears at nav position 5 with "Task Execution Phases" nested under it
- [ ] Verify the ASCII diagram and tables render correctly in dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)