### PR TITLE
fix: tolerate concurrent tasks.json reload + drop deprecated --no-input

### DIFF
--- a/tests/test_task_manager_reload.py
+++ b/tests/test_task_manager_reload.py
@@ -1,0 +1,73 @@
+"""Tests for TaskManager.reload() resilience against partial-write races.
+
+The dashboard re-reads the plan file every render frame, while agent
+subprocesses (Claude CLI) may be writing the same file non-atomically.
+``reload()`` must tolerate a transient JSONDecodeError without crashing
+the orchestrator.
+"""
+
+import json
+
+import pytest
+from whilly.task_manager import TaskManager
+
+
+def _write_plan(path, status="pending"):
+    plan = {
+        "project": "race-test",
+        "tasks": [
+            {
+                "id": "T-1",
+                "phase": "P1",
+                "category": "func",
+                "priority": "high",
+                "description": "Task one",
+                "status": status,
+                "dependencies": [],
+                "key_files": [],
+            }
+        ],
+    }
+    path.write_text(json.dumps(plan))
+
+
+def test_reload_first_load_propagates_error(tmp_path):
+    """First reload (no prior snapshot) must surface real errors."""
+    bad = tmp_path / "broken.json"
+    bad.write_text("{not json")
+    with pytest.raises(json.JSONDecodeError):
+        TaskManager(str(bad))
+
+
+def test_reload_keeps_snapshot_on_partial_write(tmp_path):
+    """After a successful load, a corrupted file should not crash reload()."""
+    plan_file = tmp_path / "tasks.json"
+    _write_plan(plan_file, status="done")
+    tm = TaskManager(str(plan_file))
+    assert tm.tasks[0].status == "done"
+
+    # Simulate an in-flight non-atomic write: file contains a truncated
+    # JSON object (writer hasn't closed the string/object yet).
+    plan_file.write_text('{"project": "race-test", "tasks": [{"id": "T-1", "status": "pen')
+
+    tm.reload()  # must not raise
+    assert tm.tasks, "should keep last good snapshot when current read is partial"
+    assert tm.tasks[0].status == "done"
+
+
+def test_reload_recovers_after_writer_finishes(tmp_path):
+    """Once the writer commits a valid file, the next reload picks it up."""
+    plan_file = tmp_path / "tasks.json"
+    _write_plan(plan_file, status="pending")
+    tm = TaskManager(str(plan_file))
+    assert tm.tasks[0].status == "pending"
+
+    # Corrupt -> reload keeps prior snapshot
+    plan_file.write_text("{garbage")
+    tm.reload()
+    assert tm.tasks[0].status == "pending"
+
+    # Writer finishes -> next reload sees the new data
+    _write_plan(plan_file, status="done")
+    tm.reload()
+    assert tm.tasks[0].status == "done"

--- a/whilly/prd_wizard.py
+++ b/whilly/prd_wizard.py
@@ -282,7 +282,7 @@ class PrdWizard:
             f"Сохрани PRD в файл {prd_path}. Только markdown."
         )
 
-        cmd = ["claude", "--model", self._model, "--print", "--no-input", "-p", prompt]
+        cmd = ["claude", "--model", self._model, "--print", "-p", prompt]
 
         try:
             result = subprocess.run(

--- a/whilly/task_manager.py
+++ b/whilly/task_manager.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import tempfile
+import time
 from collections import Counter
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -125,9 +126,30 @@ class TaskManager:
         self.reload()
 
     def reload(self) -> None:
-        """Reload tasks from file."""
-        self._data = json.loads(self.path.read_text(encoding="utf-8"))
-        self.tasks = [Task.from_dict(t) for t in self._data.get("tasks", [])]
+        """Reload tasks from file.
+
+        Tolerant of concurrent partial writes from non-atomic writers
+        (e.g. Claude CLI agent subprocesses editing the same tasks.json):
+        retries a few times on JSONDecodeError/OSError, then falls back to
+        the last good snapshot if one exists. On the very first load
+        (no prior snapshot) the error is re-raised so callers see real
+        problems instead of silently booting with an empty plan.
+        """
+        last_err: Exception | None = None
+        for attempt in range(5):
+            try:
+                raw = self.path.read_text(encoding="utf-8")
+                self._data = json.loads(raw)
+                self.tasks = [Task.from_dict(t) for t in self._data.get("tasks", [])]
+                return
+            except (json.JSONDecodeError, OSError) as e:
+                last_err = e
+                time.sleep(0.05 * (attempt + 1))
+        if self.tasks or self._data:
+            log.warning("TaskManager.reload(): %s — keeping last good snapshot", last_err)
+            return
+        assert last_err is not None
+        raise last_err
 
     def save(self) -> None:
         """Save tasks back to JSON file (atomic write via temp + rename)."""

--- a/whilly/triz_analyzer.py
+++ b/whilly/triz_analyzer.py
@@ -353,7 +353,7 @@ def format_challenge_report(report: ChallengeReport) -> str:
 
 def _call_claude(prompt: str, model: str) -> str:
     """Call Claude CLI and return response."""
-    cmd = ["claude", "--model", model, "--print", "--no-input", "-p", prompt]
+    cmd = ["claude", "--model", model, "--print", "-p", prompt]
     log.info("TRIZ analysis: calling Claude (%d chars prompt)...", len(prompt))
     t0 = time.time()
     try:


### PR DESCRIPTION
## Summary

Two small but unrelated reliability fixes that keep the orchestrator from
aborting on transient conditions.

- **`task_manager.reload()` now retries on partial writes** — agent
  subprocesses write `tasks.json` non-atomically; a 50ms in-flight
  truncation used to surface as a fatal `JSONDecodeError` and kill the
  whole run. New behaviour: 5 retries with backoff (50ms × attempt),
  then fall back to the last good in-memory snapshot. First-load
  failures still raise so genuine bad-plan problems aren't silently
  swallowed.
- **Drop deprecated `--no-input` flag** from Claude CLI calls in
  `prd_wizard.py` and `triz_analyzer.py`. Recent Claude CLI versions
  reject the flag with "unknown option"; remaining `--print -p` combo
  is the documented non-interactive mode.

## Files

| File | Change |
|---|---|
| `whilly/task_manager.py` | retry-tolerant `reload()` (+27/-5) |
| `whilly/prd_wizard.py` | drop `--no-input` (1 line) |
| `whilly/triz_analyzer.py` | drop `--no-input` (1 line) |
| `tests/test_task_manager_reload.py` | 3 new cases (new file) |

## Test plan

- [x] `python3 -m pytest tests/test_task_manager_reload.py -q` → 3 passed
- [x] `python3 -m ruff check whilly/ tests/` → All checks passed
- [x] `python3 -m ruff format --check whilly/ tests/` → 4 files unchanged
- [x] Pre-commit hooks (secret scan + file size) → passed for both commits
- [ ] CI matrices (Linux/macOS/Win × 3.10/3.11/3.12) — to be verified after PR is open

🤖 Generated with [Claude Code](https://claude.com/claude-code)