### PR TITLE
fix(sc5): include tests/unit/core/{test_gates,test_triz}.py in release smoke

### DIFF
--- a/tests/integration/test_release_smoke.py
+++ b/tests/integration/test_release_smoke.py
@@ -88,8 +88,12 @@ def test_sc_5_core_coverage_at_least_eighty_percent() -> None:
     try:
         # Step 1: collect coverage by running the unit tests that exercise
         # whilly.core specifically. tests/unit/test_state_machine.py +
-        # test_scheduler.py + test_prompts.py are authored to 100% on
-        # whilly/core/.
+        # test_scheduler.py + test_prompts.py are authored to 100% on the
+        # legacy whilly/core/ surface; tests/unit/core/test_gates.py
+        # (TASK-104c, PR #223) and tests/unit/core/test_triz.py (TASK-104b,
+        # PR #224) cover the v4.1 additions whilly/core/gates.py and
+        # whilly/core/triz.py — without them the SC-5 gate trips at 71%
+        # because triz.py shows 0% (90 stmts) and gates.py shows ~49%.
         run_args = [
             sys.executable,
             "-m",
@@ -102,6 +106,8 @@ def test_sc_5_core_coverage_at_least_eighty_percent() -> None:
             "tests/unit/test_state_machine.py",
             "tests/unit/test_scheduler.py",
             "tests/unit/test_prompts.py",
+            "tests/unit/core/test_gates.py",
+            "tests/unit/core/test_triz.py",
         ]
         run_result = subprocess.run(
             run_args,


### PR DESCRIPTION
Closes the M1 SC-5 scrutiny re-run blocker identified after TASK-104b/c merged.

### What

Update the hard-coded coverage-run argv in
`tests/integration/test_release_smoke.py::test_sc_5_core_coverage_at_least_eighty_percent`
to include the two new core test files added in M1:

- `tests/unit/core/test_gates.py` (TASK-104c, PR #223 — covers `whilly/core/gates.py`)
- `tests/unit/core/test_triz.py` (TASK-104b, PR #224 — covers `whilly/core/triz.py`)

Without these, coverage of `whilly/core/*` clocks in at ~71% on a fresh checkout
because `triz.py` reports 0% (90 stmts) and `gates.py` reports ~49%, tripping the
80% `--fail-under` gate.

Pure test-list update; no production code change.

### Validation contract

This is a release-smoke / scrutiny-validator infrastructure fix — the existing
SC-5 contract assertion (PRD NFR-4: "core coverage ≥ 80%") was being measured
against an obsolete file list. The fix restores the assertion to its intended
shape (measure all `tests/unit/core/*` plus the legacy state-machine /
scheduler / prompts trio) so M1 scrutiny can re-run cleanly.

### Test

Locally on `fix/sc5-coverage-include-new-core-tests` (off `main` @ 52c12b6):

- `pytest tests/integration/test_release_smoke.py::test_sc_5_core_coverage_at_least_eighty_percent -v` → **PASSED**
- `pytest tests/integration/test_release_smoke.py::test_sc_6_lint_imports_core_purity_kept -v` → **PASSED** (no regression)
- `ruff check whilly tests` → All checks passed
- `ruff format --check whilly tests` → 206 files already formatted
