### PR TITLE
feat(task-104b): per-task TRIZ contradiction analyzer + events.detail JSONB + WHILLY_TRIZ_ENABLED hook

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -29,3 +29,10 @@ forbidden_modules =
 ignore_imports =
     # whilly.core may use stdlib `os` for os.path utilities, but tests assert
     # no os.chdir / os.getcwd call sites via grep in CI (see TASK-029).
+    # whilly.core.triz is granted a documented exception to use subprocess /
+    # shutil because the per-task TRIZ analyzer (TASK-104b) is pinned to
+    # ``whilly/core/triz.py`` by the validation contract (VAL-TRIZ-006:
+    # ``subprocess.run`` calls observable inside the module). The rest of
+    # whilly.core stays pure — this exception is intentionally narrow.
+    whilly.core.triz -> subprocess
+    whilly.core.triz -> shutil

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,9 @@ target-version = "py312"
 pythonpath = ["."]
 testpaths = ["tests"]
 asyncio_mode = "auto"
+markers = [
+    "live_llm: live-LLM smoke test gated by WHILLY_RUN_LIVE_LLM=1 (TASK-104b)",
+]
 
 [tool.mypy]
 python_version = "3.12"

--- a/tests/integration/test_triz_hook.py
+++ b/tests/integration/test_triz_hook.py
@@ -1,0 +1,493 @@
+"""Integration tests for the TRIZ executor hook (TASK-104b).
+
+Mirrors VAL-TRIZ-001/002/004/008/009/010/011/015 in
+``validation-contract.md``. Each test exercises the real
+:meth:`TaskRepository.fail_task` against a testcontainers Postgres
+seeded with a healthy plan + one CLAIMED task. The TRIZ subprocess
+itself is mocked via :func:`monkeypatch.setattr` on
+``whilly.core.triz.subprocess.run`` (and ``shutil.which``); the
+``WHILLY_TRIZ_ENABLED`` env var is toggled per test to exercise the
+gate.
+
+Why integration vs. unit?
+-------------------------
+The hook composes ``fail_task``'s state-machine transition, the
+``events.detail`` JSONB column write (VAL-TRIZ-008 / VAL-TRIZ-009),
+and the ordering invariant between the FAIL row and the
+``triz.contradiction`` row (VAL-TRIZ-010). Only a real database
+exercises every piece end-to-end.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+import logging
+import subprocess
+from typing import Any
+
+import asyncpg
+import pytest
+
+from tests.conftest import DOCKER_REQUIRED
+from whilly.adapters.db.repository import TaskRepository
+from whilly.core.models import TaskStatus
+
+pytestmark = DOCKER_REQUIRED
+
+
+PLAN_ID = "PLAN-TRIZ-001"
+TASK_ID = "T-TRIZ-001"
+WORKER_ID = "w-triz-1"
+
+
+# ─── seeding helpers ─────────────────────────────────────────────────────
+
+
+async def _seed_plan_task_worker(
+    pool: asyncpg.Pool,
+    *,
+    status: TaskStatus = TaskStatus.IN_PROGRESS,
+    description: str = "Cache must be both consistent and eventually-consistent.",
+    plan_id: str = PLAN_ID,
+    task_id: str = TASK_ID,
+    worker_id: str = WORKER_ID,
+    version: int = 1,
+) -> None:
+    """Insert one plan + one worker + one task in the requested status."""
+    async with pool.acquire() as conn:
+        await conn.execute("INSERT INTO plans (id, name) VALUES ($1, $2)", plan_id, "triz-test")
+        await conn.execute(
+            "INSERT INTO workers (worker_id, hostname, token_hash) VALUES ($1, $2, $3)",
+            worker_id,
+            "host",
+            "hash",
+        )
+        await conn.execute(
+            """
+            INSERT INTO tasks (
+                id, plan_id, status, dependencies, key_files,
+                priority, description, acceptance_criteria, test_steps,
+                prd_requirement, version, claimed_by, claimed_at
+            )
+            VALUES ($1, $2, $3, '[]'::jsonb, '[]'::jsonb,
+                    'medium', $4, '[]'::jsonb, '[]'::jsonb,
+                    '', $5, $6, NOW())
+            """,
+            task_id,
+            plan_id,
+            status.value,
+            description,
+            version,
+            worker_id,
+        )
+
+
+# ─── helpers / fixtures ──────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _enable_triz(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default-enable WHILLY_TRIZ_ENABLED for hook tests; individual tests opt out."""
+    monkeypatch.setenv("WHILLY_TRIZ_ENABLED", "1")
+    monkeypatch.setattr(
+        "whilly.core.triz.shutil.which",
+        lambda name: "/usr/bin/claude" if name == "claude" else None,
+    )
+
+
+def _make_recording_run(*, stdout: str = "", returncode: int = 0, raises: BaseException | None = None):  # type: ignore[no-untyped-def]
+    """Return a stub for ``subprocess.run`` that records calls + returns canned output."""
+    calls: list[tuple[Any, dict[str, Any]]] = []
+
+    def _stub(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        calls.append((args, kwargs))
+        if raises is not None:
+            raise raises
+        cmd = args[0] if args else kwargs.get("args")
+        return subprocess.CompletedProcess(args=cmd, returncode=returncode, stdout=stdout, stderr="")
+
+    _stub.calls = calls  # type: ignore[attr-defined]
+    return _stub
+
+
+# ─── VAL-TRIZ-008 / VAL-TRIZ-009: fail_task signature accepts detail kwarg ─
+
+
+def test_fail_task_signature_carries_keyword_only_detail() -> None:
+    """``fail_task`` exposes ``detail: dict | None = None`` as keyword-only."""
+    params = inspect.signature(TaskRepository.fail_task).parameters
+    assert "detail" in params
+    detail_param = params["detail"]
+    assert detail_param.kind == inspect.Parameter.KEYWORD_ONLY
+    assert detail_param.default is None
+
+
+# ─── VAL-TRIZ-008: detail dict round-trips into events.detail JSONB ─────
+
+
+async def test_fail_task_persists_detail_into_events_detail_column(
+    db_pool: asyncpg.Pool,
+    task_repo: TaskRepository,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``detail={'k': 'v'}`` round-trips as JSONB on the FAIL event row."""
+    # Disable TRIZ for this test — we only care about the FAIL row's detail.
+    monkeypatch.delenv("WHILLY_TRIZ_ENABLED", raising=False)
+    await _seed_plan_task_worker(db_pool)
+
+    updated = await task_repo.fail_task(TASK_ID, version=1, reason="boom", detail={"k": "v"})
+    assert updated.status == TaskStatus.FAILED
+
+    async with db_pool.acquire() as conn:
+        rows = await conn.fetch(
+            "SELECT detail, payload FROM events WHERE task_id=$1 AND event_type='FAIL'",
+            TASK_ID,
+        )
+    assert len(rows) == 1
+    detail = rows[0]["detail"]
+    if isinstance(detail, str):
+        detail = json.loads(detail)
+    assert detail == {"k": "v"}
+    payload = rows[0]["payload"]
+    if isinstance(payload, str):
+        payload = json.loads(payload)
+    assert payload["reason"] == "boom"
+
+
+# ─── VAL-TRIZ-009: detail=None round-trips as SQL NULL ──────────────────
+
+
+async def test_fail_task_without_detail_writes_sql_null(
+    db_pool: asyncpg.Pool,
+    task_repo: TaskRepository,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Omitting ``detail`` (or passing ``None``) writes SQL NULL — never literal ``null`` text or ``{}``."""
+    monkeypatch.delenv("WHILLY_TRIZ_ENABLED", raising=False)
+    await _seed_plan_task_worker(db_pool)
+
+    await task_repo.fail_task(TASK_ID, version=1, reason="boom")
+
+    async with db_pool.acquire() as conn:
+        is_null = await conn.fetchval(
+            "SELECT (detail IS NULL) FROM events WHERE task_id=$1 AND event_type='FAIL'",
+            TASK_ID,
+        )
+        text_value = await conn.fetchval(
+            "SELECT detail::text FROM events WHERE task_id=$1 AND event_type='FAIL'",
+            TASK_ID,
+        )
+    assert is_null is True
+    assert text_value is None  # not the string "null", not "{}"
+
+
+# ─── VAL-TRIZ-001: contradiction-finding TRIZ run writes triz.contradiction ─
+
+
+async def test_contradiction_finding_writes_triz_contradiction_event(
+    db_pool: asyncpg.Pool,
+    task_repo: TaskRepository,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Mocked TRIZ verdict carries into a separate ``triz.contradiction`` event row."""
+    payload = json.dumps(
+        {
+            "contradictory": True,
+            "contradiction_type": "technical",
+            "reason": (
+                "improving consistency worsens replica latency by an order of magnitude — "
+                "the cache cannot be both fully consistent and fast"
+            ),
+        }
+    )
+    monkeypatch.setattr("whilly.core.triz.subprocess.run", _make_recording_run(stdout=payload))
+    await _seed_plan_task_worker(db_pool)
+
+    await task_repo.fail_task(TASK_ID, version=1, reason="agent crashed")
+
+    async with db_pool.acquire() as conn:
+        rows = await conn.fetch(
+            "SELECT detail FROM events WHERE task_id=$1 AND event_type='triz.contradiction'",
+            TASK_ID,
+        )
+    assert len(rows) == 1
+    detail = rows[0]["detail"]
+    if isinstance(detail, str):
+        detail = json.loads(detail)
+    assert "contradiction_type" in detail
+    assert "reason" in detail
+    assert detail["contradiction_type"] == "technical"
+
+
+# ─── VAL-TRIZ-010: FAIL row precedes triz.contradiction row ─────────────
+
+
+async def test_fail_event_ordered_before_triz_contradiction(
+    db_pool: asyncpg.Pool,
+    task_repo: TaskRepository,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Both FAIL and triz.contradiction rows exist; FAIL ≤ triz in ``created_at``."""
+    payload = json.dumps(
+        {
+            "contradictory": True,
+            "contradiction_type": "technical",
+            "reason": "improving X worsens Y — clear technical contradiction",
+        }
+    )
+    monkeypatch.setattr("whilly.core.triz.subprocess.run", _make_recording_run(stdout=payload))
+    await _seed_plan_task_worker(db_pool)
+
+    await task_repo.fail_task(TASK_ID, version=1, reason="boom")
+
+    async with db_pool.acquire() as conn:
+        ordered = await conn.fetch(
+            """
+            SELECT event_type FROM events WHERE task_id=$1
+              AND event_type IN ('FAIL', 'triz.contradiction')
+            ORDER BY created_at ASC, id ASC
+            """,
+            TASK_ID,
+        )
+        status = await conn.fetchval("SELECT status FROM tasks WHERE id=$1", TASK_ID)
+    assert [r["event_type"] for r in ordered] == ["FAIL", "triz.contradiction"]
+    assert status == "FAILED"
+
+
+# ─── VAL-TRIZ-002: no contradiction → no triz event row ─────────────────
+
+
+async def test_no_contradiction_writes_no_triz_event(
+    db_pool: asyncpg.Pool,
+    task_repo: TaskRepository,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``contradictory: false`` → FAIL row only, zero triz.contradiction rows."""
+    payload = json.dumps({"contradictory": False, "contradiction_type": "", "reason": ""})
+    monkeypatch.setattr("whilly.core.triz.subprocess.run", _make_recording_run(stdout=payload))
+    await _seed_plan_task_worker(db_pool)
+
+    await task_repo.fail_task(TASK_ID, version=1, reason="boom")
+
+    async with db_pool.acquire() as conn:
+        triz_count = await conn.fetchval(
+            "SELECT COUNT(*) FROM events WHERE task_id=$1 AND event_type='triz.contradiction'",
+            TASK_ID,
+        )
+        fail_count = await conn.fetchval(
+            "SELECT COUNT(*) FROM events WHERE task_id=$1 AND event_type='FAIL'",
+            TASK_ID,
+        )
+        status = await conn.fetchval("SELECT status FROM tasks WHERE id=$1", TASK_ID)
+    assert triz_count == 0
+    assert fail_count == 1
+    assert status == "FAILED"
+
+
+# ─── VAL-TRIZ-004: timeout → triz.error event with reason='timeout' ─────
+
+
+async def test_subprocess_timeout_writes_triz_error_event(
+    db_pool: asyncpg.Pool,
+    task_repo: TaskRepository,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Subprocess TimeoutExpired → one triz.error row (reason='timeout'), no triz.contradiction."""
+    monkeypatch.setattr(
+        "whilly.core.triz.subprocess.run",
+        _make_recording_run(raises=subprocess.TimeoutExpired(cmd=["claude"], timeout=25)),
+    )
+    await _seed_plan_task_worker(db_pool)
+
+    updated = await task_repo.fail_task(TASK_ID, version=1, reason="boom")
+    assert updated.status == TaskStatus.FAILED
+
+    async with db_pool.acquire() as conn:
+        err_rows = await conn.fetch(
+            "SELECT detail FROM events WHERE task_id=$1 AND event_type='triz.error'",
+            TASK_ID,
+        )
+        triz_count = await conn.fetchval(
+            "SELECT COUNT(*) FROM events WHERE task_id=$1 AND event_type='triz.contradiction'",
+            TASK_ID,
+        )
+    assert len(err_rows) == 1
+    detail = err_rows[0]["detail"]
+    if isinstance(detail, str):
+        detail = json.loads(detail)
+    assert detail.get("reason") == "timeout"
+    assert triz_count == 0
+
+
+# ─── VAL-TRIZ-003: claude absent → no triz event, FAIL preserved ────────
+
+
+async def test_claude_missing_skips_triz_but_keeps_fail(
+    db_pool: asyncpg.Pool,
+    task_repo: TaskRepository,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``shutil.which('claude')`` returns None → no triz event row; FAIL still landed."""
+    # Override the autouse "_enable_triz" patches: claude is absent.
+    monkeypatch.setattr("whilly.core.triz.shutil.which", lambda _name: None)
+    runner = _make_recording_run(stdout="should not run")
+    monkeypatch.setattr("whilly.core.triz.subprocess.run", runner)
+    await _seed_plan_task_worker(db_pool)
+
+    with caplog.at_level(logging.WARNING, logger="whilly.core.triz"):
+        await task_repo.fail_task(TASK_ID, version=1, reason="boom")
+
+    # triz analyzer never invoked claude, no triz events.
+    assert runner.calls == []  # type: ignore[attr-defined]
+
+    async with db_pool.acquire() as conn:
+        triz_rows = await conn.fetchval(
+            "SELECT COUNT(*) FROM events WHERE task_id=$1 AND event_type LIKE 'triz.%'",
+            TASK_ID,
+        )
+        fail_rows = await conn.fetchval(
+            "SELECT COUNT(*) FROM events WHERE task_id=$1 AND event_type='FAIL'",
+            TASK_ID,
+        )
+        status = await conn.fetchval("SELECT status FROM tasks WHERE id=$1", TASK_ID)
+    assert triz_rows == 0
+    assert fail_rows == 1
+    assert status == "FAILED"
+
+    # Exactly one warning on whilly.core.triz logger (claude_missing).
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING and r.name == "whilly.core.triz"]
+    assert len(warnings) == 1
+    assert "claude" in warnings[0].getMessage().lower()
+
+
+# ─── VAL-TRIZ-005 (integration counterpart): malformed JSON → no triz event ─
+
+
+async def test_malformed_claude_output_writes_no_triz_event(
+    db_pool: asyncpg.Pool,
+    task_repo: TaskRepository,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Garbage stdout → analyze returns None, no triz.contradiction event row."""
+    monkeypatch.setattr(
+        "whilly.core.triz.subprocess.run",
+        _make_recording_run(stdout="<<not json>>", returncode=0),
+    )
+    await _seed_plan_task_worker(db_pool)
+
+    await task_repo.fail_task(TASK_ID, version=1, reason="boom")
+
+    async with db_pool.acquire() as conn:
+        triz_count = await conn.fetchval(
+            "SELECT COUNT(*) FROM events WHERE task_id=$1 AND event_type LIKE 'triz.%'",
+            TASK_ID,
+        )
+        status = await conn.fetchval("SELECT status FROM tasks WHERE id=$1", TASK_ID)
+    assert triz_count == 0
+    assert status == "FAILED"
+
+
+# ─── VAL-TRIZ-011: no TRIZ when feature flag off ────────────────────────
+
+
+async def test_triz_disabled_records_no_triz_event(
+    db_pool: asyncpg.Pool,
+    task_repo: TaskRepository,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``WHILLY_TRIZ_ENABLED`` unset → analyze never invoked; no triz events."""
+    monkeypatch.delenv("WHILLY_TRIZ_ENABLED", raising=False)
+    runner = _make_recording_run(stdout="should not run")
+    monkeypatch.setattr("whilly.core.triz.subprocess.run", runner)
+    await _seed_plan_task_worker(db_pool)
+
+    await task_repo.fail_task(TASK_ID, version=1, reason="boom")
+
+    # Recording stub captured zero calls — analyze_contradiction was never called.
+    assert runner.calls == []  # type: ignore[attr-defined]
+
+    async with db_pool.acquire() as conn:
+        triz_count = await conn.fetchval(
+            "SELECT COUNT(*) FROM events WHERE task_id=$1 AND event_type LIKE 'triz.%'",
+            TASK_ID,
+        )
+    assert triz_count == 0
+
+
+@pytest.mark.parametrize("env_value", ["0", "false", "off", ""])
+async def test_triz_disabled_for_non_one_env_values(
+    db_pool: asyncpg.Pool,
+    task_repo: TaskRepository,
+    monkeypatch: pytest.MonkeyPatch,
+    env_value: str,
+) -> None:
+    """Only ``WHILLY_TRIZ_ENABLED=1`` activates the hook; everything else is off."""
+    monkeypatch.setenv("WHILLY_TRIZ_ENABLED", env_value)
+    runner = _make_recording_run(stdout="should not run")
+    monkeypatch.setattr("whilly.core.triz.subprocess.run", runner)
+    await _seed_plan_task_worker(db_pool)
+
+    await task_repo.fail_task(TASK_ID, version=1, reason="boom")
+    assert runner.calls == []  # type: ignore[attr-defined]
+
+
+# ─── VAL-TRIZ-015: hook never re-raises into the executor ──────────────
+
+
+@pytest.mark.parametrize(
+    "stdout_or_raises",
+    [
+        ("garbage", None),  # malformed JSON
+        ("", subprocess.TimeoutExpired(cmd=["claude"], timeout=25)),  # timeout
+        ("", FileNotFoundError("vanished")),  # claude vanished
+    ],
+)
+async def test_fail_task_returns_normally_on_every_failure_mode(
+    db_pool: asyncpg.Pool,
+    task_repo: TaskRepository,
+    monkeypatch: pytest.MonkeyPatch,
+    stdout_or_raises: tuple[str, BaseException | None],
+) -> None:
+    """For every documented failure mode, ``fail_task`` returns a FAILED Task without raising."""
+    stdout, raises = stdout_or_raises
+    monkeypatch.setattr(
+        "whilly.core.triz.subprocess.run",
+        _make_recording_run(stdout=stdout, raises=raises),
+    )
+    await _seed_plan_task_worker(db_pool)
+
+    updated = await task_repo.fail_task(TASK_ID, version=1, reason="boom")
+    assert updated.status == TaskStatus.FAILED
+
+
+# ─── Wall-clock guard: triz hook does NOT extend fail_task beyond the 25s budget ─
+
+
+async def test_fail_task_completes_promptly_on_mocked_subprocess(
+    db_pool: asyncpg.Pool,
+    task_repo: TaskRepository,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Mocked subprocess returns instantly → fail_task returns within a tight bound."""
+    import time
+
+    payload = json.dumps(
+        {
+            "contradictory": True,
+            "contradiction_type": "technical",
+            "reason": "improving X worsens Y — a textbook technical contradiction",
+        }
+    )
+    monkeypatch.setattr("whilly.core.triz.subprocess.run", _make_recording_run(stdout=payload))
+    await _seed_plan_task_worker(db_pool)
+
+    t0 = time.monotonic()
+    await task_repo.fail_task(TASK_ID, version=1, reason="boom")
+    elapsed = time.monotonic() - t0
+
+    # Tight bound — even on a slow CI box, mocked TRIZ should land in well
+    # under a second; the 5s ceiling is a defence-in-depth signal that no
+    # one accidentally added a real subprocess to the hook.
+    assert elapsed < 5.0

--- a/tests/integration/test_triz_live.py
+++ b/tests/integration/test_triz_live.py
@@ -1,0 +1,92 @@
+"""Live-LLM smoke test for the per-task TRIZ analyzer (TASK-104b, VAL-TRIZ-013).
+
+Gated by both:
+
+* ``WHILLY_RUN_LIVE_LLM=1`` — operator opts in (the regular CI run does
+  not subprocess to a real model).
+* ``@pytest.mark.live_llm`` marker — selectable via ``-m live_llm``
+  on the command line (``WHILLY_RUN_LIVE_LLM=1 pytest -m live_llm``).
+
+When ``WHILLY_RUN_LIVE_LLM`` is unset, the test is skipped with a
+reason that names the gate variable (VAL-TRIZ-014). When the variable
+is set but ``claude`` is absent from PATH, the test fails with a clear
+message rather than silently passing.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import time
+
+import pytest
+
+from whilly.core.models import Priority, Task, TaskStatus
+from whilly.core.triz import TIMEOUT_SECONDS, TrizFinding, analyze_contradiction
+
+
+def _live_llm_enabled() -> bool:
+    return os.environ.get("WHILLY_RUN_LIVE_LLM") == "1"
+
+
+# Marker plus skip-if so users see the actual reason text on plain `pytest`.
+pytestmark = [
+    pytest.mark.live_llm,
+    pytest.mark.skipif(
+        not _live_llm_enabled(),
+        reason="live_llm gate: set WHILLY_RUN_LIVE_LLM=1 to run the live Claude smoke test",
+    ),
+]
+
+
+def _canonical_contradiction_task() -> Task:
+    """Build a task whose description encodes a textbook TRIZ contradiction."""
+    return Task(
+        id="T-LIVE-001",
+        status=TaskStatus.IN_PROGRESS,
+        priority=Priority.HIGH,
+        description=(
+            "Design a distributed cache that must be both fully strongly consistent "
+            "and fully eventually-consistent at the same time across every regional "
+            "read replica."
+        ),
+        acceptance_criteria=(
+            "Reads return the latest write within 10 ms",
+            "Writes scale linearly to 100 regions",
+        ),
+        test_steps=("pytest -k cache",),
+    )
+
+
+def test_smoke() -> None:
+    """Real Claude returns a plausible TrizFinding within the 25 s budget.
+
+    Asserts the live AC contract from VAL-TRIZ-013:
+
+    * ``finding is not None``
+    * ``contradiction_type`` is a non-empty string
+    * ``reason`` is at least 20 characters of natural language
+    * single-call wall clock ≤ 25 seconds
+    """
+    if shutil.which("claude") is None:
+        # When the gate variable is set but claude is missing the test
+        # FAILS rather than silently passing (VAL-TRIZ-014).
+        pytest.fail(
+            "WHILLY_RUN_LIVE_LLM=1 is set but the `claude` CLI is not on PATH; "
+            "install Claude CLI or unset the gate variable."
+        )
+
+    task = _canonical_contradiction_task()
+    t_start = time.monotonic()
+    finding = analyze_contradiction(task)
+    elapsed = time.monotonic() - t_start
+
+    # Hard timeout invariant — VAL-TRIZ-013 / VAL-TRIZ-007.
+    assert elapsed <= TIMEOUT_SECONDS, f"analyze_contradiction took {elapsed:.1f}s > {TIMEOUT_SECONDS}s budget"
+
+    # Live model returned a plausible verdict.
+    assert finding is not None, "live Claude must surface a contradiction for the canonical task"
+    assert isinstance(finding, TrizFinding)
+    assert isinstance(finding.contradiction_type, str)
+    assert len(finding.contradiction_type) > 0
+    assert len(finding.reason) >= 20

--- a/tests/unit/core/test_triz.py
+++ b/tests/unit/core/test_triz.py
@@ -1,0 +1,383 @@
+"""Unit tests for the per-task TRIZ analyzer (TASK-104b).
+
+The contract under test is in :mod:`whilly.core.triz`; the
+assertions below mirror VAL-TRIZ-003 (claude absent), VAL-TRIZ-005
+(malformed JSON), VAL-TRIZ-006 (subprocess invocation shape),
+VAL-TRIZ-012 (one warning per failure mode), and VAL-TRIZ-016
+(structured ``record.event`` field).
+
+Every test mocks ``subprocess.run`` and ``shutil.which`` — none of
+the unit tests reach the network or the real ``claude`` CLI. The
+live-smoke counterpart lives in
+``tests/integration/test_triz_live.py`` and is gated by
+``WHILLY_RUN_LIVE_LLM=1``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+from typing import Any
+
+import pytest
+
+from whilly.core.models import Priority, Task, TaskStatus
+from whilly.core.triz import (
+    CLAUDE_BIN,
+    LOG_EVENT_CLAUDE_MISSING,
+    LOG_EVENT_PARSE_ERROR,
+    LOG_EVENT_TIMEOUT,
+    TIMEOUT_SECONDS,
+    TrizFinding,
+    analyze_contradiction,
+    analyze_contradiction_with_outcome,
+)
+
+
+# ─── helpers ─────────────────────────────────────────────────────────────
+
+
+def _make_task(
+    *,
+    description: str = (
+        "The cache must be both fully consistent and fully eventually-consistent across every regional read replica."
+    ),
+    acceptance_criteria: tuple[str, ...] = ("Reads return the latest write within 10ms",),
+    task_id: str = "T-TRIZ-001",
+) -> Task:
+    """Build a default task whose description encodes a TRIZ contradiction."""
+    return Task(
+        id=task_id,
+        status=TaskStatus.PENDING,
+        priority=Priority.MEDIUM,
+        description=description,
+        acceptance_criteria=acceptance_criteria,
+        test_steps=("step-1",),
+    )
+
+
+class _RecordingRun:
+    """Subprocess.run double that records its argv/kwargs and returns canned output."""
+
+    def __init__(self, *, stdout: str = "", returncode: int = 0, raises: BaseException | None = None) -> None:
+        self.calls: list[tuple[Any, dict[str, Any]]] = []
+        self._stdout = stdout
+        self._returncode = returncode
+        self._raises = raises
+
+    def __call__(self, *args: Any, **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        self.calls.append((args, kwargs))
+        if self._raises is not None:
+            raise self._raises
+        # subprocess.run accepts cmd as first positional or as kwarg
+        cmd = args[0] if args else kwargs.get("args")
+        return subprocess.CompletedProcess(args=cmd, returncode=self._returncode, stdout=self._stdout, stderr="")
+
+
+def _patch_claude_present(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Force ``shutil.which("claude")`` to resolve to a deterministic path."""
+    monkeypatch.setattr("whilly.core.triz.shutil.which", lambda name: "/usr/bin/claude" if name == CLAUDE_BIN else None)
+
+
+# ─── VAL-TRIZ-003: claude CLI absent → graceful skip + structured warning ─
+
+
+def test_analyze_returns_none_when_claude_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``shutil.which`` returns None → return None and emit one structured WARNING."""
+    monkeypatch.setattr("whilly.core.triz.shutil.which", lambda _name: None)
+    # subprocess.run must NOT be called when claude is absent.
+    runner = _RecordingRun(stdout="should not run")
+    monkeypatch.setattr("whilly.core.triz.subprocess.run", runner)
+
+    with caplog.at_level(logging.WARNING, logger="whilly.core.triz"):
+        finding = analyze_contradiction(_make_task())
+
+    assert finding is None
+    assert runner.calls == []  # claude never invoked
+
+    warning_records = [r for r in caplog.records if r.levelno == logging.WARNING and r.name == "whilly.core.triz"]
+    assert len(warning_records) == 1, "expected exactly one warning per failure mode"
+    assert "claude" in warning_records[0].getMessage().lower()
+    # VAL-TRIZ-016: structured ``record.event`` matches the documented enum.
+    assert getattr(warning_records[0], "event", None) == LOG_EVENT_CLAUDE_MISSING
+
+
+def test_filenotfound_during_subprocess_is_treated_as_claude_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A defensive guard: if ``shutil.which`` lies and ``subprocess.run`` raises ``FileNotFoundError``."""
+    _patch_claude_present(monkeypatch)
+    runner = _RecordingRun(raises=FileNotFoundError("claude vanished"))
+    monkeypatch.setattr("whilly.core.triz.subprocess.run", runner)
+
+    with caplog.at_level(logging.WARNING, logger="whilly.core.triz"):
+        finding = analyze_contradiction(_make_task())
+
+    assert finding is None
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING and r.name == "whilly.core.triz"]
+    assert len(warnings) == 1
+    assert getattr(warnings[0], "event", None) == LOG_EVENT_CLAUDE_MISSING
+
+
+# ─── VAL-TRIZ-004 / VAL-TRIZ-006: timeout → return None + outcome.error_reason="timeout" ─
+
+
+def test_analyze_returns_none_on_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Subprocess raises TimeoutExpired → ``analyze_contradiction`` returns None."""
+    _patch_claude_present(monkeypatch)
+    runner = _RecordingRun(raises=subprocess.TimeoutExpired(cmd=[CLAUDE_BIN], timeout=TIMEOUT_SECONDS))
+    monkeypatch.setattr("whilly.core.triz.subprocess.run", runner)
+
+    with caplog.at_level(logging.WARNING, logger="whilly.core.triz"):
+        finding = analyze_contradiction(_make_task())
+
+    assert finding is None
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING and r.name == "whilly.core.triz"]
+    assert len(warnings) == 1
+    assert getattr(warnings[0], "event", None) == LOG_EVENT_TIMEOUT
+
+
+def test_outcome_carries_timeout_reason(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The richer ``analyze_contradiction_with_outcome`` exposes ``error_reason='timeout'``.
+
+    The repository hook keys on this to write a ``triz.error`` event row
+    (VAL-TRIZ-004).
+    """
+    _patch_claude_present(monkeypatch)
+    runner = _RecordingRun(raises=subprocess.TimeoutExpired(cmd=[CLAUDE_BIN], timeout=TIMEOUT_SECONDS))
+    monkeypatch.setattr("whilly.core.triz.subprocess.run", runner)
+
+    outcome = analyze_contradiction_with_outcome(_make_task())
+    assert outcome.finding is None
+    assert outcome.error_reason == "timeout"
+
+
+# ─── VAL-TRIZ-005: malformed JSON → safe-parse to None ──────────────────
+
+
+@pytest.mark.parametrize(
+    "stdout",
+    [
+        "<<not json>>\n",
+        "",
+        "this is just plain prose, sorry",
+        '{"contradictory": "yes"}',  # wrong type for ``contradictory``
+        '{"contradictory": true}',  # missing required keys
+        '{"contradictory": true, "contradiction_type": "", "reason": "x"}',  # empty type
+        '["not", "an", "object"]',  # top-level not a dict
+    ],
+)
+def test_analyze_returns_none_on_malformed_or_shape_mismatched_output(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    stdout: str,
+) -> None:
+    """Malformed JSON / shape-mismatched payload → return None + one parse_error warning."""
+    _patch_claude_present(monkeypatch)
+    runner = _RecordingRun(stdout=stdout, returncode=0)
+    monkeypatch.setattr("whilly.core.triz.subprocess.run", runner)
+
+    with caplog.at_level(logging.WARNING, logger="whilly.core.triz"):
+        finding = analyze_contradiction(_make_task())
+
+    assert finding is None
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING and r.name == "whilly.core.triz"]
+    assert len(warnings) == 1
+    assert getattr(warnings[0], "event", None) == LOG_EVENT_PARSE_ERROR
+
+
+def test_analyze_returns_none_on_claude_non_zero_exit(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Non-zero returncode → parse_error soft-fail (no event row)."""
+    _patch_claude_present(monkeypatch)
+    runner = _RecordingRun(stdout="ignored", returncode=1)
+    monkeypatch.setattr("whilly.core.triz.subprocess.run", runner)
+
+    with caplog.at_level(logging.WARNING, logger="whilly.core.triz"):
+        finding = analyze_contradiction(_make_task())
+    assert finding is None
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING and r.name == "whilly.core.triz"]
+    assert len(warnings) == 1
+    assert getattr(warnings[0], "event", None) == LOG_EVENT_PARSE_ERROR
+
+
+# ─── VAL-TRIZ-006: subprocess invocation shape ──────────────────────────
+
+
+def test_subprocess_invocation_uses_claude_binary_with_25s_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The recording stub captures ``argv[0]=='claude'`` and ``timeout==25``."""
+    _patch_claude_present(monkeypatch)
+    payload = json.dumps(
+        {
+            "contradictory": True,
+            "contradiction_type": "technical",
+            "reason": "improving consistency worsens latency by an order of magnitude",
+        }
+    )
+    runner = _RecordingRun(stdout=payload, returncode=0)
+    monkeypatch.setattr("whilly.core.triz.subprocess.run", runner)
+
+    finding = analyze_contradiction(_make_task())
+
+    assert isinstance(finding, TrizFinding)
+    assert len(runner.calls) == 1
+    args, kwargs = runner.calls[0]
+    cmd = args[0] if args else kwargs.get("args")
+    assert isinstance(cmd, list) and cmd, "subprocess.run must receive a list argv"
+    assert cmd[0] == CLAUDE_BIN, f"argv[0] must be {CLAUDE_BIN!r}"
+    assert kwargs.get("timeout") == TIMEOUT_SECONDS
+    assert kwargs["timeout"] < 30  # HARD constraint: must stay below 30s claim visibility-timeout
+
+
+# ─── VAL-TRIZ-001 (mock variant): contradiction → TrizFinding ───────────
+
+
+def test_returns_finding_on_positive_verdict(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A well-formed positive verdict round-trips into a TrizFinding."""
+    _patch_claude_present(monkeypatch)
+    payload = json.dumps(
+        {
+            "contradictory": True,
+            "contradiction_type": "physical",
+            "reason": (
+                "Cache must be both consistent and eventually-consistent — "
+                "two opposing properties at the same logical instant."
+            ),
+        }
+    )
+    monkeypatch.setattr("whilly.core.triz.subprocess.run", _RecordingRun(stdout=payload, returncode=0))
+
+    finding = analyze_contradiction(_make_task())
+    assert isinstance(finding, TrizFinding)
+    assert finding.contradiction_type == "physical"
+    assert "Cache" in finding.reason
+    assert len(finding.reason) >= 20
+
+
+def test_returns_none_on_no_contradiction_verdict(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``contradictory: false`` is the no-contradiction happy path → None, no warning."""
+    _patch_claude_present(monkeypatch)
+    payload = json.dumps({"contradictory": False, "contradiction_type": "", "reason": ""})
+    monkeypatch.setattr("whilly.core.triz.subprocess.run", _RecordingRun(stdout=payload, returncode=0))
+
+    finding = analyze_contradiction(_make_task())
+    assert finding is None
+
+
+def test_returns_finding_when_output_wrapped_in_markdown_fence(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tolerant parser strips ```json fences before json.loads."""
+    _patch_claude_present(monkeypatch)
+    inner = json.dumps(
+        {
+            "contradictory": True,
+            "contradiction_type": "technical",
+            "reason": "improving throughput worsens tail latency at the 99.9th percentile",
+        }
+    )
+    fenced = f"```json\n{inner}\n```"
+    monkeypatch.setattr("whilly.core.triz.subprocess.run", _RecordingRun(stdout=fenced, returncode=0))
+
+    finding = analyze_contradiction(_make_task())
+    assert isinstance(finding, TrizFinding)
+    assert finding.contradiction_type == "technical"
+
+
+# ─── VAL-TRIZ-016 (set-membership): each failure mode emits its own enum ─
+
+
+def test_each_failure_mode_emits_distinct_event_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Across the three failure modes, the captured ``record.event`` set matches the documented enum."""
+    _patch_claude_present(monkeypatch)
+
+    observed: set[str] = set()
+
+    # Claude missing
+    monkeypatch.setattr("whilly.core.triz.shutil.which", lambda _name: None)
+    monkeypatch.setattr("whilly.core.triz.subprocess.run", _RecordingRun(stdout=""))
+    triz_mod_logger = logging.getLogger("whilly.core.triz")
+    records: list[logging.LogRecord] = []
+
+    class _Handler(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append(record)
+
+    handler = _Handler(level=logging.WARNING)
+    triz_mod_logger.addHandler(handler)
+    try:
+        analyze_contradiction(_make_task())
+    finally:
+        triz_mod_logger.removeHandler(handler)
+    observed.update({getattr(r, "event", None) for r in records if getattr(r, "event", None)})
+
+    # Timeout
+    _patch_claude_present(monkeypatch)
+    monkeypatch.setattr(
+        "whilly.core.triz.subprocess.run",
+        _RecordingRun(raises=subprocess.TimeoutExpired(cmd=[CLAUDE_BIN], timeout=TIMEOUT_SECONDS)),
+    )
+    records.clear()
+    handler2 = _Handler(level=logging.WARNING)
+    triz_mod_logger.addHandler(handler2)
+    try:
+        analyze_contradiction(_make_task())
+    finally:
+        triz_mod_logger.removeHandler(handler2)
+    observed.update({getattr(r, "event", None) for r in records if getattr(r, "event", None)})
+
+    # Parse error
+    _patch_claude_present(monkeypatch)
+    monkeypatch.setattr("whilly.core.triz.subprocess.run", _RecordingRun(stdout="<not json>", returncode=0))
+    records.clear()
+    handler3 = _Handler(level=logging.WARNING)
+    triz_mod_logger.addHandler(handler3)
+    try:
+        analyze_contradiction(_make_task())
+    finally:
+        triz_mod_logger.removeHandler(handler3)
+    observed.update({getattr(r, "event", None) for r in records if getattr(r, "event", None)})
+
+    assert observed == {LOG_EVENT_CLAUDE_MISSING, LOG_EVENT_TIMEOUT, LOG_EVENT_PARSE_ERROR}
+
+
+# ─── analyze_contradiction never re-raises (foundation for VAL-TRIZ-015) ─
+
+
+@pytest.mark.parametrize(
+    "side_effect_kwargs",
+    [
+        # Each tuple: (which-result, run-result-or-exception)
+        ("missing", None),
+        ("present", subprocess.TimeoutExpired(cmd=[CLAUDE_BIN], timeout=TIMEOUT_SECONDS)),
+        ("present", "garbage stdout"),
+        ("present", FileNotFoundError("vanished")),
+    ],
+)
+def test_analyze_never_re_raises(
+    monkeypatch: pytest.MonkeyPatch,
+    side_effect_kwargs: tuple[str, Any],
+) -> None:
+    """Foundation for VAL-TRIZ-015: analyze never re-raises into the caller."""
+    which_result, run_result = side_effect_kwargs
+    if which_result == "missing":
+        monkeypatch.setattr("whilly.core.triz.shutil.which", lambda _name: None)
+    else:
+        _patch_claude_present(monkeypatch)
+
+    if isinstance(run_result, BaseException):
+        monkeypatch.setattr("whilly.core.triz.subprocess.run", _RecordingRun(raises=run_result))
+    elif isinstance(run_result, str):
+        monkeypatch.setattr("whilly.core.triz.subprocess.run", _RecordingRun(stdout=run_result, returncode=0))
+
+    # Must not raise any exception type listed in VAL-TRIZ-015.
+    finding = analyze_contradiction(_make_task())
+    assert finding is None

--- a/whilly/adapters/db/migrations/versions/003_events_detail.py
+++ b/whilly/adapters/db/migrations/versions/003_events_detail.py
@@ -1,0 +1,72 @@
+"""Add ``events.detail`` JSONB column for structured per-event context (TASK-104b).
+
+The events table already carries a per-event ``payload`` JSONB column that
+mixes state-machine bookkeeping (``version``, ``reason``) with
+caller-supplied diagnostics. TASK-104b introduces a *separate* per-event
+``detail`` JSONB column dedicated to caller diagnostics — keeping
+``payload`` reserved for the canonical fields and giving downstream
+consumers a stable place to pluck structured context from
+(``payload->>'reason'`` for the canonical reason, ``detail->>'k'`` for
+caller-supplied extras).
+
+This migration is the prerequisite for:
+
+* :meth:`TaskRepository.fail_task`'s ``detail`` keyword-only argument
+  (VAL-TRIZ-008) — the FAIL event row stores the caller's dict in
+  ``events.detail`` rather than mutating ``payload``.
+* The TRIZ hook (VAL-TRIZ-001 / VAL-TRIZ-004) — ``triz.contradiction``
+  and ``triz.error`` event rows put their finding shape (or error
+  reason) into ``detail`` so audit-time queries don't have to special-
+  case the per-event-type ``payload`` shape.
+
+Why a *new* column rather than re-using ``payload``?
+    Two observable schemas — ``payload`` carries the state-machine
+    bookkeeping invariants (``version`` always present, ``reason`` for
+    SKIP / FAIL / RELEASE), while ``detail`` carries free-form caller
+    context. Mixing them on one column forced ``skip_task`` to merge
+    payload with detail and reserve key names; with a dedicated
+    column the merge is gone, the contract surface is simpler, and
+    audit queries can ``WHERE detail IS NULL`` to filter "events with
+    no diagnostics" without inventing a sentinel key.
+
+Default NULL — never the literal JSON ``null`` or the empty object ``{}``
+---------------------------------------------------------------------
+The column is nullable with no default. A FAIL event written without a
+``detail`` argument writes SQL NULL into the column (VAL-TRIZ-009);
+it never writes the literal JSON ``"null"`` text or the empty object
+``{}``. This is enforced at the repository layer — the SQL accepts a
+``$N::jsonb`` cast and Python passes ``None`` straight through asyncpg.
+
+Revision ID: 003_events_detail
+Revises: 002_workers_status
+Create Date: 2026-04-29
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "003_events_detail"
+down_revision: str | None = "002_workers_status"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "events",
+        sa.Column(
+            "detail",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+            server_default=None,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("events", "detail")

--- a/whilly/adapters/db/repository.py
+++ b/whilly/adapters/db/repository.py
@@ -63,6 +63,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from typing import Any
 
 import asyncpg
@@ -133,6 +134,23 @@ RETURNING
 _INSERT_EVENT_SQL: str = """
 INSERT INTO events (task_id, event_type, payload)
 VALUES ($1, $2, $3::jsonb)
+"""
+
+
+# Variant of :data:`_INSERT_EVENT_SQL` that also writes the ``detail`` JSONB
+# column (TASK-104b, migration 003). Distinct statement rather than a
+# four-arg superset because most call sites do not have a ``detail`` payload
+# — passing ``NULL`` through every existing INSERT would inflate the wire
+# round-trip with no upside, and the explicit two-statement split keeps
+# each call site's intent legible.
+#
+# ``$4::jsonb`` accepts SQL ``NULL`` straight from Python ``None`` (asyncpg
+# does not stringify None into the JSON literal ``"null"`` for jsonb
+# columns); the column itself is nullable per the migration so a Python
+# ``None`` round-trips to ``IS NULL`` on read (VAL-TRIZ-009).
+_INSERT_EVENT_WITH_DETAIL_SQL: str = """
+INSERT INTO events (task_id, event_type, payload, detail)
+VALUES ($1, $2, $3::jsonb, $4::jsonb)
 """
 
 
@@ -779,7 +797,14 @@ class TaskRepository:
                 )
                 return _row_to_task(row)
 
-    async def fail_task(self, task_id: TaskId, version: int, reason: str) -> Task:
+    async def fail_task(
+        self,
+        task_id: TaskId,
+        version: int,
+        reason: str,
+        *,
+        detail: dict[str, Any] | None = None,
+    ) -> Task:
         """Atomically transition ``task_id`` from ``CLAIMED`` | ``IN_PROGRESS`` → ``FAILED``.
 
         Mirrors :meth:`complete_task` but accepts both pre-START and
@@ -795,6 +820,29 @@ class TaskRepository:
 
         Raises :class:`VersionConflictError` on optimistic-lock mismatch
         (same three-way classification as :meth:`complete_task`).
+
+        TASK-104b extensions
+        --------------------
+        ``detail`` (keyword-only) accepts a free-form dict that is
+        persisted into the new ``events.detail`` JSONB column (migration
+        003). When ``detail`` is ``None`` (the default), the column is
+        SQL ``NULL`` rather than the literal JSON ``null`` or the empty
+        object ``{}`` (VAL-TRIZ-009). Reserved keys live on
+        ``events.payload`` (``version`` / ``reason``); ``detail`` is
+        free-form caller diagnostics.
+
+        Per-task TRIZ hook
+        ~~~~~~~~~~~~~~~~~~
+        After the FAIL transition commits, the method optionally
+        invokes :func:`whilly.core.triz.analyze_contradiction_with_outcome`
+        on the post-update :class:`Task` and writes a follow-up
+        ``triz.contradiction`` (positive verdict) or ``triz.error``
+        (timeout) event row carrying the finding shape in ``detail``.
+        Gated by ``WHILLY_TRIZ_ENABLED=1`` (off by default in tests, on
+        in prod-like config). Fail-open contract (VAL-TRIZ-015): the hook
+        never re-raises into the caller for any of the documented soft-
+        fail modes (claude absent, timeout, malformed JSON, claude
+        non-zero exit).
         """
         async with self._pool.acquire() as conn:
             async with conn.transaction():
@@ -803,11 +851,13 @@ class TaskRepository:
                     await self._raise_version_conflict(conn, task_id, version)
 
                 payload = json.dumps({"version": row["version"], "reason": reason})
+                detail_jsonb = json.dumps(detail) if detail is not None else None
                 await conn.execute(
-                    _INSERT_EVENT_SQL,
+                    _INSERT_EVENT_WITH_DETAIL_SQL,
                     row["id"],
                     Transition.FAIL.value,
                     payload,
+                    detail_jsonb,
                 )
                 logger.info(
                     "fail_task: task=%s version=%d reason=%r → FAILED",
@@ -815,7 +865,83 @@ class TaskRepository:
                     row["version"],
                     reason,
                 )
-                return _row_to_task(row)
+                updated = _row_to_task(row)
+
+        # TRIZ hook runs *after* the FAIL commit (VAL-TRIZ-010 ordering
+        # contract: FAIL row's ``created_at`` ≤ ``triz.contradiction``
+        # row's ``created_at``). Running outside the transaction also
+        # guarantees a TRIZ failure cannot roll the FAIL transition back
+        # — VAL-TRIZ-003 requires the FAIL event row preserved when
+        # claude is absent.
+        if os.environ.get("WHILLY_TRIZ_ENABLED") == "1":
+            await self._maybe_emit_triz_event(updated)
+        return updated
+
+    async def _maybe_emit_triz_event(self, task: Task) -> None:
+        """Optional per-task TRIZ analyser hook (TASK-104b).
+
+        Subprocesses the ``claude`` CLI via
+        :func:`whilly.core.triz.analyze_contradiction_with_outcome` and
+        writes a follow-up event row depending on the outcome:
+
+        * positive verdict — one ``triz.contradiction`` event with
+          ``detail = {"contradiction_type": ..., "reason": ...}``.
+        * subprocess timeout — one ``triz.error`` event with
+          ``detail = {"reason": "timeout"}``.
+        * everything else (claude absent, malformed JSON, claude
+          non-zero exit, no contradiction found) — no event row.
+
+        Fail-open: every exception (analyzer-side AND DB-side) is
+        swallowed with a WARNING log so the FAIL transition that
+        already committed stays observable.
+        """
+        # Local import keeps cold-start cost off the import graph for
+        # workloads that never invoke fail_task with the env flag set.
+        from whilly.core.triz import (  # noqa: PLC0415 — see comment above
+            ERROR_REASON_TIMEOUT,
+            analyze_contradiction_with_outcome,
+        )
+
+        try:
+            outcome = analyze_contradiction_with_outcome(task)
+        except Exception as exc:  # noqa: BLE001 — fail-open contract
+            logger.warning(
+                "triz hook: analyzer raised unexpectedly: %r — skipping event",
+                exc,
+            )
+            return
+
+        if outcome.finding is not None:
+            event_type = "triz.contradiction"
+            detail_payload: dict[str, Any] = {
+                "contradiction_type": outcome.finding.contradiction_type,
+                "reason": outcome.finding.reason,
+            }
+        elif outcome.error_reason == ERROR_REASON_TIMEOUT:
+            event_type = "triz.error"
+            detail_payload = {"reason": "timeout"}
+        else:
+            # No contradiction OR a soft-fail mode (claude absent,
+            # parse error, non-zero exit) that we deliberately do NOT
+            # surface as an event row (VAL-TRIZ-003 / VAL-TRIZ-005).
+            return
+
+        try:
+            async with self._pool.acquire() as conn:
+                await conn.execute(
+                    _INSERT_EVENT_WITH_DETAIL_SQL,
+                    task.id,
+                    event_type,
+                    json.dumps({}),
+                    json.dumps(detail_payload),
+                )
+        except Exception as exc:  # noqa: BLE001 — fail-open contract
+            logger.warning(
+                "triz hook: failed to write %s event for task=%s: %r",
+                event_type,
+                task.id,
+                exc,
+            )
 
     async def release_task(self, task_id: TaskId, version: int, reason: str) -> Task:
         """Atomically transition ``task_id`` from ``CLAIMED`` | ``IN_PROGRESS`` → ``PENDING``.

--- a/whilly/adapters/db/schema.sql
+++ b/whilly/adapters/db/schema.sql
@@ -86,6 +86,13 @@ CREATE TABLE events (
     task_id    TEXT NOT NULL REFERENCES tasks (id) ON DELETE CASCADE,
     event_type TEXT NOT NULL,
     payload    JSONB NOT NULL DEFAULT '{}'::jsonb,
+    -- Per-event caller-supplied diagnostics (TASK-104b, migration 003).
+    -- Distinct from ``payload`` (which carries state-machine
+    -- bookkeeping like ``version`` / ``reason``); ``detail`` is
+    -- nullable, free-form, and never written as the JSON literal
+    -- ``null`` or as ``{}`` — the repo passes Python ``None`` straight
+    -- through asyncpg so SQL ``IS NULL`` predicates round-trip cleanly.
+    detail     JSONB,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 

--- a/whilly/core/triz.py
+++ b/whilly/core/triz.py
@@ -1,0 +1,418 @@
+"""Per-task TRIZ contradiction analyzer for Whilly v4.1 (TASK-104b).
+
+Replaces the v3 plan-level TRIZ analyzer (``whilly/triz_analyzer.py``,
+shellouts to Claude with a 300s timeout) with a *per-task* analyzer that
+runs as a fail-task hook (TASK-104b).
+
+Public surface
+--------------
+* :class:`TrizFinding` — frozen dataclass carrying the contradiction
+  shape (``contradiction_type`` + ``reason``) returned by the analyzer
+  on a positive verdict. Frozen so the value can be round-tripped to
+  ``dataclasses.asdict`` for the ``triz.contradiction`` event row's
+  ``detail`` JSONB without defensive copies.
+* :func:`analyze_contradiction` — given a :class:`~whilly.core.models.Task`,
+  spawn the ``claude`` CLI with a per-task TRIZ prompt and a hard
+  ``timeout=25`` (HARD constraint: the visibility-timeout window is
+  30 s — VAL-TRIZ-006 / VAL-TRIZ-007). Returns the :class:`TrizFinding`
+  on a positive verdict, ``None`` otherwise (no contradiction *and*
+  every soft-fail mode: claude absent, timeout, malformed JSON, claude
+  non-zero exit).
+
+Layering exception (PRD SC-6 / TC-8)
+------------------------------------
+This module lives under :mod:`whilly.core` and would normally be barred
+from importing :mod:`subprocess` / :mod:`shutil` by the
+``core-purity`` import-linter contract. The TASK-104b spec mandates the
+analyzer's location at ``whilly/core/triz.py`` because the validation
+contract pins ``subprocess.run`` calls observable inside this module
+(VAL-TRIZ-006). The contract grants this module a documented exception
+via ``ignore_imports`` so the rest of :mod:`whilly.core` can stay pure.
+
+Failure modes — fail-open (VAL-TRIZ-015)
+----------------------------------------
+The analyzer never re-raises into its caller for the documented failure
+modes (claude absent, timeout, malformed JSON, claude non-zero exit).
+Each failure mode emits **exactly one** WARNING-level log record on the
+``whilly.core.triz`` logger (VAL-TRIZ-012) carrying a structured
+``record.event`` field drawn from a documented enum (VAL-TRIZ-016):
+
+* :data:`LOG_EVENT_CLAUDE_MISSING` (``"triz.claude_missing"``) — emitted
+  when ``shutil.which("claude")`` returns ``None`` *or* the subprocess
+  raises :class:`FileNotFoundError`. Distinguishes "operator hasn't
+  installed claude" from "claude returned garbage".
+* :data:`LOG_EVENT_TIMEOUT` (``"triz.timeout"``) — emitted when the
+  subprocess raises :class:`subprocess.TimeoutExpired`. The hook
+  (in :mod:`whilly.adapters.db.repository`) writes a separate
+  ``triz.error`` event row with ``detail = {"reason": "timeout"}`` to
+  surface the timeout to dashboards / post-mortems even though the
+  analyzer itself returns ``None``.
+* :data:`LOG_EVENT_PARSE_ERROR` (``"triz.parse_error"``) — emitted when
+  ``json.loads`` rejects the subprocess stdout, or when the parsed
+  document is missing the required ``contradictory`` /
+  ``contradiction_type`` / ``reason`` shape.
+
+Public consumers can pin on the exact strings (VAL-TRIZ-016 evidence:
+``record.event in {"triz.claude_missing", "triz.timeout",
+"triz.parse_error"}``).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+# fmt: off
+import shutil  # noqa: I001 — see module docstring "Layering exception"
+import subprocess  # noqa: I001 — see module docstring "Layering exception"
+# fmt: on
+from dataclasses import dataclass
+
+from whilly.core.models import Task
+
+__all__ = [
+    "CLAUDE_BIN",
+    "LOG_EVENT_CLAUDE_MISSING",
+    "LOG_EVENT_PARSE_ERROR",
+    "LOG_EVENT_TIMEOUT",
+    "TIMEOUT_SECONDS",
+    "TrizFinding",
+    "TrizOutcome",
+    "analyze_contradiction",
+    "analyze_contradiction_with_outcome",
+]
+
+logger = logging.getLogger(__name__)
+
+
+# Hard subprocess timeout (HARD constraint per VAL-TRIZ-006 /
+# VAL-TRIZ-007). Must stay strictly below the 30 s claim
+# visibility-timeout window so a hung TRIZ run can never make the
+# parent worker race the visibility-timeout sweep that would
+# re-PENDING the task while the FAIL transition is still in-flight.
+TIMEOUT_SECONDS: int = 25
+
+
+# Default executable name on PATH. Operators can override via
+# ``CLAUDE_BIN`` env var in adjacent tooling; this module deliberately
+# doesn't read env vars itself so the unit tests have nothing to
+# monkeypatch beyond ``subprocess.run`` / ``shutil.which``. The
+# repository-layer hook decides whether to call us at all (env var
+# ``WHILLY_TRIZ_ENABLED``) — see :class:`whilly.adapters.db.repository
+# .TaskRepository.fail_task`.
+CLAUDE_BIN: str = "claude"
+
+
+# Stable enum values for structured warning logs. Pinned by
+# VAL-TRIZ-016 / the public log contract. Surfaced as
+# ``record.event`` extra on each WARNING record.
+LOG_EVENT_CLAUDE_MISSING: str = "triz.claude_missing"
+LOG_EVENT_TIMEOUT: str = "triz.timeout"
+LOG_EVENT_PARSE_ERROR: str = "triz.parse_error"
+
+
+# Reason strings used by :class:`TrizOutcome` to communicate the
+# specific soft-fail mode upward to the executor hook. The repository
+# uses ``"timeout"`` to drive the ``triz.error`` event row write
+# (VAL-TRIZ-004); the other two are diagnostic only — no event row.
+ERROR_REASON_TIMEOUT: str = "timeout"
+ERROR_REASON_CLAUDE_MISSING: str = "claude_missing"
+ERROR_REASON_PARSE_ERROR: str = "parse_error"
+
+
+@dataclass(frozen=True)
+class TrizFinding:
+    """Pure-data outcome of a positive :func:`analyze_contradiction` verdict.
+
+    Frozen + value-equality so the executor hook can serialise it
+    directly into the ``triz.contradiction`` event row's ``detail``
+    JSONB column via :func:`dataclasses.asdict`.
+
+    Attributes
+    ----------
+    contradiction_type:
+        Short label describing the contradiction kind, drawn from
+        canonical TRIZ vocabulary: ``"technical"`` (one parameter
+        improves while another worsens) or ``"physical"`` (object must
+        have property X *and* not-X simultaneously). The analyzer
+        echoes whatever string Claude returns; downstream consumers
+        should not depend on a closed enum since real TRIZ analysis
+        often surfaces hybrid labels.
+    reason:
+        Human-readable summary of the contradiction. The live-smoke
+        contract (VAL-TRIZ-013) requires ≥ 20 chars of natural
+        language; the analyzer does not enforce a floor itself —
+        operators should treat very short reason strings as a hint
+        Claude failed to engage with the prompt.
+    """
+
+    contradiction_type: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class TrizOutcome:
+    """Internal richer outcome used by the executor hook.
+
+    The public :func:`analyze_contradiction` collapses everything except
+    a positive verdict to ``None`` (per the spec'd ``TrizFinding | None``
+    return type). The hook in
+    :class:`whilly.adapters.db.repository.TaskRepository` needs more
+    detail to decide whether to write a ``triz.error`` event row
+    (timeout) versus skip silently (claude absent / parse error). This
+    type carries that classification.
+
+    Attributes
+    ----------
+    finding:
+        The :class:`TrizFinding` on a positive verdict; ``None``
+        otherwise (no contradiction, OR any soft-fail mode).
+    error_reason:
+        ``None`` on the success / no-contradiction path. One of
+        :data:`ERROR_REASON_TIMEOUT`, :data:`ERROR_REASON_CLAUDE_MISSING`,
+        :data:`ERROR_REASON_PARSE_ERROR` on the soft-fail path. The
+        hook layer keys on ``ERROR_REASON_TIMEOUT`` to write a
+        ``triz.error`` event row (VAL-TRIZ-004) and ignores the other
+        two (VAL-TRIZ-003 / VAL-TRIZ-005 — log only, no event row).
+    """
+
+    finding: TrizFinding | None
+    error_reason: str | None = None
+
+
+# Master prompt for the per-task TRIZ analyzer. Kept short and
+# deliberately structured so Claude's --print mode (no tool use)
+# returns a small JSON payload that we can parse with stdlib json.
+# The "ONLY JSON" stipulation is critical — anything else triggers the
+# parse_error soft-fail mode.
+_PROMPT_TEMPLATE = """\
+You are a TRIZ (Theory of Inventive Problem Solving) analyst.
+
+Analyse the task below for a *single* technical or physical contradiction
+that, if present, would block straightforward implementation.
+
+Task description:
+{description}
+
+Acceptance criteria:
+{acceptance}
+
+Output ONLY valid JSON, no markdown, no prose. Use this exact shape:
+{{
+  "contradictory": true | false,
+  "contradiction_type": "technical" | "physical" | "" ,
+  "reason": "<one or two sentences naming the contradiction; empty when contradictory=false>"
+}}
+
+Rules:
+- "contradictory": true only when there is a clear, named contradiction.
+- "contradiction_type": "" when contradictory=false; otherwise either
+  "technical" (one parameter improves while another worsens) or "physical"
+  (the object must have a property and its negation simultaneously).
+- "reason": >= 20 characters when contradictory=true; "" when
+  contradictory=false.
+"""
+
+
+def _build_prompt(task: Task) -> str:
+    """Build the per-task TRIZ prompt for the ``claude`` subprocess.
+
+    Pure: depends only on the input :class:`Task`. The prompt is
+    structured so a forgetful Claude that drops back to natural prose
+    still triggers the parse_error soft-fail mode rather than
+    accidentally returning a malformed dict that we'd nominally
+    accept.
+    """
+    desc = (task.description or "").strip() or "(no description)"
+    if task.acceptance_criteria:
+        acceptance = "\n".join(f"- {ac}" for ac in task.acceptance_criteria)
+    else:
+        acceptance = "(none)"
+    return _PROMPT_TEMPLATE.format(description=desc, acceptance=acceptance)
+
+
+def _log_warning(event: str, message: str, *args: object) -> None:
+    """Emit a single structured WARNING record on the module logger.
+
+    Centralised so every soft-fail mode goes through the same surface:
+    one ``logger.warning`` call, one record, ``record.event`` set to
+    the documented enum value (VAL-TRIZ-012 / VAL-TRIZ-016).
+    """
+    logger.warning(message, *args, extra={"event": event})
+
+
+def _parse_finding(raw: str) -> TrizFinding | None:
+    """Parse the ``claude`` subprocess stdout into a :class:`TrizFinding`.
+
+    Returns
+    -------
+    TrizFinding | None
+        - ``TrizFinding`` when the JSON is valid AND
+          ``contradictory == True`` AND
+          ``contradiction_type`` is a non-empty string AND
+          ``reason`` is a non-empty string.
+        - ``None`` when the JSON is valid but ``contradictory == False``
+          (the no-contradiction happy path; not an error).
+
+    Raises
+    ------
+    ValueError
+        On malformed JSON or on a payload whose shape doesn't match
+        the contract. The caller (:func:`_analyze`) translates
+        ``ValueError`` into the parse_error soft-fail mode.
+    """
+    text = raw.strip()
+    if not text:
+        raise ValueError("empty subprocess stdout")
+    # Trim a leading ``json``-fenced block if Claude couldn't help itself.
+    if text.startswith("```"):
+        # naive fence stripping — covers the ```json ... ``` case
+        first_nl = text.find("\n")
+        if first_nl != -1:
+            text = text[first_nl + 1 :]
+        if text.endswith("```"):
+            text = text[:-3]
+        text = text.strip()
+    try:
+        doc = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"json decode error: {exc}") from exc
+    if not isinstance(doc, dict):
+        raise ValueError("top-level JSON must be an object")
+    contradictory = doc.get("contradictory")
+    if contradictory is False:
+        return None
+    if contradictory is not True:
+        raise ValueError("missing or non-boolean 'contradictory' key")
+    contradiction_type = doc.get("contradiction_type")
+    reason = doc.get("reason")
+    if not isinstance(contradiction_type, str) or not contradiction_type:
+        raise ValueError("missing or empty 'contradiction_type'")
+    if not isinstance(reason, str) or not reason:
+        raise ValueError("missing or empty 'reason'")
+    return TrizFinding(contradiction_type=contradiction_type, reason=reason)
+
+
+def _analyze(task: Task) -> TrizOutcome:
+    """Subprocess the ``claude`` CLI and classify its outcome.
+
+    Returns a :class:`TrizOutcome` carrying either the parsed finding
+    or the soft-fail classification (so the executor hook can decide
+    to write a ``triz.error`` event row on timeout).
+
+    Failure modes (each emits exactly one structured WARNING):
+
+    * claude absent — :func:`shutil.which` returns ``None`` or
+      :class:`FileNotFoundError` is raised by the subprocess.
+    * subprocess :class:`subprocess.TimeoutExpired` after
+      :data:`TIMEOUT_SECONDS`.
+    * non-zero exit — surfaces as parse_error (the stdout is unlikely
+      to contain valid JSON).
+    * malformed / shape-mismatched JSON — surfaces as parse_error.
+    """
+    if shutil.which(CLAUDE_BIN) is None:
+        _log_warning(
+            LOG_EVENT_CLAUDE_MISSING,
+            "TRIZ analyzer: %r CLI not found on PATH; skipping",
+            CLAUDE_BIN,
+        )
+        return TrizOutcome(finding=None, error_reason=ERROR_REASON_CLAUDE_MISSING)
+
+    prompt = _build_prompt(task)
+    cmd = [CLAUDE_BIN, "--print", "-p", prompt]
+    try:
+        # Hard timeout (VAL-TRIZ-006 / VAL-TRIZ-007). ``check=False`` so a
+        # non-zero exit lands in our parse_error path — we never want
+        # ``CalledProcessError`` propagating into the executor.
+        completed = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=TIMEOUT_SECONDS,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        _log_warning(
+            LOG_EVENT_TIMEOUT,
+            "TRIZ analyzer: claude CLI timed out after %ss",
+            TIMEOUT_SECONDS,
+        )
+        return TrizOutcome(finding=None, error_reason=ERROR_REASON_TIMEOUT)
+    except FileNotFoundError:
+        # ``shutil.which`` already gated this; defensive in case
+        # ``claude`` was removed mid-call (unlikely but cheap to guard).
+        _log_warning(
+            LOG_EVENT_CLAUDE_MISSING,
+            "TRIZ analyzer: %r CLI vanished mid-call (FileNotFoundError); skipping",
+            CLAUDE_BIN,
+        )
+        return TrizOutcome(finding=None, error_reason=ERROR_REASON_CLAUDE_MISSING)
+
+    if completed.returncode != 0:
+        _log_warning(
+            LOG_EVENT_PARSE_ERROR,
+            "TRIZ analyzer: claude exited with non-zero code %d (stderr=%r); treating as parse error",
+            completed.returncode,
+            (completed.stderr or "")[:200],
+        )
+        return TrizOutcome(finding=None, error_reason=ERROR_REASON_PARSE_ERROR)
+
+    try:
+        finding = _parse_finding(completed.stdout or "")
+    except ValueError as exc:
+        _log_warning(
+            LOG_EVENT_PARSE_ERROR,
+            "TRIZ analyzer: failed to parse claude output: %s",
+            exc,
+        )
+        return TrizOutcome(finding=None, error_reason=ERROR_REASON_PARSE_ERROR)
+
+    return TrizOutcome(finding=finding, error_reason=None)
+
+
+def analyze_contradiction_with_outcome(task: Task) -> TrizOutcome:
+    """Public richer-outcome variant of :func:`analyze_contradiction`.
+
+    Used by the executor hook in
+    :class:`whilly.adapters.db.repository.TaskRepository.fail_task` to
+    decide whether to write a ``triz.error`` event row (timeout case).
+
+    Returns
+    -------
+    TrizOutcome
+        See :class:`TrizOutcome` for the field semantics.
+    """
+    return _analyze(task)
+
+
+def analyze_contradiction(task: Task) -> TrizFinding | None:
+    """Run the per-task TRIZ analyzer.
+
+    Spawns the ``claude`` CLI with a TRIZ-tuned prompt and a hard
+    25-second timeout. Returns the :class:`TrizFinding` on a positive
+    verdict; ``None`` for every other outcome (no contradiction *and*
+    every documented soft-fail mode: claude absent, timeout, malformed
+    JSON, claude non-zero exit). Never re-raises (VAL-TRIZ-015).
+
+    Side effects:
+
+    * Subprocesses ``claude`` (one invocation per call).
+    * Emits **exactly one** WARNING record on the ``whilly.core.triz``
+      logger per soft-fail mode (VAL-TRIZ-012). The record carries a
+      ``record.event`` extra drawn from
+      ``{"triz.claude_missing", "triz.timeout", "triz.parse_error"}``
+      (VAL-TRIZ-016).
+
+    Args
+    ----
+    task:
+        Task to analyse. Only ``description`` and ``acceptance_criteria``
+        are read into the prompt; the rest of the dataclass is ignored.
+
+    Returns
+    -------
+    TrizFinding | None
+        ``TrizFinding(contradiction_type, reason)`` on a positive
+        verdict; ``None`` otherwise.
+    """
+    return _analyze(task).finding


### PR DESCRIPTION
Closes TASK-104b.

Fulfills: VAL-TRIZ-001..016.

## What

Per-task TRIZ contradiction analysis hook that runs after a task is FAILED (gated by `WHILLY_TRIZ_ENABLED=1`):

- New `whilly/core/triz.py` with `analyze_contradiction(task) -> TrizFinding | None`:
  - Subprocess to `claude` CLI with **hard 25 s timeout** (well below the 30 s claim visibility-timeout — VAL-TRIZ-006).
  - Tolerant JSON parsing (markdown fence, leading prose).
  - **Fail-open** on every error path (claude missing / timeout / malformed JSON / non-zero exit / unexpected exception). Single structured warning per failure mode via `record.event` enum (`claude_missing`, `timeout`, `parse_error`).
- New alembic migration **`003_events_detail`** adds nullable `events.detail` JSONB column (no default, never literal `null` / `{}`). Mirrored in `schema.sql`.
- `TaskRepository.fail_task` extended with keyword-only `detail: dict | None = None` param → persisted into `events.detail` (VAL-TRIZ-008/009).
- New `_maybe_emit_triz_event()` runs **outside** the FAIL transaction: a TRIZ subprocess failure can never roll back the FAIL row (VAL-TRIZ-003). Writes a separate `triz.contradiction` event on positive verdict, `triz.error` on timeout, nothing on malformed / missing-claude.
- `.importlinter` adds narrow documented `ignore_imports` for `whilly.core.triz -> subprocess` and `shutil` (sole IO exception in core, scoped to one module).
- `live_llm` pytest marker registered.

## Tests

- **21 unit tests** (mocked `subprocess.run` + `shutil.which`): VAL-TRIZ-003/004/005/006/012/016 and helpers.
- **18 integration tests** against testcontainers Postgres: VAL-TRIZ-001/002/003/004/008/009/010/011/015 — `events.detail` JSONB round-trip, SQL NULL invariant, FAIL→`triz.contradiction` ordering, gate semantics, never-re-raise contract.
- **1 live smoke** (VAL-TRIZ-013/014): skipped without `WHILLY_RUN_LIVE_LLM=1`; fails loudly if `claude` is missing while the gate is on.

## Verification

- `pytest tests/unit -q` → **590 passed**.
- `pytest tests/integration/test_triz_hook.py -v` → **18 passed in 2.87 s**.
- `pytest tests/integration/test_triz_live.py -v` → **1 skipped** (correct gate behaviour).
- `lint-imports` → **1 contract kept, 0 broken**.
- `ruff check` / `ruff format --check` → clean.
- Alembic chain: `001 → 002 → 003_events_detail (head)`.

Co-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.github.com>