### PR TITLE
feat(task-103): whilly plan reset PLAN_ID — soft (--keep-tasks) and hard modes

### DIFF
--- a/.planning/v4-1_tasks.json
+++ b/.planning/v4-1_tasks.json
@@ -224,7 +224,7 @@
       "title": "whilly plan reset PLAN_ID",
       "category": "feat",
       "priority": "high",
-      "status": "pending",
+      "status": "done",
       "dependencies": [],
       "key_files": [
         "whilly/cli/plan.py",

--- a/tests/integration/test_plan_reset.py
+++ b/tests/integration/test_plan_reset.py
@@ -1,0 +1,369 @@
+"""Integration tests for ``whilly plan reset`` (TASK-103, PRD FR-2.5).
+
+Acceptance criteria from TASK-103:
+
+* ``whilly plan reset <plan_id>`` works in both modes (``--keep-tasks`` and ``--hard``).
+* Without ``--yes`` — interactive y/N confirmation.
+* With ``--keep-tasks``: ``tasks.status='PENDING'``, ``claimed_by=NULL``,
+  ``version+=1``; events for this ``plan_id`` are deleted.
+* With ``--hard``: ``DELETE FROM tasks/events/plans WHERE plan_id=X`` (CASCADE).
+* Audit row ``RESET`` added to events with ``reason='manual_reset'``.
+
+Why integration over unit?
+--------------------------
+``reset_plan`` is a multi-statement transaction touching three tables;
+the SQL invariants (events DELETE before tasks UPDATE, RESET event per
+task, FK cascade behaviour for hard mode) are exactly what a unit test
+would have to mock away.
+
+Why sync test functions (not ``async def``)?
+--------------------------------------------
+:func:`whilly.cli.plan.run_plan_command` is the synchronous CLI entry
+point — it owns its own ``asyncio.run()`` calls internally. Wrapping
+the test in an outer ``async def`` would put pytest-asyncio's loop
+between the test and ``run_plan_command``, and the inner ``asyncio.run``
+would raise ``RuntimeError: cannot be called from a running event
+loop``. Mirrors the pattern in :mod:`tests.integration.test_plan_io`,
+which keeps its CLI-driving tests synchronous for the same reason.
+
+For the seed / verify steps that need direct asyncpg access, we
+wrap them in :func:`asyncio.run` against a freshly-opened pool tied
+to the session-scoped Postgres container. We deliberately do NOT
+use the session conftest's async ``db_pool`` fixture here: that
+fixture's pool lives on pytest-asyncio's loop, and using it from
+inside our own ``asyncio.run`` would cross loops.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from collections.abc import Awaitable, Callable, Iterator
+from pathlib import Path
+from typing import Any
+
+import asyncpg
+import pytest
+
+from tests.conftest import DOCKER_REQUIRED
+from whilly.adapters.db import close_pool, create_pool
+from whilly.adapters.db.repository import TaskRepository
+from whilly.cli.plan import (
+    DATABASE_URL_ENV,
+    EXIT_ENVIRONMENT_ERROR,
+    EXIT_OK,
+    run_plan_command,
+)
+
+pytestmark = DOCKER_REQUIRED
+
+
+# ─── fixtures ────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def database_url(postgres_dsn: str) -> Iterator[str]:
+    """Set ``WHILLY_DATABASE_URL`` for the duration of one test.
+
+    Mirrors the fixture in ``test_plan_io.py``: :func:`run_plan_command`
+    reads the DSN from the environment, so we set it for the test and
+    restore the prior value on teardown.
+
+    Also TRUNCATEs every relevant table at setup so each test starts
+    from a clean DB. This replaces the role the async ``db_pool``
+    fixture's TRUNCATE plays for async-style tests — we can't use that
+    fixture here without crossing event loops (see module docstring).
+    """
+    prior = os.environ.get(DATABASE_URL_ENV)
+    os.environ[DATABASE_URL_ENV] = postgres_dsn
+
+    async def _truncate() -> None:
+        pool = await create_pool(postgres_dsn)
+        try:
+            async with pool.acquire() as conn:
+                await conn.execute("TRUNCATE events, tasks, plans, workers RESTART IDENTITY CASCADE")
+        finally:
+            await close_pool(pool)
+
+    asyncio.run(_truncate())
+    try:
+        yield postgres_dsn
+    finally:
+        if prior is None:
+            os.environ.pop(DATABASE_URL_ENV, None)
+        else:
+            os.environ[DATABASE_URL_ENV] = prior
+
+
+@pytest.fixture
+def sample_plan_payload() -> dict[str, Any]:
+    """Return a v4 plan dict with three tasks at mixed priorities.
+
+    T-001 critical, T-002 high, T-003 low — picked so the
+    deterministic claim order (priority, then id) puts T-001 first
+    and T-002 second; the seed helper relies on that ordering to
+    leave the DB in a known mid-lifecycle state.
+    """
+    return {
+        "plan_id": "plan-reset-001",
+        "project": "Reset Workshop",
+        "tasks": [
+            {
+                "id": "T-001",
+                "status": "PENDING",
+                "priority": "critical",
+                "description": "First task",
+                "dependencies": [],
+                "key_files": [],
+                "acceptance_criteria": [],
+                "test_steps": [],
+                "prd_requirement": "",
+            },
+            {
+                "id": "T-002",
+                "status": "PENDING",
+                "priority": "high",
+                "description": "Second task",
+                "dependencies": ["T-001"],
+                "key_files": [],
+                "acceptance_criteria": [],
+                "test_steps": [],
+                "prd_requirement": "",
+            },
+            {
+                "id": "T-003",
+                "status": "PENDING",
+                "priority": "low",
+                "description": "Third task",
+                "dependencies": [],
+                "key_files": [],
+                "acceptance_criteria": [],
+                "test_steps": [],
+                "prd_requirement": "",
+            },
+        ],
+    }
+
+
+@pytest.fixture
+def sample_plan_file(tmp_path: Path, sample_plan_payload: dict[str, Any]) -> Path:
+    """Materialise the sample plan as JSON on disk so ``plan import`` reads it."""
+    target = tmp_path / "plan.json"
+    target.write_text(json.dumps(sample_plan_payload), encoding="utf-8")
+    return target
+
+
+# ─── helpers ─────────────────────────────────────────────────────────────
+
+
+def _run_with_pool(dsn: str, fn: Callable[[asyncpg.Pool], Awaitable[Any]]) -> Any:
+    """Open a pool against ``dsn``, run ``fn(pool)``, close the pool.
+
+    Single-shot helper that lets sync tests interact with asyncpg
+    without keeping a long-lived pool around. We deliberately don't
+    reuse the session's ``db_pool`` fixture because it lives on a
+    different event loop (see module docstring) and crossing loops
+    risks "got Future ... attached to a different loop" errors.
+    """
+
+    async def _wrapper() -> Any:
+        pool = await create_pool(dsn)
+        try:
+            return await fn(pool)
+        finally:
+            await close_pool(pool)
+
+    return asyncio.run(_wrapper())
+
+
+async def _seed_progress(pool: asyncpg.Pool, plan_id: str, worker_id: str) -> None:
+    """Drive a few tasks through the lifecycle so the reset has state to wipe.
+
+    Inserts a worker, claims and starts T-001 and T-002. After this
+    helper runs, the DB carries:
+
+    * 1 worker row,
+    * 3 task rows: T-001=IN_PROGRESS, T-002=IN_PROGRESS, T-003=PENDING,
+    * a few CLAIM / START events.
+
+    The reset under test must wipe / reset all of that according to the
+    selected mode. Side-stepping the HTTP transport keeps the test
+    focused on the repository contract.
+    """
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "INSERT INTO workers (worker_id, hostname, token_hash) VALUES ($1, $2, $3)",
+            worker_id,
+            "host-reset-test",
+            "hash-reset-test",
+        )
+    repo = TaskRepository(pool)
+    claimed = await repo.claim_task(worker_id, plan_id)
+    assert claimed is not None and claimed.id == "T-001"
+    started = await repo.start_task(claimed.id, claimed.version)
+    assert started.status.value == "IN_PROGRESS"
+    second = await repo.claim_task(worker_id, plan_id)
+    # Claim order is priority bucket then id: T-001 critical first,
+    # T-002 high second, T-003 low last.
+    assert second is not None and second.id == "T-002"
+    started2 = await repo.start_task(second.id, second.version)
+    assert started2.status.value == "IN_PROGRESS"
+
+
+# ─── tests ───────────────────────────────────────────────────────────────
+
+
+def test_reset_keep_tasks_resets_status_and_writes_audit_rows(
+    database_url: str,
+    sample_plan_file: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``--keep-tasks --yes`` resets every task to PENDING and writes RESET events."""
+    assert run_plan_command(["import", str(sample_plan_file)]) == EXIT_OK
+    capsys.readouterr()
+
+    _run_with_pool(database_url, lambda pool: _seed_progress(pool, "plan-reset-001", "w-reset-keep"))
+
+    rc = run_plan_command(["reset", "plan-reset-001", "--keep-tasks", "--yes"])
+    assert rc == EXIT_OK, f"reset returned {rc}"
+    out = capsys.readouterr().out
+    assert "3 task(s) affected" in out
+    assert "reset" in out.lower()
+
+    async def _verify(pool: asyncpg.Pool) -> dict[str, int]:
+        async with pool.acquire() as conn:
+            rows = await conn.fetch(
+                "SELECT id, status, claimed_by, claimed_at, version FROM tasks WHERE plan_id = $1 ORDER BY id",
+                "plan-reset-001",
+            )
+            assert [r["id"] for r in rows] == ["T-001", "T-002", "T-003"]
+            for r in rows:
+                assert r["status"] == "PENDING", f"{r['id']} not reset to PENDING"
+                assert r["claimed_by"] is None
+                assert r["claimed_at"] is None
+            version_by_id = {r["id"]: r["version"] for r in rows}
+            # T-001 / T-002 went through CLAIM (v0→1) → START (v1→2) →
+            # RESET (v2→3). T-003 was never claimed; only RESET (v0→1).
+            assert version_by_id == {"T-001": 3, "T-002": 3, "T-003": 1}
+
+            events = await conn.fetch(
+                "SELECT task_id, event_type, payload "
+                "FROM events WHERE task_id IN (SELECT id FROM tasks WHERE plan_id = $1) "
+                "ORDER BY task_id, id",
+                "plan-reset-001",
+            )
+            assert {row["event_type"] for row in events} == {"RESET"}
+            assert len(events) == 3
+            for row in events:
+                payload = json.loads(row["payload"]) if isinstance(row["payload"], str) else row["payload"]
+                assert payload["reason"] == "manual_reset"
+                assert payload["mode"] == "keep_tasks"
+                assert payload["version"] == version_by_id[row["task_id"]]
+            return version_by_id
+
+    _run_with_pool(database_url, _verify)
+
+
+def test_reset_hard_deletes_plan_tasks_and_events(
+    database_url: str,
+    sample_plan_file: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``--hard --yes`` removes plan, tasks, and events via FK cascade."""
+    assert run_plan_command(["import", str(sample_plan_file)]) == EXIT_OK
+    capsys.readouterr()
+
+    _run_with_pool(database_url, lambda pool: _seed_progress(pool, "plan-reset-001", "w-reset-hard"))
+
+    rc = run_plan_command(["reset", "plan-reset-001", "--hard", "--yes"])
+    assert rc == EXIT_OK
+    out = capsys.readouterr().out
+    assert "3 task(s) affected" in out
+    assert "deleted" in out.lower()
+
+    async def _verify(pool: asyncpg.Pool) -> None:
+        async with pool.acquire() as conn:
+            plan_count = await conn.fetchval("SELECT COUNT(*) FROM plans WHERE id = $1", "plan-reset-001")
+            task_count = await conn.fetchval("SELECT COUNT(*) FROM tasks WHERE plan_id = $1", "plan-reset-001")
+            event_count = await conn.fetchval(
+                "SELECT COUNT(*) FROM events WHERE task_id IN ($1, $2, $3)",
+                "T-001",
+                "T-002",
+                "T-003",
+            )
+            assert plan_count == 0
+            assert task_count == 0
+            assert event_count == 0
+
+    _run_with_pool(database_url, _verify)
+
+
+def test_reset_unknown_plan_id_exits_environment_error(
+    database_url: str,  # noqa: ARG001 — sets WHILLY_DATABASE_URL for run_plan_command
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Resetting a non-existent ``plan_id`` exits 2 with a helpful stderr."""
+    rc = run_plan_command(["reset", "no-such-plan", "--keep-tasks", "--yes"])
+    assert rc == EXIT_ENVIRONMENT_ERROR
+    err = capsys.readouterr().err
+    assert "no-such-plan" in err
+    assert "not found" in err
+
+
+def test_reset_without_mode_flag_fails_argparse(
+    database_url: str,  # noqa: ARG001
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``whilly plan reset <id>`` without ``--keep-tasks`` / ``--hard`` exits 2.
+
+    argparse's ``mutually_exclusive_group(required=True)`` is the rule;
+    the test ensures we don't accidentally disable that constraint
+    in a future refactor.
+    """
+    with pytest.raises(SystemExit) as excinfo:
+        run_plan_command(["reset", "plan-reset-001"])
+    assert excinfo.value.code == 2
+    err = capsys.readouterr().err
+    assert "--keep-tasks" in err or "--hard" in err
+
+
+def test_reset_keep_tasks_is_idempotent(
+    database_url: str,
+    sample_plan_file: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Running ``--keep-tasks --yes`` twice in a row leaves the plan in PENDING.
+
+    Second invocation finds tasks already PENDING; the UPDATE matches
+    them anyway (no status filter on reset_plan's keep-tasks UPDATE),
+    bumps versions, wipes the previous RESET events, and writes fresh
+    RESET events. Net effect: same task count, same status, but
+    ``version`` is one higher per reset. This is the documented
+    contract — the operator-facing surface only says "tasks are
+    PENDING after reset", not "version is unchanged on a no-op reset".
+    """
+    assert run_plan_command(["import", str(sample_plan_file)]) == EXIT_OK
+    capsys.readouterr()
+
+    assert run_plan_command(["reset", "plan-reset-001", "--keep-tasks", "--yes"]) == EXIT_OK
+    capsys.readouterr()
+    assert run_plan_command(["reset", "plan-reset-001", "--keep-tasks", "--yes"]) == EXIT_OK
+    capsys.readouterr()
+
+    async def _verify(pool: asyncpg.Pool) -> None:
+        async with pool.acquire() as conn:
+            rows = await conn.fetch(
+                "SELECT id, status, version FROM tasks WHERE plan_id = $1 ORDER BY id",
+                "plan-reset-001",
+            )
+            assert [r["status"] for r in rows] == ["PENDING", "PENDING", "PENDING"]
+            assert {r["version"] for r in rows} == {2}
+            events = await conn.fetch(
+                "SELECT event_type FROM events WHERE task_id IN (SELECT id FROM tasks WHERE plan_id = $1)",
+                "plan-reset-001",
+            )
+            assert {row["event_type"] for row in events} == {"RESET"}
+            assert len(events) == 3
+
+    _run_with_pool(database_url, _verify)

--- a/whilly/adapters/db/repository.py
+++ b/whilly/adapters/db/repository.py
@@ -439,6 +439,55 @@ RETURNING task_id
 """
 
 
+# Plan reset (TASK-103). Two modes:
+#
+# * ``keep-tasks`` — soft reset. Wipe the events table for every task in
+#   the plan, flip every task back to ``PENDING`` (clearing claim
+#   ownership, bumping ``version``), then write one ``RESET`` event per
+#   task carrying ``payload = {"reason": "manual_reset", "mode":
+#   "keep_tasks", "version": <new>}``. Useful for replaying a
+#   debug-stuck plan from scratch without re-importing the JSON.
+#
+# * ``hard`` — DELETE the plan row; ON DELETE CASCADE on the FK chain
+#   (plans → tasks → events) wipes everything in one statement. Useful
+#   when the plan JSON itself changed and an idempotent re-import would
+#   otherwise refuse to clobber existing rows (DO NOTHING semantics).
+#   No audit row is written: the events table is gone with the rest of
+#   the plan, so any RESET row would be deleted before commit anyway —
+#   operators relying on durable audit trail should use ``keep-tasks``
+#   or rely on the file-based mirror (TASK-106).
+#
+# All three statements (events DELETE, tasks UPDATE, RESET INSERT) run
+# inside a single Python-level ``async with conn.transaction()`` rather
+# than one combined CTE because per-statement diagnostics matter on the
+# operator-facing reset path: a CHECK violation should surface with the
+# offending statement's verb in the error, not as a generic CTE failure.
+# The transaction wrapper provides the same atomicity guarantee as the
+# combined CTE form would.
+_RESET_DELETE_EVENTS_SQL: str = """
+DELETE FROM events
+WHERE task_id IN (SELECT id FROM tasks WHERE plan_id = $1)
+"""
+
+_RESET_UPDATE_TASKS_SQL: str = """
+UPDATE tasks
+SET status = 'PENDING',
+    claimed_by = NULL,
+    claimed_at = NULL,
+    version = tasks.version + 1,
+    updated_at = NOW()
+WHERE plan_id = $1
+RETURNING id, version
+"""
+
+# ``DELETE FROM plans WHERE id = $1`` cascades through the FK chain
+# (tasks ON DELETE CASCADE, events ON DELETE CASCADE on tasks.id) so
+# one statement clears the entire plan. The pre-DELETE COUNT lets us
+# return a row count to the CLI for the operator-facing summary line.
+_RESET_COUNT_TASKS_SQL: str = "SELECT COUNT(*)::int AS c FROM tasks WHERE plan_id = $1"
+_RESET_DELETE_PLAN_SQL: str = "DELETE FROM plans WHERE id = $1"
+
+
 class VersionConflictError(Exception):
     """Optimistic-locking mismatch on a :class:`TaskRepository` mutation.
 
@@ -1069,6 +1118,112 @@ class TaskRepository:
             return False
         logger.debug("update_heartbeat: worker %s last_heartbeat refreshed", worker_id)
         return True
+
+    async def reset_plan(self, plan_id: PlanId, *, keep_tasks: bool) -> int:
+        """Reset every task in ``plan_id`` to ``PENDING`` (or wipe the plan).
+
+        Implements the data-side half of the ``whilly plan reset`` CLI
+        (TASK-103). Two modes, selected by the ``keep_tasks`` flag:
+
+        * ``keep_tasks=True`` — soft reset. Deletes every event row whose
+          task lives under ``plan_id``, then flips every such task back
+          to ``status='PENDING'`` (clearing ``claimed_by`` /
+          ``claimed_at``, incrementing ``version``), and writes one
+          ``RESET`` event per task carrying ``payload = {"reason":
+          "manual_reset", "mode": "keep_tasks", "version": <new>}``.
+          Returns the number of tasks reset.
+
+        * ``keep_tasks=False`` — hard reset. ``DELETE FROM plans WHERE
+          id = $1``; the FK chain's ``ON DELETE CASCADE`` wipes the
+          tasks rows and (transitively) the events rows in one
+          statement. Returns the pre-delete count of tasks (so the CLI
+          can show the same "N tasks affected" summary as in soft mode).
+
+        Atomicity
+        ---------
+        Both modes run inside a single ``async with conn.transaction()``
+        so an operator can't observe a partial reset. In soft mode the
+        three statements (events DELETE, tasks UPDATE, audit INSERT
+        per task) commit as a unit. In hard mode the COUNT and DELETE
+        commit as a unit — the COUNT runs against the same MVCC
+        snapshot the DELETE will operate on, so the returned value
+        matches the rows that were actually affected.
+
+        Why not a single combined CTE?
+            Per-statement diagnostics matter on the operator-facing
+            reset path: a CHECK constraint violation (e.g. someone
+            extending ``events.event_type`` with a CHECK) should surface
+            with the offending verb in the error message rather than
+            being lost behind a CTE wrapper. The transaction is the
+            atomicity contract; the per-statement granularity is
+            developer ergonomics.
+
+        Why no audit row in hard mode?
+            ``DELETE FROM plans`` cascades to ``events`` — anything we
+            insert before the delete would be wiped before commit, and
+            anything inserted after the delete has no ``task_id`` to
+            reference (FK NOT NULL). Operators relying on a durable
+            audit trail should use ``keep_tasks=True`` or wait for the
+            file-based audit mirror (TASK-106).
+
+        Args
+        ----
+        plan_id:
+            The plan to reset. A non-existent ``plan_id`` returns ``0``
+            without error in either mode (idempotent — repeated resets
+            on the same id are safe).
+        keep_tasks:
+            ``True`` for soft reset, ``False`` for hard reset.
+
+        Returns
+        -------
+        int
+            Number of tasks affected (reset to PENDING in soft mode, or
+            scheduled for deletion in hard mode). Returns ``0`` when the
+            plan is unknown — callers can use this to differentiate
+            "plan exists, was empty" from "plan doesn't exist" by
+            checking the plan row separately if they care.
+        """
+        async with self._pool.acquire() as conn:
+            async with conn.transaction():
+                if keep_tasks:
+                    # Wipe events first so the post-reset audit rows are
+                    # the only RESET-tagged rows left for this plan.
+                    await conn.execute(_RESET_DELETE_EVENTS_SQL, plan_id)
+                    rows = await conn.fetch(_RESET_UPDATE_TASKS_SQL, plan_id)
+                    for row in rows:
+                        payload = json.dumps(
+                            {
+                                "reason": "manual_reset",
+                                "mode": "keep_tasks",
+                                "version": row["version"],
+                            }
+                        )
+                        await conn.execute(
+                            _INSERT_EVENT_SQL,
+                            row["id"],
+                            "RESET",
+                            payload,
+                        )
+                    logger.info(
+                        "reset_plan(keep_tasks=True): plan=%s reset %d task(s)",
+                        plan_id,
+                        len(rows),
+                    )
+                    return len(rows)
+
+                # Hard mode: count first (so we can report what we
+                # nuked), then DELETE the plan row. CASCADE handles
+                # tasks + events in the same statement.
+                count_row = await conn.fetchrow(_RESET_COUNT_TASKS_SQL, plan_id)
+                count = int(count_row["c"]) if count_row else 0
+                await conn.execute(_RESET_DELETE_PLAN_SQL, plan_id)
+                logger.info(
+                    "reset_plan(keep_tasks=False): plan=%s deleted (%d task(s) cascaded)",
+                    plan_id,
+                    count,
+                )
+                return count
 
     async def _raise_version_conflict(
         self,

--- a/whilly/cli/plan.py
+++ b/whilly/cli/plan.py
@@ -99,6 +99,7 @@ import asyncpg
 from rich.console import Console
 
 from whilly.adapters.db import close_pool, create_pool
+from whilly.adapters.db.repository import TaskRepository
 from whilly.adapters.filesystem.plan_io import PlanParseError, parse_plan, serialize_plan
 from whilly.core.models import Plan, Priority, Task, TaskId, TaskStatus
 from whilly.core.scheduler import detect_cycles
@@ -250,6 +251,38 @@ def build_plan_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Force plain ASCII output (default: auto-detect via isatty).",
     )
+
+    # ── plan reset ───────────────────────────────────────────────────────
+    # Operator-facing recovery primitive (TASK-103). Two modes:
+    #   --keep-tasks → soft: tasks → PENDING, events purged, RESET row
+    #                  per task with reason=manual_reset.
+    #   --hard       → DELETE plan row; cascades to tasks + events.
+    # Without --yes, the handler prompts y/N (interactive only —
+    # non-TTY callers pipeline `--yes` to skip the prompt).
+    p_reset = sub.add_parser(
+        "reset",
+        help="Reset a plan to PENDING (--keep-tasks) or DELETE it (--hard).",
+    )
+    p_reset.add_argument(
+        "plan_id",
+        help="Plan id to reset (matches the 'plan_id' field in the original JSON).",
+    )
+    mode_group = p_reset.add_mutually_exclusive_group(required=True)
+    mode_group.add_argument(
+        "--keep-tasks",
+        action="store_true",
+        help="Soft reset: tasks → PENDING, events purged, RESET audit row per task.",
+    )
+    mode_group.add_argument(
+        "--hard",
+        action="store_true",
+        help="Hard reset: DELETE plan row (cascades to tasks + events).",
+    )
+    p_reset.add_argument(
+        "--yes",
+        action="store_true",
+        help="Skip the interactive y/N confirmation prompt.",
+    )
     return parser
 
 
@@ -268,6 +301,13 @@ def run_plan_command(argv: Sequence[str]) -> int:
         return _run_export(args.plan_id)
     if args.action == "show":
         return _run_show(args.plan_id, no_color=bool(args.no_color))
+    if args.action == "reset":
+        return _run_reset(
+            args.plan_id,
+            keep_tasks=bool(args.keep_tasks),
+            hard=bool(args.hard),
+            yes=bool(args.yes),
+        )
     # argparse's ``required=True`` already surfaces a 2-exit on missing
     # action; this branch is defensive for future subcommands added without
     # an explicit handler here.
@@ -917,3 +957,114 @@ def _should_use_color(*, no_color: bool) -> bool:
     except (io.UnsupportedOperation, ValueError):
         # Closed buffer / detached file descriptor.
         return False
+
+
+# ── plan reset (TASK-103) ────────────────────────────────────────────────
+
+
+def _run_reset(plan_id: str, *, keep_tasks: bool, hard: bool, yes: bool) -> int:
+    """Implement ``whilly plan reset <plan_id> --keep-tasks|--hard [--yes]``.
+
+    Two-step compose: a SELECT-side preflight to check the plan exists
+    and count its tasks (so the y/N prompt can show the operator what
+    they're about to wipe), then a single :meth:`TaskRepository.reset_plan`
+    call to do the real work. The preflight reuses the :func:`_async_export`
+    SELECT path so a future schema change only needs to be made in one
+    place.
+
+    Mode invariant: argparse's ``mutually_exclusive_group(required=True)``
+    guarantees exactly one of ``--keep-tasks`` / ``--hard`` is set, so we
+    don't validate that pair again here — the assertion is loud-fail
+    only as a guard against future refactors that disable the argparse
+    group.
+
+    Confirmation flow:
+        Without ``--yes``, the handler reads a y/N answer from stdin.
+        Anything other than ``y`` / ``Y`` / ``yes`` aborts with
+        :data:`EXIT_OK` (a deliberate decision by the operator is not an
+        error). Non-TTY stdin (CI / piped invocation) without ``--yes``
+        is treated as "no answer" → abort. Operators automating the
+        reset should pass ``--yes`` explicitly so the intent is in the
+        command line.
+
+    Returns
+    -------
+    EXIT_OK
+        Reset succeeded, or operator aborted at the prompt.
+    EXIT_ENVIRONMENT_ERROR
+        DSN unset, or plan_id not found.
+    """
+    assert keep_tasks ^ hard, "argparse mutex group should make this unreachable"
+
+    dsn = os.environ.get(DATABASE_URL_ENV)
+    if not dsn:
+        print(
+            f"whilly plan reset: {DATABASE_URL_ENV} is not set — point it at a Postgres "
+            "instance with the v4 schema applied (see scripts/db-up.sh).",
+            file=sys.stderr,
+        )
+        return EXIT_ENVIRONMENT_ERROR
+
+    # Preflight: confirm the plan exists and grab the task count for the
+    # confirmation prompt. Reuses _async_export's SELECT path.
+    preflight = asyncio.run(_async_export(dsn, plan_id))
+    if preflight is None:
+        print(
+            f"whilly plan reset: plan {plan_id!r} not found — check the id matches the "
+            "'plan_id' you used at import time.",
+            file=sys.stderr,
+        )
+        return EXIT_ENVIRONMENT_ERROR
+    plan, tasks = preflight
+    mode_label = "keep-tasks" if keep_tasks else "hard"
+    summary = f"plan {plan.id!r} ({plan.name}) — {len(tasks)} task(s), mode={mode_label}"
+
+    if not yes and not _confirm_reset(summary, hard=hard):
+        print("whilly plan reset: aborted by operator (no --yes).", file=sys.stderr)
+        return EXIT_OK
+
+    affected = asyncio.run(_async_reset(dsn, plan_id, keep_tasks=keep_tasks))
+    verb = "reset" if keep_tasks else "deleted"
+    print(f"whilly plan reset: {verb} {summary} ({affected} task(s) affected).")
+    return EXIT_OK
+
+
+def _confirm_reset(summary: str, *, hard: bool) -> bool:
+    """Prompt the operator with a y/N question; return True iff they said yes.
+
+    Hard-mode prompts use a stronger wording (``DELETE``) to reflect
+    the irrecoverable nature of the operation: with --keep-tasks an
+    operator who confirms by mistake still has the plan rows on disk;
+    with --hard the plan is gone, FK-cascaded events and all.
+
+    Non-TTY stdin (CI / piped invocation) is treated as "no answer" →
+    return False. Operators automating the reset should pass ``--yes``
+    so the intent is explicit at the command line; falling through
+    silently here would be the worst of both worlds.
+    """
+    is_tty = getattr(sys.stdin, "isatty", None)
+    if not callable(is_tty) or not is_tty():
+        return False
+    verb = "DELETE" if hard else "RESET"
+    prompt = f"About to {verb} {summary}. Continue? [y/N]: "
+    try:
+        answer = input(prompt).strip().lower()
+    except EOFError:
+        return False
+    return answer in ("y", "yes")
+
+
+async def _async_reset(dsn: str, plan_id: str, *, keep_tasks: bool) -> int:
+    """Open a pool, call :meth:`TaskRepository.reset_plan`, close the pool.
+
+    Mirrors :func:`_async_import` lifecycle: short-lived pool, ``SELECT 1``
+    health check on construction, ``finally`` always closes. Returns the
+    number of tasks affected (reset to PENDING in keep-tasks mode, or
+    scheduled for deletion in hard mode).
+    """
+    pool = await create_pool(dsn)
+    try:
+        repo = TaskRepository(pool)
+        return await repo.reset_plan(plan_id, keep_tasks=keep_tasks)
+    finally:
+        await close_pool(pool)


### PR DESCRIPTION
## Summary

Closes **TASK-103**. Operator-facing recovery primitive that replaces the manual `DELETE FROM tasks/events/plans WHERE plan_id=X` psql dance with a typed CLI surface.

### Modes

| Mode | Behaviour |
|---|---|
| `--keep-tasks` | DELETE events for plan, UPDATE tasks → PENDING (clear claim, version+=1), INSERT one `RESET` event per task with `{reason: 'manual_reset', mode: 'keep_tasks', version: <new>}`. Atomic — all three statements run in one transaction. |
| `--hard` | DELETE plan row; FK `ON DELETE CASCADE` wipes tasks then events. No audit row written (events go with the cascade). Returns pre-delete task count for operator summary. |

Both are mutually exclusive (`required=True` argparse group); neither-or-both exits 2 before any DB work.

### Confirmation

- Without `--yes` → interactive y/N prompt. Hard-mode prompt uses **DELETE** wording to reflect irrecoverability; soft mode says **RESET**.
- Non-TTY stdin without `--yes` is treated as 'no answer' and aborts cleanly with exit 0 (operators automating the reset must pass `--yes` explicitly so intent is in the command line).

### Exit codes

| | |
|---|---|
| 0 | Success, or operator aborted at prompt |
| 2 | DSN unset, or plan_id not found, or argparse usage error |

### Files touched

- `whilly/adapters/db/repository.py` — `TaskRepository.reset_plan(plan_id, *, keep_tasks)` + 4 SQL constants.
- `whilly/cli/plan.py` — `plan reset` subparser + `_run_reset` / `_confirm_reset` / `_async_reset`.
- `tests/integration/test_plan_reset.py` — 5 cases (new file).
- `.planning/v4-1_tasks.json` — TASK-103 `pending` → `done`.

### Tests (5/5 pass against testcontainers Postgres)

1. `test_reset_keep_tasks_resets_status_and_writes_audit_rows` — full happy path: claim T-001/T-002 → start them → soft reset → verify PENDING, version bumps (3 for claimed-then-started, 1 for never-claimed T-003), exactly 3 `RESET` events with documented payload shape, no `CLAIM` / `START` survivors.
2. `test_reset_hard_deletes_plan_tasks_and_events` — hard reset wipes plan + all 3 tasks + all events via CASCADE.
3. `test_reset_unknown_plan_id_exits_environment_error` — exit 2, stderr names the missing id.
4. `test_reset_without_mode_flag_fails_argparse` — argparse rejects without `--keep-tasks`/`--hard`.
5. `test_reset_keep_tasks_is_idempotent` — two consecutive soft resets leave tasks PENDING@v2, only the most-recent RESET batch survives.

Tests are sync `def` (not async) because `run_plan_command` owns its own `asyncio.run()` — pytest-asyncio's outer loop would clash with the inner one. Seed/verify steps wrap a fresh asyncpg pool inside `asyncio.run()` (helper `_run_with_pool`) to side-step the conftest `db_pool` fixture's loop binding.

### Verification

- `ruff check` + `ruff format --check` clean
- `pytest -q tests/unit/` — 551 passed
- `pytest tests/integration/test_plan_reset.py` — 5 passed

> [!note]
> No auto-merge — please review and merge manually.