### PR TITLE
chore(task-109): simplify pass — fix CLI flag propagation + dedupe helpers

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,47 @@
+"""Shared fixtures for ``tests/unit/``.
+
+The proxy/probe test suites bind real localhost sockets to validate the
+TCP-handshake probe end-to-end (mocking would bypass the very
+``socket.create_connection`` we want to exercise). The fixtures are
+identical across test_claude_proxy_probe.py and test_cli_init_proxy.py,
+so they live here for pytest auto-discovery rather than being copied
+file-to-file.
+"""
+
+from __future__ import annotations
+
+import socket
+from collections.abc import Iterator
+
+import pytest
+
+
+@pytest.fixture
+def listening_port() -> Iterator[int]:
+    """Bind a real listener on an ephemeral port; yield it; close on teardown.
+
+    ``backlog=1`` is plenty — the probe never ``accept()``s, it just
+    completes the handshake. The yield/close pattern guarantees the
+    socket is released even if the test raises mid-assertion.
+    """
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(("127.0.0.1", 0))
+    sock.listen(1)
+    try:
+        yield sock.getsockname()[1]
+    finally:
+        sock.close()
+
+
+@pytest.fixture
+def closed_port() -> int:
+    """Return a port that is *not* listening.
+
+    Bind + close releases the port; the kernel won't immediately reuse
+    it for a competing listener within the test, so a probe against
+    this port reliably gets ``ConnectionRefusedError``.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        port = sock.getsockname()[1]
+    return port

--- a/tests/unit/test_claude_proxy_probe.py
+++ b/tests/unit/test_claude_proxy_probe.py
@@ -9,9 +9,9 @@ Covers :func:`whilly.adapters.runner.proxy.probe_proxy_or_raise`:
 * Diagnostic message contains the SSH-tunnel hint that the PRD
   requires.
 
-The fake server is a `socket.socket` bound to ``127.0.0.1:0`` (kernel
-picks the port). Two reasons for using a real socket rather than a
-mock:
+The ``listening_port`` / ``closed_port`` fixtures live in
+``tests/unit/conftest.py`` (shared with ``test_cli_init_proxy.py``).
+Two reasons for using real sockets rather than mocks:
 
 * The probe does ``socket.create_connection``; mocking that would
   bypass the actual code path we want to validate.
@@ -22,45 +22,9 @@ PRD: ``docs/PRD-v41-claude-proxy.md`` FR-3 / SC-3.
 
 from __future__ import annotations
 
-import socket
-from collections.abc import Iterator
-
 import pytest
 
 from whilly.adapters.runner.proxy import probe_proxy_or_raise
-
-
-@pytest.fixture
-def listening_port() -> Iterator[int]:
-    """Bind a real listener on an ephemeral port; yield it; close on teardown.
-
-    ``backlog=1`` means a single pending connection slot which is all the
-    probe ever needs (it doesn't ``accept()``, just connects). The yield/
-    close pattern guarantees the socket goes away even if the test
-    raises mid-assertion.
-    """
-    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    sock.bind(("127.0.0.1", 0))
-    sock.listen(1)
-    try:
-        port = sock.getsockname()[1]
-        yield port
-    finally:
-        sock.close()
-
-
-@pytest.fixture
-def closed_port() -> int:
-    """Return a port that is *not* listening.
-
-    Bind + close releases the port; the kernel won't immediately reuse
-    it for a competing listener within the test, so a probe against
-    this port reliably gets ``ConnectionRefusedError``.
-    """
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-        sock.bind(("127.0.0.1", 0))
-        port = sock.getsockname()[1]
-    return port
 
 
 # ─── happy path ────────────────────────────────────────────────────────────

--- a/tests/unit/test_claude_subprocess_env.py
+++ b/tests/unit/test_claude_subprocess_env.py
@@ -123,13 +123,34 @@ async def test_claude_cli_does_not_mutate_os_environ(
 # ─── prd_generator._call_claude ───────────────────────────────────────────
 
 
-def test_prd_generator_call_claude_with_proxy(monkeypatch: pytest.MonkeyPatch) -> None:
-    """PRD-wizard's call site also injects HTTPS_PROXY into spawned env."""
-    monkeypatch.setenv(WHILLY_PROXY_URL_ENV, "http://prd-proxy:9999")
-    monkeypatch.delenv(INHERITED_HTTPS_PROXY_ENV, raising=False)
-    monkeypatch.setenv("CLAUDE_BIN", "/bin/true")
+class _StreamLike:
+    """Minimal file-like for the heartbeat / drain threads in ``_call_claude``.
 
-    captured: dict[str, Any] = {}
+    The production code reads stderr line-by-line and stdout via
+    ``communicate()``; we hand back tiny stand-ins that don't block.
+    """
+
+    def __init__(self, payload: bytes) -> None:
+        self._payload = payload.decode("utf-8")
+        self._consumed = False
+
+    def __iter__(self) -> Any:
+        return iter(())  # no stderr lines
+
+    def read(self) -> str:
+        if self._consumed:
+            return ""
+        self._consumed = True
+        return self._payload
+
+
+def _make_fake_popen(captured: dict[str, Any]) -> type:
+    """Return a ``FakePopen`` class that records the ``env`` kwarg into ``captured``.
+
+    Factory rather than module-level class so the per-test ``captured``
+    dict is closed over without a global. Two production callers pass
+    the result to ``monkeypatch.setattr`` for ``subprocess.Popen``.
+    """
 
     class FakePopen:
         def __init__(self, *args: Any, **kwargs: Any) -> None:
@@ -148,7 +169,17 @@ def test_prd_generator_call_claude_with_proxy(monkeypatch: pytest.MonkeyPatch) -
         def wait(self) -> int:
             return 0
 
-    monkeypatch.setattr("whilly.prd_generator.subprocess.Popen", FakePopen)
+    return FakePopen
+
+
+def test_prd_generator_call_claude_with_proxy(monkeypatch: pytest.MonkeyPatch) -> None:
+    """PRD-wizard's call site also injects HTTPS_PROXY into spawned env."""
+    monkeypatch.setenv(WHILLY_PROXY_URL_ENV, "http://prd-proxy:9999")
+    monkeypatch.delenv(INHERITED_HTTPS_PROXY_ENV, raising=False)
+    monkeypatch.setenv("CLAUDE_BIN", "/bin/true")
+
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr("whilly.prd_generator.subprocess.Popen", _make_fake_popen(captured))
 
     from whilly.prd_generator import _call_claude
 
@@ -169,25 +200,7 @@ def test_prd_generator_call_claude_without_proxy(monkeypatch: pytest.MonkeyPatch
     monkeypatch.setenv("CLAUDE_BIN", "/bin/true")
 
     captured: dict[str, Any] = {}
-
-    class FakePopen:
-        def __init__(self, *args: Any, **kwargs: Any) -> None:
-            captured["env"] = kwargs.get("env")
-            self.stdout = _StreamLike(b'{"ok": 1}')
-            self.stderr = _StreamLike(b"")
-            self.returncode = 0
-            self.pid = 12345
-
-        def communicate(self, timeout: float | None = None) -> tuple[str, str]:
-            return ('{"ok": 1}', "")
-
-        def kill(self) -> None:
-            pass
-
-        def wait(self) -> int:
-            return 0
-
-    monkeypatch.setattr("whilly.prd_generator.subprocess.Popen", FakePopen)
+    monkeypatch.setattr("whilly.prd_generator.subprocess.Popen", _make_fake_popen(captured))
 
     from whilly.prd_generator import _call_claude
 
@@ -196,24 +209,3 @@ def test_prd_generator_call_claude_without_proxy(monkeypatch: pytest.MonkeyPatch
     env = captured["env"]
     assert env is not None
     assert "HTTPS_PROXY" not in env
-
-
-class _StreamLike:
-    """Minimal file-like for the heartbeat / drain threads in _call_claude.
-
-    The production code reads stderr line-by-line and stdout via
-    communicate(); we hand back tiny stand-ins that don't block.
-    """
-
-    def __init__(self, payload: bytes) -> None:
-        self._payload = payload.decode("utf-8")
-        self._consumed = False
-
-    def __iter__(self) -> Any:
-        return iter(())  # no stderr lines
-
-    def read(self) -> str:
-        if self._consumed:
-            return ""
-        self._consumed = True
-        return self._payload

--- a/tests/unit/test_cli_init_proxy.py
+++ b/tests/unit/test_cli_init_proxy.py
@@ -18,14 +18,12 @@ probe function, just the env it consults.
 
 from __future__ import annotations
 
-import socket
-from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
 import pytest
 
-from whilly.adapters.runner.proxy import WHILLY_PROBE_ENV, WHILLY_PROXY_URL_ENV
+from whilly.adapters.runner.proxy import WHILLY_PROXY_PROBE_ENV, WHILLY_PROXY_URL_ENV
 from whilly.cli.init import (
     EXIT_ENVIRONMENT_ERROR,
     EXIT_OK,
@@ -60,31 +58,11 @@ def test_parser_proxy_default_none() -> None:
     assert args.no_claude_proxy is False
 
 
-# ─── probe fixtures ────────────────────────────────────────────────────────
-
-
-@pytest.fixture
-def listening_port() -> Iterator[int]:
-    """Bind a real listener on an ephemeral port."""
-    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    sock.bind(("127.0.0.1", 0))
-    sock.listen(1)
-    try:
-        yield sock.getsockname()[1]
-    finally:
-        sock.close()
-
-
-@pytest.fixture
-def closed_port() -> int:
-    """Return a port that is *not* listening."""
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-        sock.bind(("127.0.0.1", 0))
-        port = sock.getsockname()[1]
-    return port
-
-
 # ─── helpers (mirror test_cli_init.py shape) ──────────────────────────────
+
+
+# ``listening_port`` / ``closed_port`` fixtures are auto-discovered from
+# ``tests/unit/conftest.py``.
 
 
 def _make_fake_runner_writes_prd(prd_text: str = "# PRD\n\nfake\n") -> Any:
@@ -187,7 +165,7 @@ def test_init_probe_skipped_when_env_disables(
     chose by setting the opt-out.
     """
     monkeypatch.setenv("WHILLY_DATABASE_URL", "postgresql://fake/test")
-    monkeypatch.setenv(WHILLY_PROBE_ENV, "0")
+    monkeypatch.setenv(WHILLY_PROXY_PROBE_ENV, "0")
     proxy_url = f"http://127.0.0.1:{closed_port}"
 
     rc = run_init_command(
@@ -263,3 +241,83 @@ def test_init_cli_flag_overrides_env_url(
         plan_inserter=_fake_plan_inserter(),
     )
     assert rc == EXIT_OK
+
+
+# ─── CLI → downstream env propagation (regression for review-found bug) ────
+
+
+def test_init_cli_url_propagates_to_os_environ_for_downstream_spawn(
+    listening_port: int,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``--claude-proxy URL`` must be visible to downstream re-resolves.
+
+    ``_call_claude`` / ``_spawn_and_collect`` re-read ``os.environ`` to
+    decide whether to inject ``HTTPS_PROXY`` into the spawn. If
+    ``run_init_command`` only used the flag for the probe (early bug) and
+    never propagated, the spawned Claude would skip the proxy. This test
+    pins the propagation by inspecting ``os.environ`` from inside the
+    fake runner — that's the exact moment downstream would re-resolve.
+    """
+    import os
+
+    monkeypatch.setenv("WHILLY_DATABASE_URL", "postgresql://fake/test")
+    monkeypatch.delenv(WHILLY_PROXY_URL_ENV, raising=False)
+    monkeypatch.delenv("HTTPS_PROXY", raising=False)
+    cli_url = f"http://127.0.0.1:{listening_port}"
+
+    seen_in_runner: dict[str, str | None] = {}
+
+    def runner_inspecting_env(*, idea: str, slug: str, output_dir: Path, model: str) -> int:
+        seen_in_runner["proxy_url_env"] = os.environ.get(WHILLY_PROXY_URL_ENV)
+        path = Path(output_dir).resolve() / f"PRD-{slug}.md"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("# PRD\n", encoding="utf-8")
+        return 0
+
+    rc = run_init_command(
+        ["idea", "--headless", "--claude-proxy", cli_url, "--output-dir", str(tmp_path)],
+        headless_runner=runner_inspecting_env,
+        tasks_builder=_fake_tasks_builder(),
+        plan_inserter=_fake_plan_inserter(),
+    )
+    assert rc == EXIT_OK
+    assert seen_in_runner["proxy_url_env"] == cli_url
+
+
+def test_init_no_claude_proxy_clears_inherited_env_for_downstream(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``--no-claude-proxy`` must remove inherited proxy vars before runner runs.
+
+    Otherwise downstream ``resolve_proxy_settings`` (which only reads
+    ``os.environ``) would re-introduce the proxy via the
+    ``HTTPS_PROXY`` fallback against the operator's explicit opt-out.
+    """
+    import os
+
+    monkeypatch.setenv("WHILLY_DATABASE_URL", "postgresql://fake/test")
+    monkeypatch.setenv(WHILLY_PROXY_URL_ENV, "http://will-be-cleared:1")
+    monkeypatch.setenv("HTTPS_PROXY", "http://also-cleared:1")
+
+    seen_in_runner: dict[str, str | None] = {}
+
+    def runner_inspecting_env(*, idea: str, slug: str, output_dir: Path, model: str) -> int:
+        seen_in_runner["proxy_url_env"] = os.environ.get(WHILLY_PROXY_URL_ENV)
+        seen_in_runner["https_proxy"] = os.environ.get("HTTPS_PROXY")
+        path = Path(output_dir).resolve() / f"PRD-{slug}.md"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("# PRD\n", encoding="utf-8")
+        return 0
+
+    rc = run_init_command(
+        ["idea", "--headless", "--no-claude-proxy", "--output-dir", str(tmp_path)],
+        headless_runner=runner_inspecting_env,
+        tasks_builder=_fake_tasks_builder(),
+        plan_inserter=_fake_plan_inserter(),
+    )
+    assert rc == EXIT_OK
+    assert seen_in_runner["proxy_url_env"] is None
+    assert seen_in_runner["https_proxy"] is None

--- a/whilly/adapters/runner/claude_cli.py
+++ b/whilly/adapters/runner/claude_cli.py
@@ -176,8 +176,7 @@ async def _spawn_and_collect(prompt: str, model: str) -> AgentResult:
     # TASK-109-3: inject HTTPS_PROXY/NO_PROXY into the spawned env only,
     # so worker-side asyncpg / httpx (running in the parent process)
     # keep going direct to Postgres / control plane.
-    settings = proxy.resolve_proxy_settings()
-    child_env = proxy.build_subprocess_env(os.environ, settings)
+    child_env = proxy.spawn_env_for_claude()
     try:
         proc = await asyncio.create_subprocess_exec(
             *cmd,

--- a/whilly/adapters/runner/proxy.py
+++ b/whilly/adapters/runner/proxy.py
@@ -27,7 +27,7 @@ DEFAULT_NO_PROXY: str = "localhost,127.0.0.1,::1"
 
 WHILLY_PROXY_URL_ENV: str = "WHILLY_CLAUDE_PROXY_URL"
 WHILLY_NO_PROXY_ENV: str = "WHILLY_CLAUDE_NO_PROXY"
-WHILLY_PROBE_ENV: str = "WHILLY_CLAUDE_PROXY_PROBE"
+WHILLY_PROXY_PROBE_ENV: str = "WHILLY_CLAUDE_PROXY_PROBE"
 
 INHERITED_HTTPS_PROXY_ENV: str = "HTTPS_PROXY"
 
@@ -140,11 +140,45 @@ def build_subprocess_env(
     spawns; mutating it would leak the proxy into the parent process.
     """
     result = dict(parent_env)
-    if settings.is_active:
-        assert settings.url is not None  # narrowed by is_active
-        result["HTTPS_PROXY"] = settings.url
+    # Bind to a local so the truthy check narrows for the type checker
+    # without an `assert` — assertions are stripped under ``python -O``,
+    # so a real branch is the safer guard.
+    url = settings.url
+    if url:
+        result["HTTPS_PROXY"] = url
         result["NO_PROXY"] = settings.no_proxy
     return result
+
+
+def spawn_env_for_claude(parent_env: Mapping[str, str] | None = None) -> dict[str, str]:
+    """Resolve proxy settings from ``parent_env`` and build the spawn-env in one step.
+
+    Single entry-point used by both ``claude_cli._spawn_and_collect`` and
+    ``prd_generator._call_claude``. CLI overrides from ``whilly init`` are
+    already materialised into env vars by ``run_init_command`` before any
+    spawn happens, so the env-only resolution path is correct here.
+    """
+    if parent_env is None:
+        import os
+
+        parent_env = os.environ
+    settings = resolve_proxy_settings(env=parent_env)
+    return build_subprocess_env(parent_env, settings)
+
+
+def should_probe(env: Mapping[str, str] | None = None) -> bool:
+    """Return ``True`` iff the TCP probe should run before invoking Claude.
+
+    The probe is enabled by default; an operator opts out with
+    ``WHILLY_CLAUDE_PROXY_PROBE=0`` (e.g. for proxies that legitimately
+    reject bare TCP probes). Centralised here so any future relaxation of
+    the opt-out grammar (``"false"``, ``"no"``, …) lands in one place.
+    """
+    if env is None:
+        import os
+
+        env = os.environ
+    return env.get(WHILLY_PROXY_PROBE_ENV, "1") != "0"
 
 
 def probe_proxy_or_raise(url: str, *, timeout: float = 0.5) -> None:
@@ -171,7 +205,7 @@ def probe_proxy_or_raise(url: str, *, timeout: float = 0.5) -> None:
     if host is None:
         raise RuntimeError(
             f"whilly: cannot parse Claude proxy URL {url!r} "
-            f"(expected http://host:port). To skip this check: {WHILLY_PROBE_ENV}=0"
+            f"(expected http://host:port). To skip this check: {WHILLY_PROXY_PROBE_ENV}=0"
         )
 
     port = parsed.port
@@ -194,7 +228,7 @@ def probe_proxy_or_raise(url: str, *, timeout: float = 0.5) -> None:
             f"whilly: Claude proxy unreachable at {url} ({exc.__class__.__name__}: {exc})\n"
             f"Hint: bring up the SSH tunnel first, e.g.:\n"
             f"  ssh -fN -L {port}:127.0.0.1:8888 gpt-proxy\n"
-            f"To skip this check: {WHILLY_PROBE_ENV}=0"
+            f"To skip this check: {WHILLY_PROXY_PROBE_ENV}=0"
         ) from exc
 
 
@@ -203,9 +237,11 @@ __all__ = [
     "INHERITED_HTTPS_PROXY_ENV",
     "ProxySettings",
     "WHILLY_NO_PROXY_ENV",
-    "WHILLY_PROBE_ENV",
+    "WHILLY_PROXY_PROBE_ENV",
     "WHILLY_PROXY_URL_ENV",
     "build_subprocess_env",
     "probe_proxy_or_raise",
     "resolve_proxy_settings",
+    "should_probe",
+    "spawn_env_for_claude",
 ]

--- a/whilly/cli/init.py
+++ b/whilly/cli/init.py
@@ -33,6 +33,8 @@ import sys
 from pathlib import Path
 from typing import Sequence
 
+from whilly.adapters.runner import proxy
+
 logger = logging.getLogger("whilly.cli.init")
 
 # Exit codes (kept identical to the v4 plan/run subcommands so a shell
@@ -273,19 +275,31 @@ def run_init_command(
     # confusing connection-refused buried inside Claude's HTTP client.
     # WHILLY_CLAUDE_PROXY_PROBE=0 opts out (e.g. weird proxies that
     # reject TCP probes; we trust the operator).
-    from whilly.adapters.runner import proxy as _proxy
-
-    _settings = _proxy.resolve_proxy_settings(
+    proxy_settings = proxy.resolve_proxy_settings(
         cli_url=args.claude_proxy,
         cli_disabled=args.no_claude_proxy,
     )
-    if _settings.is_active and os.environ.get(_proxy.WHILLY_PROBE_ENV, "1") != "0":
+    proxy_url = proxy_settings.url
+    if proxy_url and proxy.should_probe():
         try:
-            assert _settings.url is not None
-            _proxy.probe_proxy_or_raise(_settings.url)
+            proxy.probe_proxy_or_raise(proxy_url)
         except RuntimeError as probe_exc:
             print(str(probe_exc), file=sys.stderr)
             return EXIT_ENVIRONMENT_ERROR
+
+    # Materialise the resolved CLI/env priority into ``os.environ`` so
+    # downstream re-resolves (in ``_call_claude`` / ``_spawn_and_collect``,
+    # which read ``os.environ`` only) see the same decision the probe was
+    # based on. ``WHILLY_CLAUDE_PROXY_URL`` is only read by Whilly's own
+    # ``resolve_proxy_settings`` — setting it has no behavioural effect on
+    # parent-process httpx. For ``--no-claude-proxy`` we additionally drop
+    # ``HTTPS_PROXY`` so the env-fallback branch in ``resolve_proxy_settings``
+    # doesn't re-introduce a proxy downstream against the operator's intent.
+    if proxy_url and args.claude_proxy:
+        os.environ[proxy.WHILLY_PROXY_URL_ENV] = args.claude_proxy
+    elif args.no_claude_proxy:
+        os.environ.pop(proxy.WHILLY_PROXY_URL_ENV, None)
+        os.environ.pop(proxy.INHERITED_HTTPS_PROXY_ENV, None)
 
     # ── Step 1: produce PRD file ────────────────────────────────────────
     try:

--- a/whilly/prd_generator.py
+++ b/whilly/prd_generator.py
@@ -24,6 +24,8 @@ import threading
 import time
 from pathlib import Path
 
+from whilly.adapters.runner import proxy
+
 log = logging.getLogger("whilly.prd")
 
 _PRD_SYSTEM_PROMPT = """\
@@ -399,10 +401,7 @@ def _call_claude(prompt: str, model: str) -> str:
     # The PRD-wizard caller (whilly init) holds Postgres / httpx
     # connections in this same parent process when the import phase
     # runs; we mustn't route those through the Claude proxy.
-    from whilly.adapters.runner import proxy as _proxy
-
-    _settings = _proxy.resolve_proxy_settings()
-    _child_env = _proxy.build_subprocess_env(os.environ, _settings)
+    child_env = proxy.spawn_env_for_claude()
 
     try:
         proc = subprocess.Popen(
@@ -410,7 +409,7 @@ def _call_claude(prompt: str, model: str) -> str:
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
-            env=_child_env,
+            env=child_env,
         )
     except FileNotFoundError:
         log.error("Claude CLI not found. Install: npm install -g @anthropic-ai/claude-code")


### PR DESCRIPTION
Simplify-skill review of TASK-109 Claude proxy work (5 commits, 7 files). Three review agents (reuse / quality / efficiency) flagged 8 issues; all fixed.

## Bug fix

**CLI flags didn't reach the spawn.** `--claude-proxy URL` and `--no-claude-proxy` were honoured by the startup probe in `run_init_command` but ignored downstream because `_call_claude` / `_spawn_and_collect` re-resolve from `os.environ` only. Tests passed because `headless_runner` was faked out. Fix: `run_init_command` now materialises the resolved settings into `os.environ` (`WHILLY_CLAUDE_PROXY_URL` set for `--claude-proxy`; `WHILLY_CLAUDE_PROXY_URL` + `HTTPS_PROXY` popped for `--no-claude-proxy`) so the spawn sites see the same decision the probe was based on. Two regression tests added.

## Cleanup

- `proxy.spawn_env_for_claude()` collapses the duplicated 2-line `resolve_proxy_settings()` + `build_subprocess_env(os.environ, …)` pattern in `claude_cli` and `prd_generator`.
- `proxy.should_probe()` owns the `WHILLY_CLAUDE_PROXY_PROBE=0` opt-out grammar.
- Replaced brittle `assert settings.url is not None` in `build_subprocess_env` with a real truthy-check branch (assertions get stripped under `python -O`).
- Renamed `WHILLY_PROBE_ENV` → `WHILLY_PROXY_PROBE_ENV` for symmetry with peer constants.
- Hoisted inline `from whilly.adapters.runner import proxy as _proxy` to top-level imports; dropped the `_proxy` private alias.
- `listening_port` / `closed_port` fixtures moved to `tests/unit/conftest.py` (auto-discovered).
- `FakePopen` consolidated into a `_make_fake_popen(captured)` factory.

## Verification

`ruff check` + `ruff format --check` clean; all 1,224 `tests/unit/` tests pass.