### PR TITLE
fix(agents): retry subprocess spawn on EAGAIN (macOS RLIMIT_NPROC)

### DIFF
--- a/tests/test_agent_backend_claude.py
+++ b/tests/test_agent_backend_claude.py
@@ -246,3 +246,44 @@ class TestRunAsyncPreamble:
         assert "whilly agent preamble" in content
         assert "backend   : claude" in content
         popen_mock.assert_called_once()
+
+
+# ── EAGAIN retry on Popen ──────────────────────────────────────────────────
+
+
+class TestRunAsyncEagainRetry:
+    """Regression: one EAGAIN from fork/posix_spawn shouldn't kill the plan.
+
+    macOS raises ``BlockingIOError(errno=35)`` from ``subprocess.Popen`` when
+    RLIMIT_NPROC is momentarily exhausted. We retry with backoff instead of
+    propagating the first transient failure.
+    """
+
+    def test_retries_and_succeeds(self, tmp_path: Path, monkeypatch):
+        log = tmp_path / "log.txt"
+        monkeypatch.setattr("whilly.agents.base.time.sleep", lambda *_: None)
+
+        call_count = {"n": 0}
+
+        def fake_popen(*_args, **_kwargs):
+            call_count["n"] += 1
+            if call_count["n"] < 3:
+                raise BlockingIOError(35, "Resource temporarily unavailable")
+            return object()  # sentinel — base helper just returns this through
+
+        with patch("whilly.agents.claude.subprocess.Popen", side_effect=fake_popen):
+            ClaudeBackend().run_async("p", log_file=log)
+
+        assert call_count["n"] == 3
+
+    def test_reraises_after_all_retries(self, tmp_path: Path, monkeypatch):
+        log = tmp_path / "log.txt"
+        monkeypatch.setattr("whilly.agents.base.time.sleep", lambda *_: None)
+
+        def always_eagain(*_a, **_kw):
+            raise BlockingIOError(35, "Resource temporarily unavailable")
+
+        with patch("whilly.agents.claude.subprocess.Popen", side_effect=always_eagain):
+            with pytest.raises(BlockingIOError) as excinfo:
+                ClaudeBackend().run_async("p", log_file=log)
+        assert excinfo.value.errno == 35

--- a/whilly/agents/base.py
+++ b/whilly/agents/base.py
@@ -11,10 +11,57 @@ behind this Protocol — selected via ``--agent {claude,opencode}`` CLI flag
 
 from __future__ import annotations
 
+import logging
 import subprocess
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Protocol
+from typing import Callable, Protocol, TypeVar
+
+log = logging.getLogger("whilly")
+
+_T = TypeVar("_T")
+
+
+def spawn_with_eagain_retry(
+    spawn_fn: Callable[[], _T],
+    *,
+    attempts: int = 5,
+    initial_delay: float = 0.5,
+) -> _T:
+    """Run *spawn_fn* and retry on ``BlockingIOError`` (EAGAIN from fork/posix_spawn).
+
+    On macOS ``fork()`` / ``posix_spawn()`` may return ``EAGAIN`` (errno 35)
+    when the per-user process/thread limit (``RLIMIT_NPROC``, often 5333) is
+    momentarily exhausted — e.g. when other Node.js CLIs or background agents
+    hold many threads. That's transient: other processes will exit within
+    seconds. Without a retry one such blip kills an entire plan run.
+
+    Delays are exponential (default 0.5, 1, 2, 4, 8s — up to ~15s total).
+    After *attempts* failures the last ``BlockingIOError`` is re-raised so
+    callers still see the real operational failure if the system is truly
+    saturated.
+    """
+    delay = initial_delay
+    last_err: BlockingIOError | None = None
+    for attempt in range(attempts):
+        try:
+            return spawn_fn()
+        except BlockingIOError as e:  # EAGAIN on fork/exec
+            last_err = e
+            if attempt == attempts - 1:
+                break
+            log.warning(
+                "spawn hit EAGAIN (errno %s) — retrying in %.1fs (attempt %d/%d)",
+                e.errno,
+                delay,
+                attempt + 1,
+                attempts,
+            )
+            time.sleep(delay)
+            delay *= 2
+    assert last_err is not None
+    raise last_err
 
 
 @dataclass

--- a/whilly/agents/claude.py
+++ b/whilly/agents/claude.py
@@ -17,7 +17,7 @@ import subprocess
 import time
 from pathlib import Path
 
-from whilly.agents.base import AgentResult, AgentUsage, COMPLETION_MARKER
+from whilly.agents.base import AgentResult, AgentUsage, COMPLETION_MARKER, spawn_with_eagain_retry
 
 log = logging.getLogger("whilly")
 
@@ -146,13 +146,15 @@ class ClaudeBackend:
         start = time.monotonic()
         cmd = self.build_command(prompt, model=model)
         try:
-            proc = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                timeout=timeout,
-                cwd=str(cwd) if cwd else None,
-                check=False,
+            proc = spawn_with_eagain_retry(
+                lambda: subprocess.run(
+                    cmd,
+                    capture_output=True,
+                    text=True,
+                    timeout=timeout,
+                    cwd=str(cwd) if cwd else None,
+                    check=False,
+                )
             )
         except subprocess.TimeoutExpired:
             return AgentResult(
@@ -165,6 +167,12 @@ class ClaudeBackend:
                 exit_code=-2,
                 duration_s=time.monotonic() - start,
                 result_text=f"{self._claude_bin()} CLI not found",
+            )
+        except BlockingIOError as e:
+            return AgentResult(
+                exit_code=-3,
+                duration_s=time.monotonic() - start,
+                result_text=f"spawn EAGAIN after retries: {e}",
             )
 
         duration = time.monotonic() - start
@@ -211,11 +219,13 @@ class ClaudeBackend:
         else:
             stdout_target = subprocess.PIPE
 
-        return subprocess.Popen(
-            cmd,
-            stdout=stdout_target,
-            stderr=subprocess.STDOUT,
-            cwd=str(cwd) if cwd else None,
+        return spawn_with_eagain_retry(
+            lambda: subprocess.Popen(
+                cmd,
+                stdout=stdout_target,
+                stderr=subprocess.STDOUT,
+                cwd=str(cwd) if cwd else None,
+            )
         )
 
     def collect_result(

--- a/whilly/agents/opencode.py
+++ b/whilly/agents/opencode.py
@@ -31,7 +31,7 @@ import subprocess
 import time
 from pathlib import Path
 
-from whilly.agents.base import AgentResult, AgentUsage, COMPLETION_MARKER
+from whilly.agents.base import AgentResult, AgentUsage, COMPLETION_MARKER, spawn_with_eagain_retry
 
 log = logging.getLogger("whilly")
 
@@ -330,13 +330,15 @@ class OpenCodeBackend:
         start = time.monotonic()
         cmd = self.build_command(prompt, model=model)
         try:
-            proc = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                timeout=timeout,
-                cwd=str(cwd) if cwd else None,
-                check=False,
+            proc = spawn_with_eagain_retry(
+                lambda: subprocess.run(
+                    cmd,
+                    capture_output=True,
+                    text=True,
+                    timeout=timeout,
+                    cwd=str(cwd) if cwd else None,
+                    check=False,
+                )
             )
         except subprocess.TimeoutExpired:
             return AgentResult(
@@ -349,6 +351,12 @@ class OpenCodeBackend:
                 exit_code=-2,
                 duration_s=time.monotonic() - start,
                 result_text=f"{self._opencode_bin()} CLI not found",
+            )
+        except BlockingIOError as e:
+            return AgentResult(
+                exit_code=-3,
+                duration_s=time.monotonic() - start,
+                result_text=f"spawn EAGAIN after retries: {e}",
             )
 
         duration = time.monotonic() - start
@@ -389,11 +397,13 @@ class OpenCodeBackend:
         else:
             stdout_target = subprocess.PIPE
 
-        return subprocess.Popen(
-            cmd,
-            stdout=stdout_target,
-            stderr=subprocess.STDOUT,
-            cwd=str(cwd) if cwd else None,
+        return spawn_with_eagain_retry(
+            lambda: subprocess.Popen(
+                cmd,
+                stdout=stdout_target,
+                stderr=subprocess.STDOUT,
+                cwd=str(cwd) if cwd else None,
+            )
         )
 
     def collect_result(


### PR DESCRIPTION
## Summary
- `subprocess.Popen` в `ClaudeBackend.run_async` и `OpenCodeBackend.run_async` падал с `BlockingIOError [Errno 35] Resource temporarily unavailable` — ядро macOS возвращает `EAGAIN` из `fork()`/`posix_spawn()`, когда на момент спауна исчерпан per-user лимит `RLIMIT_NPROC`. Одна такая транзиентная ошибка роняла весь план.
- Добавлен общий хелпер `spawn_with_eagain_retry` в `whilly/agents/base.py` с exponential backoff `0.5→1→2→4→8s` (5 попыток, ~15s максимум). Оборачивает оба spawn-сайта в обоих backend'ах.
- Синхронные `run()` теперь возвращают `AgentResult(exit_code=-3)` при исчерпании ретраев вместо того, чтобы пробрасывать исключение.

## Why
macOS `kern.maxprocperuid` = 5333 учитывает **потоки**, не только процессы. Node.js `claude` CLI держит 19–26 потоков каждый. При работе whilly параллельно с другими резидентными Node.js агентами пик thread count лёгко задевает лимит на долю секунды — и этого достаточно, чтобы убить orchestrator без ретрая.

Трассировка из падения:
```
File "whilly/agents/claude.py", line 214, in run_async
  return subprocess.Popen(...)
BlockingIOError: [Errno 35] Resource temporarily unavailable
```

## Test plan
- [x] 2 новых unit-теста в `test_agent_backend_claude.py`:
  - `test_retries_and_succeeds` — 2 EAGAIN затем успех → вызов Popen 3 раза
  - `test_reraises_after_all_retries` — 5 EAGAIN → `BlockingIOError` пробрасывается
- [x] `pytest -q` = 661/661 passed
- [x] `ruff check` + `ruff format --check` зелёные
- [x] Pre-commit hooks зелёные

🤖 Generated with [Claude Code](https://claude.com/claude-code)