### PR TITLE
feat!: workspace off by default + release 3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to Whilly Orchestrator will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.0] - 2026-04-24
+
+### Changed (BREAKING)
+- **Plan-level git worktree workspace is OFF by default.** Previously `USE_WORKSPACE` defaulted to `true`, so every `run_plan` invocation created/entered `.whilly_workspaces/{slug}/` via `git worktree add`. In the real-world pilot flows (pending-change-heavy repos, subprocess pipelines with absolute paths into `.venv`) this more often surprised users than it protected them. New default is `false` — agents run in cwd. Opt back in with `whilly --workspace` (alias `--worktree`) or `WHILLY_USE_WORKSPACE=1` / `USE_WORKSPACE = true` in `whilly.toml`. `--no-workspace` / `--no-worktree` are retained as no-ops for backward compatibility. Docs: `README.md`, `docs/Whilly-Usage.md`, `docs/Getting-Started.md`, `CLAUDE.md` all refreshed.
+
+## [3.2.2] - 2026-04-24
+
+### Added
+- `whilly doctor` now detects **ghost plans** — task-plan JSONs referenced by state/history that no longer exist on disk (or point outside the repo). Surfaced as a dedicated diagnostic row so a stale `.whilly_state.json` can't silently re-point the orchestrator at a deleted plan ([#209](https://github.com/mshegolev/whilly-orchestrator/pull/209), [`a6ac28d`](https://github.com/mshegolev/whilly-orchestrator/commit/a6ac28d)).
+
+### Fixed
+- Interactive menu: `n` hotkey (new plan / PRD wizard entry) was swallowed by the Rich Live layer in some terminals; now routed through the same keybind dispatcher as `q`/`p`/`d`/`l`/`t`/`h` ([#209](https://github.com/mshegolev/whilly-orchestrator/pull/209), [`a6ac28d`](https://github.com/mshegolev/whilly-orchestrator/commit/a6ac28d)).
+
+### Chore
+- `.gitignore` now excludes `.claude/` so per-machine Claude Code project state (settings, memory, transcripts) never leaks into PRs. Sync-state manifests refreshed from the 2026-04-23 sync run ([#211](https://github.com/mshegolev/whilly-orchestrator/pull/211), [`757c0fd`](https://github.com/mshegolev/whilly-orchestrator/commit/757c0fd)).
+
 ## [3.2.1] - 2026-04-22
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ Line length is 120 (`[tool.ruff]` in `pyproject.toml`). Target `py310`.
 - `whilly --reset PLAN.json` resets all tasks to `pending`.
 - `whilly --init "desc" [--plan] [--go]` PRD → tasks → optional auto-exec pipeline.
 - `whilly --prd-wizard [slug]` launches Claude CLI interactively with the PRD master prompt.
-- `whilly --no-worktree` / `--no-workspace` disables the default plan-level workspace in `.whilly_workspaces/{slug}/`.
+- Plan-level workspace in `.whilly_workspaces/{slug}/` is **off by default since v3.3.0**. Opt in with `whilly --workspace` (or `--worktree`) / `WHILLY_USE_WORKSPACE=1`. `--no-workspace` / `--no-worktree` are retained as no-ops for backward compatibility.
 
 Config is almost entirely env vars read by `WhillyConfig.from_env()` (`whilly/config.py`) — prefix `WHILLY_`, e.g. `WHILLY_MAX_PARALLEL`, `WHILLY_BUDGET_USD`, `WHILLY_MODEL`, `WHILLY_USE_TMUX`, `WHILLY_HEADLESS`, `WHILLY_TIMEOUT`, `WHILLY_STATE_FILE`. Defaults: model `claude-opus-4-6[1m]`, max_parallel 3, log_dir `whilly_logs/`.
 
@@ -50,7 +50,7 @@ Config is almost entirely env vars read by `WhillyConfig.from_env()` (`whilly/co
 
 The main loop lives in `whilly/cli.py::run_plan`. One plan execution flows like this:
 
-1. **Workspace isolation.** If `USE_WORKSPACE` (default on), `worktree_runner.create_plan_workspace` creates/reuses a git worktree at `.whilly_workspaces/{slug}/` and the loop `chdir`s into it. The plan file itself is resolved to an absolute path *before* chdir so agents still read/write the canonical JSON in the main repo.
+1. **Workspace isolation.** If `USE_WORKSPACE` is on (**off by default since v3.3.0** — enable with `--workspace` or `WHILLY_USE_WORKSPACE=1`), `worktree_runner.create_plan_workspace` creates/reuses a git worktree at `.whilly_workspaces/{slug}/` and the loop `chdir`s into it. The plan file itself is resolved to an absolute path *before* chdir so agents still read/write the canonical JSON in the main repo.
 2. **Task loading.** `task_manager.TaskManager` loads a JSON plan (`{project, prd_file, tasks: [...]}`) with atomic writes. Task statuses: `pending | in_progress | done | failed | skipped`. `get_ready_tasks()` respects `dependencies`, `PRIORITY_ORDER`, and resets stale `in_progress` tasks on startup.
 3. **Batch planning.** If `MAX_PARALLEL > 1`, `orchestrator.plan_batches` groups ready tasks by non-overlapping `key_files` (or `plan_batches_llm` asks an LLM). Only the first batch of each iteration is dispatched — the loop re-evaluates after it completes so newly-unblocked tasks can join the next batch.
 4. **Agent dispatch.** Two runners:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,58 @@
+.DEFAULT_GOAL := help
+SHELL := /bin/bash
+
+PYTHON ?= python3
+PIPX ?= pipx
+PKG := whilly-orchestrator
+
+.PHONY: help install install-dev uninstall lint format test version
+
+help: ## Show available targets
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+	@echo ""
+	@echo "Default user install:       make install        (pipx, isolated CLI, release version from PyPI)"
+	@echo "Contributor install:        make install-dev    (editable link to this checkout + dev extras)"
+
+install: ## Prod install — isolated CLI via pipx from PyPI
+	@command -v $(PIPX) >/dev/null 2>&1 || { \
+		echo "pipx not found. Install it first:"; \
+		echo "  macOS:    brew install pipx && pipx ensurepath"; \
+		echo "  Linux:    python3 -m pip install --user pipx && python3 -m pipx ensurepath"; \
+		echo "Or use plain pip (no isolation): $(PYTHON) -m pip install $(PKG)"; \
+		exit 1; \
+	}
+	$(PIPX) install --force $(PKG)
+	@echo ""
+	@echo "whilly installed at: $$(command -v whilly 2>/dev/null || echo '(not on PATH — run: pipx ensurepath)')"
+
+install-dev: ## Dev install — editable link to this checkout via pipx + [dev] extras
+	@command -v $(PIPX) >/dev/null 2>&1 || { \
+		echo "pipx not found. Install it first (see 'make install' output for hints)."; \
+		echo "Fallback without pipx: $(PYTHON) -m pip install -e '.[dev]'"; \
+		exit 1; \
+	}
+	$(PIPX) install --force --editable '.[dev]'
+	@echo ""
+	@echo "whilly (editable) at: $$(command -v whilly 2>/dev/null || echo '(not on PATH — run: pipx ensurepath)')"
+	@echo "Source tree: $$(pwd)  — edits in whilly/ reflect immediately on next 'whilly' invocation."
+
+uninstall: ## Remove whilly from pipx (and user-site pip as a courtesy)
+	-$(PIPX) uninstall $(PKG) 2>/dev/null
+	-$(PYTHON) -m pip uninstall -y $(PKG) 2>/dev/null
+	@echo "whilly removed (ignored missing installs)."
+
+lint: ## Run ruff (same command CI runs)
+	$(PYTHON) -m ruff check whilly/ tests/
+	$(PYTHON) -m ruff format --check whilly/ tests/
+
+format: ## Apply ruff formatter
+	$(PYTHON) -m ruff format whilly/ tests/
+	$(PYTHON) -m ruff check --fix whilly/ tests/
+
+test: ## Run pytest
+	$(PYTHON) -m pytest -q
+
+version: ## Show source version vs installed CLI version (diagnoses install drift)
+	@echo "Source (whilly/__init__.py): $$(grep -oE '[0-9]+\.[0-9]+\.[0-9]+' whilly/__init__.py | head -1)"
+	@echo "Source (pyproject.toml):     $$(grep -oE '^version = \"[0-9]+\.[0-9]+\.[0-9]+\"' pyproject.toml | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')"
+	@which whilly >/dev/null 2>&1 && echo "CLI on PATH ($$(which whilly)): $$(whilly --version 2>&1 | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -1)" || echo "CLI on PATH: not installed"

--- a/README.md
+++ b/README.md
@@ -66,19 +66,33 @@ Issue ──► Intake ──► Normalize ──► Readiness ──► Strateg
 
 ## Install
 
+Two install variants — pick the one that matches your role.
+
+### For users (prod — default)
+
+Isolated CLI via [pipx](https://pipx.pypa.io/), latest release from PyPI:
+
 ```bash
+pipx install whilly-orchestrator
+# or, if you don't have pipx:
 pip install whilly-orchestrator
 ```
 
-Or from source:
+### For contributors (dev)
+
+Editable link to your local checkout + `[dev]` extras (ruff, pytest, mypy). Edits in `whilly/` reflect immediately on the next `whilly` invocation — no reinstall needed:
 
 ```bash
 git clone https://github.com/mshegolev/whilly-orchestrator
 cd whilly-orchestrator
-pip install -e .
+make install-dev
+# Equivalent to: pipx install --force --editable '.[dev]'
+# Without pipx:   python3 -m pip install -e '.[dev]'
 ```
 
-Requires [Claude CLI](https://docs.claude.com/en/docs/claude-code) on `PATH` (or set `CLAUDE_BIN`).
+Useful contributor targets (see `make help` for all): `make lint`, `make format`, `make test`, `make version` (diagnose install drift — shows source vs installed-CLI version), `make uninstall`.
+
+Both variants require [Claude CLI](https://docs.claude.com/en/docs/claude-code) on `PATH` (or set `CLAUDE_BIN`).
 
 ## Quick start
 
@@ -217,7 +231,7 @@ See [docs/Whilly-Usage.md](docs/Whilly-Usage.md) for the full config guide (TOML
 
 **New here?** Start with [`docs/Getting-Started.md`](docs/Getting-Started.md) — practical walkthroughs from install to first run.
 
-Key CLI flags: `--all`, `--headless`, `--timeout N`, `--resume`, `--reset PLAN.json`, `--init "desc" [--plan] [--go]`, `--plan PRD.md`, `--prd-wizard`, `--no-worktree`, `--agent {claude,opencode,claude_handoff}`.
+Key CLI flags: `--all`, `--headless`, `--timeout N`, `--resume`, `--reset PLAN.json`, `--init "desc" [--plan] [--go]`, `--plan PRD.md`, `--prd-wizard`, `--workspace` (opt into plan-level git worktree — off by default since v3.3.0), `--agent {claude,opencode,claude_handoff}`.
 
 ### Task sources (pull issues into plans)
 
@@ -356,11 +370,13 @@ Running HackSprint1 or a self-paced walkthrough? The full workshop kit (BRD, PRD
 
 ## Development
 
+See **[Install → For contributors (dev)](#for-contributors-dev)** for the one-command setup (`make install-dev`). Day-to-day loops:
+
 ```bash
-pip install -e ".[dev]"
-pytest
-ruff check whilly/ tests/
-ruff format whilly/ tests/
+make test          # pytest -q
+make lint          # ruff check + format --check (same command CI runs)
+make format        # ruff format + ruff check --fix
+make version       # show source version vs installed CLI — diagnoses install drift
 ```
 
 ## Credits

--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -204,7 +204,7 @@ Iterates every `done` task in the plan, moves its card to `Done`, and transition
 |---|---|
 | `gh: Bad credentials (HTTP 401)` | `unset GITHUB_TOKEN && gh auth status` — if that's clean, set `WHILLY_GH_PREFER_KEYRING=1` in whilly.toml |
 | `Legacy .env detected` warning each run | `whilly --config migrate` |
-| Dashboard doesn't render | non-TTY stdout → auto-headless; run whilly in a real terminal, or pass `--no-worktree` to simplify |
+| Dashboard doesn't render | non-TTY stdout → auto-headless; run whilly in a real terminal. Workspace isolation is off by default since v3.3.0 (pass `--workspace` to opt in). |
 | Card doesn't move | `gh auth refresh -s project` (Projects scope) + `whilly --ensure-board-statuses` |
 | Windows: some hotkeys don't work | expected — `q/d/l/t/h` are POSIX-only; dashboard rendering still works |
 | Task stuck "in_progress" across restarts | whilly resets stale in_progress tasks automatically on start |

--- a/docs/Whilly-Usage.md
+++ b/docs/Whilly-Usage.md
@@ -10,8 +10,9 @@ Python-based task orchestrator that runs Claude CLI agents to execute tasks from
 ## Quick Start
 
 ```bash
-# Install (pipx works on macOS/Linux/Windows)
+# Install — prod (default, released version, isolated CLI on macOS/Linux/Windows)
 pipx install whilly-orchestrator
+# Contributor install instead? See README "For contributors (dev)" or: make install-dev
 
 # First run: let whilly tell you where your user config lives
 whilly --config path
@@ -168,7 +169,7 @@ AGENT_BACKEND = "claude"
 MODEL = "claude-opus-4-7[1m]"
 
 # Workspace + tmux
-USE_WORKSPACE = true
+USE_WORKSPACE = false           # v3.3.0: off by default; set to true or pass --workspace to enable
 USE_TMUX = false
 
 # Logging
@@ -218,7 +219,7 @@ Used by `whilly/gh_utils.py::gh_subprocess_env()` when invoking `gh`:
 | `WHILLY_AGENT_BACKEND`            | `claude`               | `claude` or `opencode` |
 | `WHILLY_MODEL`                    | `claude-opus-4-6[1m]`  | LLM model |
 | `WHILLY_USE_TMUX`                 | `0`                    | Run each agent in its own tmux session |
-| `WHILLY_USE_WORKSPACE`            | `1`                    | Plan-level git worktree workspace |
+| `WHILLY_USE_WORKSPACE`            | `0`                    | Plan-level git worktree workspace (off by default since v3.3.0; set `1` or use `--workspace` to enable) |
 | `WHILLY_LOG_DIR`                  | `whilly_logs`          | Directory for per-task logs |
 | `WHILLY_ORCHESTRATOR`             | `file`                 | `file` (key-files collisions) or `llm` (LLM batching) |
 | `WHILLY_VOICE`                    | `1`                    | macOS voice notifications |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "whilly-orchestrator"
-version = "3.2.1"
+version = "3.3.0"
 description = "Whilly Wiggum loop — Ralph's smarter brother technique for continuous AI agent loops: TRIZ analyzer, Decision Gate, PRD wizard, Rich TUI dashboard, tmux/git-worktree parallelism, self-healing system"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/whilly/__init__.py
+++ b/whilly/__init__.py
@@ -1,3 +1,3 @@
 """Whilly task orchestrator — Python rewrite of whilly.sh."""
 
-__version__ = "3.2.1"
+__version__ = "3.3.0"

--- a/whilly/cli.py
+++ b/whilly/cli.py
@@ -1225,7 +1225,7 @@ def run_plan(
             log.info("chdir → %s (workspace %s)", _workspace.path, slug)
         except RuntimeError as e:
             _ansi(f"{RD}Workspace creation failed: {e}{R}")
-            _ansi(f"{YL}Продолжаю без workspace (--no-worktree для подавления){R}")
+            _ansi(f"{YL}Продолжаю без workspace (workspace сейчас off by default; --workspace для явного включения){R}")
             _workspace = None
 
     tm = TaskManager(plan_file)
@@ -2763,7 +2763,12 @@ def main(argv: list[str] | None = None) -> int:
             _ansi(f"{RD}--timeout requires a value{R}")
             return 1
 
-    # --no-worktree / --no-workspace: disable plan-level git worktree isolation
+    # Plan-level git worktree isolation is OFF by default as of v3.3.0.
+    # --workspace / --worktree: explicitly enable.
+    # --no-workspace / --no-worktree: retained as no-ops for backward compatibility.
+    if "--workspace" in args or "--worktree" in args:
+        config.USE_WORKSPACE = True
+        args = [a for a in args if a not in ("--workspace", "--worktree")]
     if "--no-worktree" in args or "--no-workspace" in args:
         config.USE_WORKSPACE = False
         args = [a for a in args if a not in ("--no-worktree", "--no-workspace")]

--- a/whilly/config.py
+++ b/whilly/config.py
@@ -87,7 +87,7 @@ class WhillyConfig:
     TIMEOUT: int = 0
     STATE_FILE: str = ".whilly_state.json"
     WORKTREE: bool = False  # WHILLY_WORKTREE=1 — per-task git worktree (только при MAX_PARALLEL > 1)
-    USE_WORKSPACE: bool = True  # WHILLY_USE_WORKSPACE=0 — отключить plan-level workspace
+    USE_WORKSPACE: bool = False  # WHILLY_USE_WORKSPACE=1 (или --workspace) — включить plan-level worktree
 
     # Agent backend selection (OC-109) — drives whilly.agents.get_backend()
     AGENT_BACKEND: str = "claude"  # "claude" | "opencode"


### PR DESCRIPTION
## Summary

- **Breaking change:** `WhillyConfig.USE_WORKSPACE` default flips `True → False`. Plan-level git worktree at `.whilly_workspaces/{slug}/` is no longer auto-created on every `run_plan`. In pilot flows with pending changes or subprocess pipelines using absolute `.venv` paths, auto-workspace surprised more users than it protected.
- **New CLI flags:** `--workspace` / `--worktree` for explicit opt-in. `--no-workspace` / `--no-worktree` retained as no-ops so existing scripts keep working.
- **Version bump 3.2.1 → 3.3.0** (skipping 3.2.2 — it was never tagged; its CHANGELOG section is preserved alongside the new 3.3.0 section for historical clarity). Also bundles the pending install-ergonomics docs (`Makefile`, README "For users / For contributors" split, `make install-dev` workflow) that were sitting uncommitted from the 3.2.2 prep.

## Flag precedence

`--workspace` is processed before `--no-workspace`, so `whilly --workspace --no-workspace` → OFF (last flag wins).

## How to opt back in to the old behavior

Any one of:
- `whilly --workspace` (or `--worktree`)
- `WHILLY_USE_WORKSPACE=1 whilly ...`
- `USE_WORKSPACE = true` in `whilly.toml`

## Test plan

- [x] `python3 -m pytest -q` — **659 passed**
- [x] `python3 -m ruff check whilly/ tests/` — clean
- [x] `python3 -m ruff format --check whilly/ tests/` — clean
- [x] `python3 -m whilly --version` prints `WHILLY v3.3.0`
- [x] `tests/test_whilly_headless.py` (most workspace-sensitive) — 19/19 pass
- [ ] Manual: `whilly --tasks plan.json` produces no `.whilly_workspaces/` dir (new default)
- [ ] Manual: `whilly --workspace --tasks plan.json` creates `.whilly_workspaces/{slug}/` (opt-in still works)
- [ ] Manual: `whilly --no-workspace --tasks plan.json` still exits 0 (backward compat)

## Files touched

| File | Change |
|------|--------|
| `whilly/config.py` | default flip |
| `whilly/cli.py` | new `--workspace` handler + error-message update |
| `whilly/__init__.py`, `pyproject.toml` | 3.2.2 → 3.3.0 |
| `CHANGELOG.md` | new `[3.3.0]` section above `[3.2.2]` |
| `README.md`, `CLAUDE.md`, `docs/Whilly-Usage.md`, `docs/Getting-Started.md` | doc refresh |
| `Makefile` | pre-existing 3.2.2 release prep (bundled) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)