### PR TITLE
feat(doctor): ghost-plan detector + menu 'n' hotkey fix

### DIFF
--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1,0 +1,116 @@
+"""Tests for whilly.doctor — the read-only diagnostic."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from whilly.doctor import (
+    _extract_gh_issue_nums,
+    diagnose_plan,
+    format_report,
+    run_doctor,
+)
+
+
+def _write_plan(path: Path, tasks: list[dict], **extra: object) -> Path:
+    payload = {"project": "test", "tasks": tasks, **extra}
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_clean_directory_has_no_findings(tmp_path: Path) -> None:
+    report = run_doctor(cwd=tmp_path, check_gh=False)
+    assert report.findings == []
+    assert "All clean" in format_report(report, color=False)
+
+
+def test_ghost_plan_all_done(tmp_path: Path) -> None:
+    _write_plan(tmp_path / "tasks-old.json", [{"id": "T1", "status": "done"}])
+    d = diagnose_plan(tmp_path / "tasks-old.json")
+    assert d.kind == "ghost"
+    assert "resolved" in d.detail
+
+
+def test_ghost_plan_empty_tasks(tmp_path: Path) -> None:
+    _write_plan(tmp_path / "tasks-empty.json", [])
+    d = diagnose_plan(tmp_path / "tasks-empty.json")
+    assert d.kind == "ghost"
+    assert "0 tasks" in d.detail
+
+
+def test_invalid_name_flagged(tmp_path: Path) -> None:
+    p = tmp_path / "github-https:--example.com-tasks.json"
+    _write_plan(p, [{"id": "T1", "status": "pending"}])
+    d = diagnose_plan(p)
+    assert d.kind == "invalid_name"
+
+
+def test_healthy_plan(tmp_path: Path) -> None:
+    p = _write_plan(tmp_path / "tasks-live.json", [{"id": "T1", "status": "pending"}])
+    d = diagnose_plan(p)
+    assert d.kind == "healthy"
+
+
+def test_ghost_when_all_linked_issues_closed(tmp_path: Path) -> None:
+    tasks = [
+        {"id": "GH-101", "status": "pending"},
+        {"id": "GH-102", "status": "pending"},
+    ]
+    p = _write_plan(tmp_path / "tasks-backlog.json", tasks)
+    d = diagnose_plan(p, issues_state={101: "CLOSED", 102: "CLOSED"})
+    assert d.kind == "ghost"
+    assert "CLOSED" in d.detail
+
+
+def test_stale_when_some_issues_closed(tmp_path: Path) -> None:
+    tasks = [
+        {"id": "GH-101", "status": "pending"},
+        {"id": "GH-102", "status": "pending"},
+    ]
+    p = _write_plan(tmp_path / "tasks-mixed.json", tasks)
+    d = diagnose_plan(p, issues_state={101: "CLOSED", 102: "OPEN"})
+    assert d.kind == "stale"
+    assert "1/2" in d.detail
+
+
+def test_extract_gh_nums_from_prd_requirement_url() -> None:
+    tasks = [
+        {"id": "T1", "prd_requirement": "https://github.com/owner/repo/issues/42"},
+        {"id": "T2", "prd_requirement": "https://github.com/owner/repo/issues/7#issuecomment-1"},
+        {"id": "gh-99-slug"},
+    ]
+    assert _extract_gh_issue_nums(tasks) == [7, 42, 99]
+
+
+def test_tasks_json_canonical_name_is_not_orphan(tmp_path: Path) -> None:
+    # tasks.json is the canonical default plan, never reported as orphan.
+    _write_plan(tmp_path / "tasks.json", [{"id": "T1", "status": "pending"}])
+    report = run_doctor(cwd=tmp_path, check_gh=False)
+    assert report.plans == []
+    assert report.findings == []
+
+
+def test_stale_state_file_detected(tmp_path: Path) -> None:
+    (tmp_path / ".whilly_state.json").write_text(
+        json.dumps({"plan_file": str(tmp_path / "nonexistent.json")}),
+        encoding="utf-8",
+    )
+    report = run_doctor(cwd=tmp_path, check_gh=False)
+    assert report.stale_state_file is not None
+    assert "stale_state" in report.findings
+
+
+def test_orphan_workspaces_detected(tmp_path: Path) -> None:
+    ws = tmp_path / ".whilly_workspaces" / "some-slug"
+    ws.mkdir(parents=True)
+    report = run_doctor(cwd=tmp_path, check_gh=False)
+    assert len(report.orphan_workspaces) == 1
+    assert any(f.startswith("workspaces:") for f in report.findings)
+
+
+def test_exit_code_via_findings(tmp_path: Path) -> None:
+    # ghost plan ⇒ has findings ⇒ CLI should exit 1
+    _write_plan(tmp_path / "tasks-zombie.json", [])
+    report = run_doctor(cwd=tmp_path, check_gh=False)
+    assert bool(report.findings) is True

--- a/whilly/cli.py
+++ b/whilly/cli.py
@@ -806,8 +806,10 @@ def select_plan_interactive(plans: list[Path]) -> list[Path]:
     if choice in ("q", ""):
         sys.exit(0)
     if choice == "n":
-        _ansi(f"{CY}Запусти: {R}whilly --prd-wizard")
-        sys.exit(0)
+        from whilly.prd_launcher import run_prd_wizard
+
+        config = WhillyConfig.from_env()
+        sys.exit(run_prd_wizard(model=config.MODEL))
     if choice == "g":
         from whilly.github_interactive import github_interactive_menu
 

--- a/whilly/cli.py
+++ b/whilly/cli.py
@@ -1987,6 +1987,11 @@ Usage: whilly [OPTIONS] [PLAN_FILE...]
                                     from orphan Stories. --apply: link
                                     assignments + materialise inferred Epics
                                     via the tracker adapter.
+  whilly --doctor                 🆕 Diagnose ghost plans + runtime leftovers
+                                    (orphan workspaces, stale .whilly_state.json,
+                                    leftover tmux sessions). Read-only. Exit 1
+                                    if any findings. Add --no-gh to skip the
+                                    `gh issue view` lookup.
   whilly -h, --help               Show this help
 
 Exit codes (headless mode):
@@ -2071,6 +2076,14 @@ def main(argv: list[str] | None = None) -> int:
         idx = args.index("--ensure-board-statuses")
         names_arg = args[idx + 1] if idx + 1 < len(args) and not args[idx + 1].startswith("-") else None
         return _run_ensure_board_statuses(names_arg)
+
+    if "--doctor" in args:
+        from whilly.doctor import format_report, run_doctor
+
+        check_gh = "--no-gh" not in args
+        report = run_doctor(check_gh=check_gh)
+        print(format_report(report, color=sys.stdout.isatty()))
+        return 1 if report.findings else 0
 
     if "--handoff-list" in args:
         return _run_handoff_list()

--- a/whilly/doctor.py
+++ b/whilly/doctor.py
@@ -1,0 +1,273 @@
+"""Read-only diagnostic for Whilly — finds stale plans and runtime leftovers.
+
+Complements `.gitignore` (which keeps generated plans out of git): doctor finds
+the files that are already ignored but rot on the local disk — ghost plans
+(all-pending plans whose GitHub issues are already closed), invalid filenames
+leaked from URL-based names, orphan workspaces/worktrees, leftover tmux
+sessions, and stale `.whilly_state.json` pointing at a missing plan.
+
+`run_doctor()` returns a `DoctorReport`; the CLI entry (`whilly --doctor`)
+formats it with colour and exits non-zero when findings exist. Doctor never
+deletes — cleanup is the operator's call.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# Plan-shaped files at repo root that discover_plans() does NOT pick up.
+# Patterns match what `whilly --init` / GitHub import / pilot plans produce.
+ORPHAN_PLAN_PATTERNS: tuple[str, ...] = (
+    "tasks-*.json",
+    "github-*tasks*.json",
+)
+
+
+@dataclass
+class PlanDiagnosis:
+    """Verdict for a single plan-shaped file."""
+
+    path: Path
+    kind: str  # ghost | stale | invalid_name | not_a_plan | healthy
+    detail: str = ""
+
+
+@dataclass
+class DoctorReport:
+    plans: list[PlanDiagnosis] = field(default_factory=list)
+    stale_state_file: Path | None = None
+    orphan_workspaces: list[Path] = field(default_factory=list)
+    orphan_worktrees: list[Path] = field(default_factory=list)
+    whilly_tmux_sessions: list[str] = field(default_factory=list)
+
+    @property
+    def findings(self) -> list[str]:
+        """Short human-readable finding codes — empty ⇒ all clean."""
+        out: list[str] = []
+        for d in self.plans:
+            if d.kind in ("ghost", "stale", "invalid_name"):
+                out.append(f"{d.kind}:{d.path.name}")
+        if self.stale_state_file is not None:
+            out.append("stale_state")
+        if self.orphan_workspaces:
+            out.append(f"workspaces:{len(self.orphan_workspaces)}")
+        if self.orphan_worktrees:
+            out.append(f"worktrees:{len(self.orphan_worktrees)}")
+        if self.whilly_tmux_sessions:
+            out.append(f"tmux:{len(self.whilly_tmux_sessions)}")
+        return out
+
+
+def _orphan_plan_files(cwd: Path) -> list[Path]:
+    seen: set[Path] = set()
+    for pattern in ORPHAN_PLAN_PATTERNS:
+        for p in cwd.glob(pattern):
+            if p.name == "tasks.json":  # canonical default plan — not an orphan
+                continue
+            if p.is_file():
+                seen.add(p)
+    return sorted(seen)
+
+
+def _load_plan(p: Path) -> dict | None:
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if isinstance(data, dict) and isinstance(data.get("tasks"), list):
+        return data
+    return None
+
+
+def _extract_gh_issue_nums(tasks: list[dict]) -> list[int]:
+    nums: set[int] = set()
+    for t in tasks:
+        url = str(t.get("prd_requirement") or "")
+        if "/issues/" in url:
+            tail = url.rsplit("/issues/", 1)[1]
+            head = tail.split("/", 1)[0].split("#", 1)[0]
+            if head.isdigit():
+                nums.add(int(head))
+        tid = str(t.get("id") or "")
+        # Accept both "GH-157" and "gh-157-slug" shapes.
+        upper = tid.upper()
+        if upper.startswith("GH-"):
+            body = upper[3:]
+            prefix = body.split("-", 1)[0]
+            if prefix.isdigit():
+                nums.add(int(prefix))
+    return sorted(nums)
+
+
+def _gh_issues_state(numbers: list[int]) -> dict[int, str]:
+    """Fetch {issue_num: state} via `gh`; silently return {} if gh is absent or fails."""
+    if not numbers:
+        return {}
+    out: dict[int, str] = {}
+    for n in numbers:
+        try:
+            r = subprocess.run(
+                ["gh", "issue", "view", str(n), "--json", "state", "--jq", ".state"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=False,
+            )
+        except (subprocess.SubprocessError, FileNotFoundError):
+            return {}  # bail on first hard failure — no partial state
+        if r.returncode == 0 and r.stdout.strip():
+            out[n] = r.stdout.strip().upper()
+    return out
+
+
+def diagnose_plan(p: Path, issues_state: dict[int, str] | None = None) -> PlanDiagnosis:
+    if ":" in p.name:
+        return PlanDiagnosis(p, "invalid_name", "filename contains ':' (likely leaked from a URL)")
+
+    data = _load_plan(p)
+    if data is None:
+        return PlanDiagnosis(p, "not_a_plan", "not valid plan JSON")
+
+    tasks = data.get("tasks", [])
+    if not tasks:
+        return PlanDiagnosis(p, "ghost", "0 tasks")
+
+    statuses = [str(t.get("status", "pending")) for t in tasks]
+    if all(s in ("done", "skipped") for s in statuses):
+        return PlanDiagnosis(p, "ghost", f"all {len(tasks)} tasks resolved — safe to archive")
+
+    all_pending = all(s == "pending" for s in statuses)
+    nums = _extract_gh_issue_nums(tasks)
+    if issues_state and nums:
+        known = {n: issues_state[n] for n in nums if n in issues_state}
+        if known:
+            closed = [n for n, s in known.items() if s == "CLOSED"]
+            if closed and all_pending and len(closed) == len(known):
+                return PlanDiagnosis(
+                    p,
+                    "ghost",
+                    f"all {len(tasks)} pending, but all {len(known)} linked issues are CLOSED",
+                )
+            if closed:
+                return PlanDiagnosis(
+                    p,
+                    "stale",
+                    f"{len(closed)}/{len(known)} referenced issues are already CLOSED",
+                )
+
+    return PlanDiagnosis(p, "healthy", f"{len(tasks)} tasks")
+
+
+def _tmux_whilly_sessions() -> list[str]:
+    try:
+        r = subprocess.run(
+            ["tmux", "list-sessions", "-F", "#{session_name}"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (subprocess.SubprocessError, FileNotFoundError):
+        return []
+    if r.returncode != 0:
+        return []
+    return sorted(s for s in r.stdout.splitlines() if s.startswith("whilly-"))
+
+
+def _stale_state_file(cwd: Path) -> Path | None:
+    state = cwd / ".whilly_state.json"
+    if not state.exists():
+        return None
+    try:
+        sd = json.loads(state.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return state  # unreadable ⇒ stale
+    plan = sd.get("plan_file") or sd.get("plan")
+    if plan and not Path(plan).exists():
+        return state
+    return None
+
+
+def run_doctor(cwd: Path | None = None, check_gh: bool = True) -> DoctorReport:
+    cwd = cwd or Path.cwd()
+    report = DoctorReport()
+
+    orphans = _orphan_plan_files(cwd)
+    all_nums: set[int] = set()
+    for p in orphans:
+        data = _load_plan(p)
+        if data:
+            all_nums.update(_extract_gh_issue_nums(data.get("tasks", [])))
+    issues_state = _gh_issues_state(sorted(all_nums)) if check_gh else {}
+
+    for p in orphans:
+        report.plans.append(diagnose_plan(p, issues_state))
+
+    report.stale_state_file = _stale_state_file(cwd)
+
+    ws = cwd / ".whilly_workspaces"
+    if ws.is_dir():
+        report.orphan_workspaces = sorted(d for d in ws.iterdir() if d.is_dir())
+
+    wt = cwd / ".whilly_worktrees"
+    if wt.is_dir():
+        report.orphan_worktrees = sorted(d for d in wt.iterdir() if d.is_dir())
+
+    report.whilly_tmux_sessions = _tmux_whilly_sessions()
+
+    return report
+
+
+def format_report(report: DoctorReport, *, color: bool = True) -> str:
+    # ANSI fallback-safe: callers pass color=False in non-TTY contexts.
+    RD, YL, GR, CY, D, R = (
+        ("\033[31m", "\033[33m", "\033[32m", "\033[36m", "\033[2m", "\033[0m") if color else ("", "", "", "", "", "")
+    )
+    kind_color = {
+        "ghost": RD,
+        "stale": YL,
+        "invalid_name": RD,
+        "not_a_plan": D,
+        "healthy": GR,
+    }
+
+    lines = [f"{CY}Whilly doctor — diagnostic report{R}", "=" * 40]
+
+    if report.plans:
+        lines.append(f"\n{CY}Orphan plan files (not picked up by discover_plans):{R}")
+        for d in report.plans:
+            c = kind_color.get(d.kind, "")
+            lines.append(f"  {c}[{d.kind}]{R} {d.path.name} — {d.detail}")
+    else:
+        lines.append(f"\n{D}Orphan plan files: none{R}")
+
+    if report.stale_state_file:
+        lines.append(f"\n{YL}Stale state file:{R} {report.stale_state_file}  {D}(plan_file missing){R}")
+
+    if report.orphan_workspaces:
+        lines.append(f"\n{YL}Leftover .whilly_workspaces:{R}")
+        for w in report.orphan_workspaces:
+            lines.append(f"  {w.name}")
+
+    if report.orphan_worktrees:
+        lines.append(f"\n{YL}Leftover .whilly_worktrees:{R}")
+        for w in report.orphan_worktrees:
+            lines.append(f"  {w.name}")
+
+    if report.whilly_tmux_sessions:
+        lines.append(f"\n{YL}Leftover tmux sessions:{R}")
+        for s in report.whilly_tmux_sessions:
+            lines.append(f"  {s}")
+
+    if not report.findings:
+        lines.append(f"\n{GR}All clean.{R}")
+    else:
+        lines.append(
+            f"\n{D}Doctor is read-only. Clean up manually: "
+            f"`rm` ghost plans, `tmux kill-session -t <name>`, archive workspaces.{R}"
+        )
+
+    return "\n".join(lines)


### PR DESCRIPTION
## Summary

Two small related changes around "unfinished sessions" hygiene:

1. **`whilly --doctor`** — new read-only diagnostic. Finds plan files that `.gitignore` keeps out of git but that linger on disk: ghost plans (all tasks done/skipped, or all-pending with linked issues CLOSED via `gh issue view`), stale plans (some issues closed), invalid-name files (`:` in filename — URL-leak), and runtime leftovers (`.whilly_workspaces/`, `.whilly_worktrees/`, `whilly-*` tmux sessions, dangling `.whilly_state.json`). Exits `1` when findings exist. Use `--no-gh` to skip the network lookup.

2. **Menu hotkey `n`** — was printing `"Запусти: whilly --prd-wizard"` and exiting. Now it imports `run_prd_wizard` and calls it inline with the configured model, matching the behaviour the menu already advertised.

## Test plan

- [x] `pytest tests/test_doctor.py -q` — 12 new tests (ghost/stale/invalid_name/healthy/canonical tasks.json/stale state/orphan workspaces)
- [x] Full suite: `pytest -q` → 659 passed
- [x] `ruff check` / `ruff format` — clean
- [x] Live: `python3 -m whilly --doctor` on this repo correctly identifies 4 orphan plan files and exits 1

## Sample live output

```
Orphan plan files (not picked up by discover_plans):
  [invalid_name] github-https:--github.com-mshegolev-whilly-orchestrator-tasks.json — filename contains ':' (likely leaked from a URL)
  [stale] github-mshegolev-whilly-orchestrator-tasks.json — 31/50 referenced issues are already CLOSED
  [ghost] tasks-issue-mshegolev-whilly-orchestrator-157.json — all 1 tasks resolved — safe to archive
  [ghost] tasks-pilot-157.json — all 1 pending, but all 1 linked issues are CLOSED
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)