### PR TITLE
feat: whilly-auto autonomous loop (proxy preflight + reset + retry)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,10 @@ whilly_events.jsonl
 progress.txt
 .planning/reports/
 
+# whilly-auto.sh iteration logs
+whilly-auto-runs/
+whilly-auto-run-*.log
+
 # Auto-generated task files
 tasks-*.json
 !tasks.json  # Keep example tasks.json files

--- a/scripts/whilly-auto-loop.sh
+++ b/scripts/whilly-auto-loop.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# whilly-auto-loop.sh — autonomous retry loop for whilly-auto.sh.
+#
+# Flow (per iteration):
+#   1. whilly-auto-reset.sh <issue>      # scrub workspace, reset board card
+#   2. whilly-auto.sh                    # run the full pipeline
+#   3. On success: exit 0 (issue merged to main, card in Done)
+#   4. On failure: capture log, inspect, wait $BACKOFF_SEC, try again
+#
+# Usage:
+#   scripts/whilly-auto-loop.sh                   # first whilly:ready issue, 10 tries
+#   scripts/whilly-auto-loop.sh 159               # specific issue
+#   MAX_ATTEMPTS=3 scripts/whilly-auto-loop.sh    # cap retries
+#   BACKOFF_SEC=60 scripts/whilly-auto-loop.sh    # delay between attempts
+#
+# Environment:
+#   MAX_ATTEMPTS   — cap on retries (default: 10)
+#   BACKOFF_SEC    — seconds to wait after a failure before retrying (default: 30)
+#   LOG_DIR        — where iteration logs land (default: whilly-auto-runs/)
+#
+# Exit codes:
+#   0  one of the attempts succeeded
+#   2  all attempts exhausted without success
+
+set -uo pipefail
+
+MAX_ATTEMPTS="${MAX_ATTEMPTS:-10}"
+BACKOFF_SEC="${BACKOFF_SEC:-30}"
+LOG_DIR="${LOG_DIR:-whilly-auto-runs}"
+TARGET_ISSUE="${1:-}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RESET="${SCRIPT_DIR}/whilly-auto-reset.sh"
+AUTO="${SCRIPT_DIR}/whilly-auto.sh"
+
+mkdir -p "$LOG_DIR"
+
+for i in $(seq 1 "$MAX_ATTEMPTS"); do
+    ts=$(date -u +'%Y-%m-%dT%H-%M-%SZ')
+    log="${LOG_DIR}/iter-${i}-${ts}.log"
+
+    echo "============================================================"
+    echo "  Attempt $i/$MAX_ATTEMPTS  ·  $(date -u +%FT%TZ)  ·  log: $log"
+    echo "============================================================"
+
+    # Reset state (never fatal — log warnings and continue)
+    echo "== reset ==" | tee -a "$log"
+    if [[ -n "$TARGET_ISSUE" ]]; then
+        "$RESET" "$TARGET_ISSUE" >>"$log" 2>&1 || echo "reset warning (non-fatal)" | tee -a "$log"
+    else
+        "$RESET" >>"$log" 2>&1 || echo "reset warning (non-fatal)" | tee -a "$log"
+    fi
+
+    # Run the pipeline
+    echo "== whilly-auto ==" | tee -a "$log"
+    if "$AUTO" >>"$log" 2>&1; then
+        echo
+        echo "✓ SUCCESS on attempt $i — see $log"
+        grep -E "^(→|✓)" "$log" | tail -20
+        exit 0
+    fi
+
+    rc=$?
+    echo
+    echo "✗ attempt $i failed (exit $rc)"
+    echo "== failure context (last 40 lines of $log) =="
+    tail -40 "$log"
+    echo
+
+    if (( i < MAX_ATTEMPTS )); then
+        echo "waiting ${BACKOFF_SEC}s before retry..."
+        sleep "$BACKOFF_SEC"
+    fi
+done
+
+echo
+echo "✗ all $MAX_ATTEMPTS attempts exhausted — logs in $LOG_DIR"
+exit 2

--- a/scripts/whilly-auto-reset.sh
+++ b/scripts/whilly-auto-reset.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# whilly-auto-reset.sh — scrub every artefact `whilly-auto.sh` might have left
+# behind and return a GitHub issue to "Todo" on the project board, so the next
+# `whilly-auto.sh` run starts from a pristine state.
+#
+# What it cleans:
+#   * all `.whilly_workspaces/*/` worktrees (whilly/workspace/* branches too)
+#   * all `tasks-issue-*.json` plan files in the repo root
+#   * `.whilly_state.json` crash-recovery state
+#   * any open PR whose head branch is `whilly/workspace/*`
+#   * the issue's project v2 card → "Todo"
+#
+# What it does NOT touch:
+#   * main / upstream (only fetches, never pushes anything destructive)
+#   * merged PRs, closed issues, release tags
+#   * whilly_logs/ in the main repo (those are useful post-mortem artifacts)
+#
+# Usage:
+#   scripts/whilly-auto-reset.sh                      # pick first whilly:ready issue
+#   scripts/whilly-auto-reset.sh 159                  # reset specific issue number
+#   REPO=owner/name scripts/whilly-auto-reset.sh 159
+#   DRY_RUN=1 scripts/whilly-auto-reset.sh 159        # show the plan, do nothing
+#
+# Exit codes:
+#   0  reset succeeded
+#   1  precondition missing or gh auth / jq missing
+#   2  partial failure (some cleanup step failed — details logged)
+
+set -euo pipefail
+
+LABEL="${LABEL:-whilly:ready}"
+BASE_BRANCH="${BASE_BRANCH:-main}"
+REPO="${REPO:-}"
+DRY_RUN="${DRY_RUN:-0}"
+PROJECT_URL="${PROJECT_URL:-https://github.com/users/mshegolev/projects/4}"
+
+unset GITHUB_TOKEN 2>/dev/null || true
+
+die()  { echo "error: $*" >&2; exit "${2:-1}"; }
+info() { echo "→ $*"; }
+warn() { echo "warn: $*" >&2; }
+run()  { [[ "$DRY_RUN" == "1" ]] && echo "[dry-run] $*" || eval "$@"; }
+
+command -v gh >/dev/null || die "gh CLI not on PATH" 1
+command -v jq >/dev/null || die "jq not on PATH" 1
+command -v git >/dev/null || die "git not on PATH" 1
+
+if [[ -z "$REPO" ]]; then
+    REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null) \
+        || die "cannot detect repo (pass REPO=owner/name)" 1
+fi
+
+# Target issue: explicit arg or the first open one matching $LABEL.
+TARGET_ISSUE="${1:-}"
+if [[ -z "$TARGET_ISSUE" ]]; then
+    TARGET_ISSUE=$(gh issue list --repo "$REPO" --label "$LABEL" --state open --limit 1 \
+        --json number -q '.[0].number' 2>/dev/null)
+    [[ -n "$TARGET_ISSUE" ]] || die "no open issues with label '$LABEL' — nothing to reset" 1
+fi
+info "Repo: $REPO  ·  Target issue: #$TARGET_ISSUE"
+
+# ── 1. Close any open PR from whilly/workspace/* (these would block re-run) ───
+OPEN_WHILLY_PRS=$(gh pr list --repo "$REPO" --state open \
+    --json number,headRefName -q '.[] | select(.headRefName | startswith("whilly/workspace/")) | .number' \
+    2>/dev/null || true)
+if [[ -n "$OPEN_WHILLY_PRS" ]]; then
+    while IFS= read -r pr; do
+        info "Closing stale whilly PR #$pr"
+        run "gh pr close $pr --repo '$REPO' --delete-branch --comment 'Reset by whilly-auto-reset.sh' 2>&1 | tail -3"
+    done <<<"$OPEN_WHILLY_PRS"
+else
+    info "No open whilly/workspace/* PRs to close"
+fi
+
+# ── 2. Remove every .whilly_workspaces/* worktree ──────────────────────────────
+WORKTREES_TO_REMOVE=$(git worktree list --porcelain \
+    | awk '/^worktree / && $2 ~ /\.whilly_workspaces/ {print $2}' || true)
+if [[ -n "$WORKTREES_TO_REMOVE" ]]; then
+    while IFS= read -r wt; do
+        info "Removing worktree: $wt"
+        run "git worktree remove '$wt' --force 2>&1 | head -3"
+    done <<<"$WORKTREES_TO_REMOVE"
+else
+    info "No whilly worktrees to remove"
+fi
+
+# ── 3. Delete whilly/workspace/* branches (local + remote) ─────────────────────
+LOCAL_WSP_BRANCHES=$(git branch --list 'whilly/workspace/*' | sed 's/^[*+ ]*//' || true)
+if [[ -n "$LOCAL_WSP_BRANCHES" ]]; then
+    while IFS= read -r br; do
+        [[ -z "$br" ]] && continue
+        info "Deleting local branch: $br"
+        run "git branch -D '$br' 2>&1 | head -3"
+    done <<<"$LOCAL_WSP_BRANCHES"
+fi
+
+REMOTE_WSP_BRANCHES=$(git ls-remote --heads origin 'whilly/workspace/*' \
+    | awk '{print $2}' | sed 's|refs/heads/||' || true)
+if [[ -n "$REMOTE_WSP_BRANCHES" ]]; then
+    while IFS= read -r br; do
+        [[ -z "$br" ]] && continue
+        info "Deleting remote branch: $br"
+        run "git push origin --delete '$br' 2>&1 | tail -3"
+    done <<<"$REMOTE_WSP_BRANCHES"
+fi
+
+# ── 4. Remove stale plan files + state + events log ────────────────────────────
+for pattern in "tasks-issue-*.json" "tasks-from-*.json" ".whilly_state.json"; do
+    matches=$(compgen -G "$pattern" 2>/dev/null || true)
+    if [[ -n "$matches" ]]; then
+        info "Removing: $pattern"
+        run "rm -f $pattern"
+    fi
+done
+
+# ── 5. Fetch origin, fast-forward base branch ──────────────────────────────────
+info "Syncing $BASE_BRANCH with origin"
+if [[ "$DRY_RUN" != "1" ]]; then
+    git fetch origin "$BASE_BRANCH" --prune --quiet || warn "git fetch failed (continuing)"
+    CURRENT=$(git rev-parse --abbrev-ref HEAD)
+    if [[ "$CURRENT" != "$BASE_BRANCH" ]]; then
+        # Best-effort switch; ignore if blocked by uncommitted changes (user may have WIP).
+        git checkout "$BASE_BRANCH" --quiet 2>/dev/null || warn "cannot switch to $BASE_BRANCH (uncommitted changes?)"
+    fi
+    git pull --ff-only origin "$BASE_BRANCH" --quiet 2>/dev/null || warn "pull --ff-only failed (local diverged?)"
+fi
+
+# ── 6. Reset the target issue's project board card to "Todo" ───────────────────
+# Use scripts/move_project_card.py — it uses the gh CLI token which has the
+# `project` scope needed for Projects v2 mutations.
+if [[ -x "scripts/move_project_card.py" ]]; then
+    info "Resetting issue #$TARGET_ISSUE card → Todo"
+    if [[ "$DRY_RUN" != "1" ]]; then
+        python3 scripts/move_project_card.py "$PROJECT_URL" "$TARGET_ISSUE" "Todo" --repo "$REPO" 2>&1 \
+            | tail -3 \
+            || warn "move_project_card failed — card may already be in Todo or not on the board"
+    fi
+else
+    warn "scripts/move_project_card.py missing — card reset skipped"
+fi
+
+# ── 7. Reopen the issue if it was auto-closed by a stale PR ───────────────────
+ISSUE_STATE=$(gh issue view "$TARGET_ISSUE" --repo "$REPO" --json state -q .state 2>/dev/null || echo "")
+if [[ "$ISSUE_STATE" == "CLOSED" ]]; then
+    info "Issue #$TARGET_ISSUE was CLOSED — reopening"
+    run "gh issue reopen $TARGET_ISSUE --repo '$REPO' 2>&1 | tail -2"
+fi
+
+info "Reset complete for issue #$TARGET_ISSUE"

--- a/scripts/whilly-auto.sh
+++ b/scripts/whilly-auto.sh
@@ -44,6 +44,21 @@ die()  { echo "error: $*" >&2; exit "${2:-1}"; }
 info() { echo "→ $*"; }
 run()  { [[ "$DRY_RUN" == "1" ]] && echo "[dry-run] $*" || eval "$@"; }
 
+# ── 0.0. Proxy preflight (zshp equivalent for this shell only) ────────────────
+# Whilly spawns `claude` which hits api.anthropic.com; in this environment the
+# host needs the SSH tunnel that `zshp` sets up. This block ensures the tunnel
+# is live and exports HTTP(S)_PROXY / NO_PROXY for the whole process tree
+# (whilly → claude) without requiring the user to pre-run `zshp`.
+#
+# Skip with WHILLY_PROXY_SKIP=1 if you're on a network without this requirement.
+
+_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ -f "${_SCRIPT_DIR}/whilly-proxy-preflight.sh" ]]; then
+    # shellcheck source=whilly-proxy-preflight.sh
+    source "${_SCRIPT_DIR}/whilly-proxy-preflight.sh" \
+        || die "proxy preflight failed — see errors above" 1
+fi
+
 # ── 0. Preconditions ───────────────────────────────────────────────────────────
 
 command -v whilly >/dev/null || die "whilly not on PATH — pip install whilly-orchestrator" 1

--- a/scripts/whilly-auto.sh
+++ b/scripts/whilly-auto.sh
@@ -92,11 +92,13 @@ if [[ "${SKIP_SYNC:-0}" != "1" ]]; then
         git pull --ff-only origin "$BASE_BRANCH" --quiet \
             || die "git pull --ff-only origin $BASE_BRANCH failed (local diverged)" 1
         info "On $BASE_BRANCH @ $(git rev-parse --short HEAD)"
-        # Best-effort restore: switch back + pop stash only if we moved.
+        # Stay on $BASE_BRANCH so whilly's workspace worktree (phase 3) is
+        # rooted in the up-to-date base branch, not the caller's feature
+        # branch. The caller can run `git checkout $CURRENT_BRANCH` afterwards.
         if [[ "$CURRENT_BRANCH" != "$BASE_BRANCH" ]]; then
-            git checkout "$CURRENT_BRANCH" --quiet 2>/dev/null || true
+            info "Note: staying on $BASE_BRANCH; was on '$CURRENT_BRANCH' — switch back after the run completes."
         fi
-        [[ "$STASHED" == "1" ]] && git stash pop --quiet 2>/dev/null || true
+        [[ "$STASHED" == "1" ]] && info "Note: local changes stashed as 'whilly-auto autosync' — recover with 'git stash pop' after the run."
     fi
 fi
 

--- a/scripts/whilly-proxy-preflight.sh
+++ b/scripts/whilly-proxy-preflight.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# whilly-proxy-preflight.sh — source-able helper that activates the SSH-based
+# HTTP proxy for the current shell session (same thing `zshp` does, but
+# callable from bash instead of an interactive zsh).
+#
+# Usage:
+#   source scripts/whilly-proxy-preflight.sh   # from another bash script
+#   scripts/whilly-proxy-preflight.sh          # standalone (prints env to stdout)
+#
+# What it does (idempotent):
+#   1. If ALL_PROXY / HTTPS_PROXY / https_proxy already set — no-op (assumes the
+#      caller already ran `zshp` in the parent zsh shell).
+#   2. Otherwise: calls the user's `_ensure_tunnel gpt-proxy 11112 8888` (via a
+#      zsh subshell that sources ~/.zshrc), waits until the local listener on
+#      11112 is up, then exports HTTP(S)_PROXY / NO_PROXY matching what `zshp`
+#      http-mode would set.
+#   3. Verifies the tunnel is actually forwarding traffic via curl against
+#      https://api.anthropic.com. On failure: exits 1 with a clear hint.
+#
+# Env override:
+#   WHILLY_PROXY_SKIP=1         — skip entirely (for networks w/o need for proxy)
+#   WHILLY_PROXY_HOST=gpt-proxy — ssh host alias (default: gpt-proxy)
+#   WHILLY_PROXY_LOCAL=11112    — local port for HTTP tunnel
+#   WHILLY_PROXY_REMOTE=8888    — remote port on the proxy host
+#
+# Exit codes (when run standalone):
+#   0  proxy is active (either was already set, or we brought it up)
+#   1  tunnel could not be brought up or verified
+
+# Detect if sourced vs. executed — both paths work.
+_whilly_proxy_was_sourced=0
+if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
+    _whilly_proxy_was_sourced=1
+fi
+
+_whilly_proxy_info() { echo "→ [proxy] $*" >&2; }
+_whilly_proxy_die()  { echo "error: [proxy] $*" >&2; return 1; }
+
+_whilly_activate_proxy() {
+    if [[ "${WHILLY_PROXY_SKIP:-0}" == "1" ]]; then
+        _whilly_proxy_info "WHILLY_PROXY_SKIP=1 — skipping proxy setup"
+        return 0
+    fi
+
+    # Already active in parent shell? (user ran `zshp` themselves)
+    if [[ -n "${ALL_PROXY:-}${HTTPS_PROXY:-}${https_proxy:-}" ]]; then
+        _whilly_proxy_info "proxy already active: ${HTTPS_PROXY:-${ALL_PROXY:-${https_proxy}}}"
+        return 0
+    fi
+
+    local host="${WHILLY_PROXY_HOST:-gpt-proxy}"
+    local local_port="${WHILLY_PROXY_LOCAL:-11112}"
+    local remote_port="${WHILLY_PROXY_REMOTE:-8888}"
+    local proxy_url="http://127.0.0.1:${local_port}"
+
+    # Mirror zshp http-mode no_proxy list so traffic to internal hosts
+    # bypasses the tunnel.
+    local no_proxy_list="localhost,127.0.0.1,*.mts.ru,gitlab.services.mts.ru,10.*,11.*"
+
+    # Is the tunnel already listening? (idempotent — `zshp` may have been
+    # called earlier in a different shell that's since closed)
+    if ! lsof -iTCP:"${local_port}" -sTCP:LISTEN >/dev/null 2>&1; then
+        _whilly_proxy_info "bringing up SSH tunnel: ${host} -> 127.0.0.1:${local_port}"
+        # Call the user's _ensure_tunnel helper via zsh. It's defined in their
+        # .zshrc (or shell snapshot) — the only reliable way to reuse it.
+        if ! zsh -c "source ~/.zshrc >/dev/null 2>&1; typeset -f _ensure_tunnel >/dev/null" 2>/dev/null; then
+            _whilly_proxy_die "no _ensure_tunnel helper in your zsh — run 'zshp' manually once"
+            return 1
+        fi
+        zsh -c "source ~/.zshrc >/dev/null 2>&1; _ensure_tunnel ${host} ${local_port} ${remote_port}" \
+            || { _whilly_proxy_die "_ensure_tunnel ${host} failed — check 'ssh ${host}' works"; return 1; }
+    else
+        _whilly_proxy_info "tunnel already listening on :${local_port}"
+    fi
+
+    # Export proxy env for this process tree (bash-side, no `exec zsh`).
+    export HTTP_PROXY="${proxy_url}"
+    export HTTPS_PROXY="${proxy_url}"
+    export http_proxy="${proxy_url}"
+    export https_proxy="${proxy_url}"
+    export ALL_PROXY="${proxy_url}"
+    export all_proxy="${proxy_url}"
+    export NO_PROXY="${no_proxy_list}"
+    export no_proxy="${no_proxy_list}"
+
+    # Smoke test — don't proceed if the proxy can't reach Anthropic.
+    if ! curl -sSf --proxy "${proxy_url}" --max-time 10 \
+            -o /dev/null -w "%{http_code}" \
+            https://api.anthropic.com/v1/messages -X POST 2>/dev/null \
+            | grep -qE "^(401|400|405)$"; then
+        # 401/400/405 means we reached the API (auth error is fine — we just
+        # verify the path is open). Anything else (000 = no connection, 5xx)
+        # means the tunnel is broken.
+        local code
+        code=$(curl -s --proxy "${proxy_url}" --max-time 10 \
+            -o /dev/null -w "%{http_code}" \
+            https://api.anthropic.com 2>/dev/null || echo "000")
+        if [[ "$code" == "000" ]]; then
+            _whilly_proxy_die "tunnel up but no traffic — 'ssh ${host}' works? run 'zshp' manually"
+            return 1
+        fi
+        # Anything else (200, 403, …) is fine — we reached the endpoint.
+    fi
+    _whilly_proxy_info "proxy active: ${proxy_url}"
+    return 0
+}
+
+# Main
+if ! _whilly_activate_proxy; then
+    # When sourced: return non-zero so caller can decide. When executed: exit.
+    if (( _whilly_proxy_was_sourced == 1 )); then
+        return 1
+    else
+        exit 1
+    fi
+fi
+
+# When executed standalone, emit the env in a form the caller can eval.
+if (( _whilly_proxy_was_sourced == 0 )); then
+    for v in HTTP_PROXY HTTPS_PROXY http_proxy https_proxy ALL_PROXY all_proxy NO_PROXY no_proxy; do
+        val="${!v-}"
+        [[ -n "$val" ]] && printf 'export %s=%q\n' "$v" "$val"
+    done
+fi


### PR DESCRIPTION
## Goal

Make `scripts/whilly-auto.sh` actually complete its mission end-to-end — all 8 phases plus push → PR → CI green → merge → board card → Done — **unattended**, restarting from a pristine state after each failed attempt.

## What's in this PR

Four scripts, zero changes to `whilly/` itself (all orchestration lives in `scripts/`):

| Script | Role |
|---|---|
| **`scripts/whilly-proxy-preflight.sh`** | Activates the SSH HTTP proxy for the current bash process tree — equivalent of `zshp http` but callable from bash (zshp does `exec zsh` which a non-zsh script can't use). Idempotent, smoke-tests `api.anthropic.com` before declaring success. `WHILLY_PROXY_SKIP=1` opts out. |
| **`scripts/whilly-auto-reset.sh`** | Scrubs every artefact a previous `whilly-auto.sh` attempt might have left behind, so the next run starts pristine: closes stale `whilly/workspace/*` PRs, removes the corresponding local + remote branches, removes every `.whilly_workspaces/*` worktree, deletes plan JSONs + `.whilly_state.json`, fast-forwards `main`, moves the target issue's Projects v2 card back to Todo, reopens the issue if a stale PR auto-closed it. |
| **`scripts/whilly-auto.sh`** (updated) | Now sources the proxy preflight (new phase 0.0), stays on `\$BASE_BRANCH` after sync so the workspace worktree is rooted in the up-to-date base rather than the caller's feature branch. |
| **`scripts/whilly-auto-loop.sh`** | Outer retry loop: `reset → whilly-auto → success?` repeat up to `MAX_ATTEMPTS` (default 10) with `BACKOFF_SEC` (default 30) between attempts. Logs each iteration to `whilly-auto-runs/iter-N-TIMESTAMP.log`. |

## How to run

### In the morning

```bash
# Simplest — picks the first whilly:ready issue, 10 attempts:
./scripts/whilly-auto-loop.sh

# Target a specific issue:
./scripts/whilly-auto-loop.sh 159

# Fewer tries, longer backoff:
MAX_ATTEMPTS=3 BACKOFF_SEC=120 ./scripts/whilly-auto-loop.sh 159
```

### Allowlist (one-time)

The loop performs: branch switches, stash, force-delete branches, `gh pr close`, `gh pr merge --auto`, `git push --delete`. Add to `.claude/settings.local.json` so the loop doesn't pause for approval on each step:

```json
{
  "permissions": {
    "allow": [
      "Bash(./scripts/whilly-auto-loop.sh*)",
      "Bash(./scripts/whilly-auto-reset.sh*)",
      "Bash(./scripts/whilly-auto.sh*)"
    ]
  }
}
```

## Constraints this design respects

- **Proxy-aware** — no more Claude CLI 403 when run from a shell that hasn't sourced `zshp`. The preflight brings up the tunnel and exports `HTTP(S)_PROXY` / `NO_PROXY` for the whole process tree (whilly → claude).
- **Idempotent** — every step of reset is safe to re-run. No error if worktree / branch / plan file already absent.
- **Log trail** — each iteration lands as a separate log under `whilly-auto-runs/` (gitignored) for post-mortem.
- **No force-push to main** — outer loop never touches `main` itself; it uses normal `gh pr merge --auto` which respects branch protection when present.

## Known gotcha

The `--post-merge` hook inside whilly uses the token stored in the OS keyring (`whilly/github`), which on this machine is a fine-grained PAT without Projects v2 write permission. `move_project_card.py` (used by the reset step) uses `gh auth`'s token which has the `project` scope, so reset works. Once whilly-auto.sh's `--post-merge` runs at the end of the pipeline, it'll log a warning — non-fatal, and the card will already be in In Review from the live-sync during phase 6. Fix when we next regenerate the keyring token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)