### PR TITLE
fix(m1-scrutiny-r2): cross-plan strict guard + WORKTREE/USE_WORKSPACE no-op cleanup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,8 +39,11 @@
 # WHILLY_OPENCODE_SERVER_URL=          # Optional remote OpenCode server
 
 # ─── Workspaces, worktrees, tmux ─────────────────────────────────────────────
-# WHILLY_USE_WORKSPACE=1               # 0 = disable plan-level git worktree
-# WHILLY_WORKTREE=0                    # 1 = per-task worktree (needs MAX_PARALLEL>1)
+# WHILLY_USE_WORKSPACE / WHILLY_WORKTREE were plan-level / per-task git
+# worktree toggles in v3. Removed in v4 (TASK-107) — they are now no-ops kept
+# only for backward `.env` compatibility (the v4 CLI silently ignores them).
+# WHILLY_USE_WORKSPACE=                # removed no-op since v3.3+ (kept for backward script compat)
+# WHILLY_WORKTREE=                     # removed no-op since v3.3+ (kept for backward script compat)
 # WHILLY_USE_TMUX=0                    # 1 = run each agent in its own tmux session
 
 # ─── Orchestration & decomposition ───────────────────────────────────────────

--- a/tests/integration/test_strict_cross_plan.py
+++ b/tests/integration/test_strict_cross_plan.py
@@ -1,0 +1,259 @@
+"""Integration tests for cross-plan safety of ``whilly plan apply --strict``.
+
+Round-2 scrutiny finding (B1): the strict gate must not mutate task
+rows owned by a different plan, even when the parsed plan file carries
+a task id that collides with a row already in the ``tasks`` table.
+
+Background
+----------
+``tasks.id`` is the schema's global primary key. The ``plan apply``
+import path uses ``INSERT ... ON CONFLICT (id) DO NOTHING`` so a
+re-run is idempotent on plan_id. This means a plan whose task ids
+collide with rows already owned by *another* plan_id will silently
+have its tasks skipped at INSERT time — but ``--strict`` previously
+called ``repo.skip_task(task_id, version)`` against those ids
+regardless, mutating the *other* plan's rows.
+
+The fix snapshots the set of task ids that actually live under the
+applying plan's ``plan_id`` after the import transaction commits and
+refuses to call ``skip_task`` on any task id outside that set.
+
+These tests exercise that contract by seeding plan B first (the
+"victim") and then applying plan A (the "attacker") with ``--strict``;
+plan B's row must remain unchanged.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import asyncpg
+import pytest
+
+from tests.conftest import DOCKER_REQUIRED
+from whilly.adapters.db import close_pool, create_pool
+from whilly.cli.plan import DATABASE_URL_ENV, EXIT_OK, run_plan_command
+
+pytestmark = DOCKER_REQUIRED
+
+
+# ─── fixtures ────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def database_url(postgres_dsn: str) -> Iterator[str]:
+    """Set ``WHILLY_DATABASE_URL`` and TRUNCATE tables for one test."""
+    prior = os.environ.get(DATABASE_URL_ENV)
+    os.environ[DATABASE_URL_ENV] = postgres_dsn
+
+    async def _truncate() -> None:
+        pool = await create_pool(postgres_dsn)
+        try:
+            async with pool.acquire() as conn:
+                await conn.execute("TRUNCATE events, tasks, plans, workers RESTART IDENTITY CASCADE")
+        finally:
+            await close_pool(pool)
+
+    asyncio.run(_truncate())
+    try:
+        yield postgres_dsn
+    finally:
+        if prior is None:
+            os.environ.pop(DATABASE_URL_ENV, None)
+        else:
+            os.environ[DATABASE_URL_ENV] = prior
+
+
+def _write_plan(tmp_path: Path, name: str, payload: dict[str, Any]) -> Path:
+    target = tmp_path / name
+    target.write_text(json.dumps(payload), encoding="utf-8")
+    return target
+
+
+def _query_db(postgres_dsn: str, sql: str, *args: object) -> list[asyncpg.Record]:
+    """Synchronous read helper — opens a fresh pool, runs one SELECT, closes."""
+
+    async def _go() -> list[asyncpg.Record]:
+        pool = await create_pool(postgres_dsn)
+        try:
+            async with pool.acquire() as conn:
+                return await conn.fetch(sql, *args)
+        finally:
+            await close_pool(pool)
+
+    return asyncio.run(_go())
+
+
+def _victim_plan_payload() -> dict[str, Any]:
+    """Plan B — healthy, owns the colliding task id ``T-SHARED``."""
+    return {
+        "plan_id": "plan-victim",
+        "project": "Victim Plan",
+        "tasks": [
+            {
+                "id": "T-SHARED",
+                "status": "PENDING",
+                "priority": "high",
+                "description": "Owned by plan B; must remain PENDING after the cross-plan apply.",
+                "dependencies": [],
+                "key_files": [],
+                "acceptance_criteria": ["plan B's AC stays in place"],
+                "test_steps": ["pytest -k victim"],
+                "prd_requirement": "",
+            },
+        ],
+    }
+
+
+def _attacker_plan_payload() -> dict[str, Any]:
+    """Plan A — gate-failing, shares the task id ``T-SHARED`` with plan B."""
+    return {
+        "plan_id": "plan-attacker",
+        "project": "Attacker Plan",
+        "tasks": [
+            {
+                "id": "T-SHARED",
+                "status": "PENDING",
+                "priority": "medium",
+                "description": "Refactor logging utilities to use structlog throughout.",
+                "dependencies": [],
+                "key_files": [],
+                # Empty AC → gate REJECT; --strict would historically call
+                # skip_task("T-SHARED", ...) and flip the victim row.
+                "acceptance_criteria": [],
+                "test_steps": ["pytest -k logging"],
+                "prd_requirement": "",
+            },
+        ],
+    }
+
+
+# ─── B1 round-2 cross-plan safety (primary contract) ─────────────────────
+
+
+def test_strict_apply_does_not_mutate_other_plans_task(
+    database_url: str,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Strict apply on plan A leaves plan B's colliding task untouched."""
+    victim_file = _write_plan(tmp_path, "victim.json", _victim_plan_payload())
+    attacker_file = _write_plan(tmp_path, "attacker.json", _attacker_plan_payload())
+
+    # Seed plan B with the shared task id first — it owns the row.
+    assert run_plan_command(["import", str(victim_file)]) == EXIT_OK
+    capsys.readouterr()  # drain output from the seed import
+
+    pre_rows = _query_db(
+        database_url,
+        "SELECT id, plan_id, status, version FROM tasks WHERE id = $1",
+        "T-SHARED",
+    )
+    assert len(pre_rows) == 1, "victim plan should own exactly one T-SHARED row"
+    pre_row = pre_rows[0]
+    assert pre_row["plan_id"] == "plan-victim"
+    assert pre_row["status"] == "PENDING"
+    pre_version = pre_row["version"]
+
+    # Apply the attacker plan with --strict. The shared id must not
+    # be flipped to SKIPPED on plan B's row.
+    rc = run_plan_command(["apply", "--strict", str(attacker_file)])
+    assert rc == EXIT_OK
+
+    captured = capsys.readouterr()
+    # Stderr names the collision so the operator can investigate.
+    assert "T-SHARED" in captured.err
+    assert "collide" in captured.err.lower() or "collision" in captured.err.lower()
+
+    # Plan B's task is untouched: same plan_id, still PENDING, version
+    # unchanged (no UPDATE applied).
+    post_rows = _query_db(
+        database_url,
+        "SELECT id, plan_id, status, version FROM tasks WHERE id = $1",
+        "T-SHARED",
+    )
+    assert len(post_rows) == 1
+    post_row = post_rows[0]
+    assert post_row["plan_id"] == "plan-victim", "cross-plan mutation: T-SHARED must remain owned by plan B"
+    assert post_row["status"] == "PENDING", "cross-plan mutation: T-SHARED must remain PENDING"
+    assert post_row["version"] == pre_version, "cross-plan mutation: T-SHARED version must not advance"
+
+    # No SKIP event row references T-SHARED — the strict path refused
+    # to call skip_task on the colliding id.
+    skip_events = _query_db(
+        database_url,
+        "SELECT task_id FROM events WHERE task_id = $1 AND event_type = 'SKIP'",
+        "T-SHARED",
+    )
+    assert skip_events == [], "cross-plan mutation: SKIP event row was written for T-SHARED"
+
+    # Plan A is recorded but contributed no tasks (the only task id
+    # collided and was skipped at INSERT time).
+    plan_a_rows = _query_db(
+        database_url,
+        "SELECT id FROM plans WHERE id = $1",
+        "plan-attacker",
+    )
+    assert len(plan_a_rows) == 1
+    plan_a_tasks = _query_db(
+        database_url,
+        "SELECT id FROM tasks WHERE plan_id = $1",
+        "plan-attacker",
+    )
+    assert plan_a_tasks == []
+
+
+def test_strict_apply_still_skips_own_failing_tasks(
+    database_url: str,
+    tmp_path: Path,
+) -> None:
+    """The cross-plan guard does not regress single-plan strict-skip behavior."""
+    payload = {
+        "plan_id": "plan-solo",
+        "project": "Solo Plan",
+        "tasks": [
+            {
+                "id": "T-OK-1",
+                "status": "PENDING",
+                "priority": "high",
+                "description": "Implement the feature flag rollout for the dashboard.",
+                "dependencies": [],
+                "key_files": [],
+                "acceptance_criteria": ["dashboard shows the flag"],
+                "test_steps": ["pytest -k dashboard"],
+                "prd_requirement": "",
+            },
+            {
+                "id": "T-BAD-EMPTY-AC",
+                "status": "PENDING",
+                "priority": "medium",
+                "description": "Refactor logging utilities to use structlog throughout.",
+                "dependencies": [],
+                "key_files": [],
+                "acceptance_criteria": [],
+                "test_steps": ["pytest -k logging"],
+                "prd_requirement": "",
+            },
+        ],
+    }
+    plan_file = _write_plan(tmp_path, "solo.json", payload)
+    assert run_plan_command(["apply", "--strict", str(plan_file)]) == EXIT_OK
+
+    rows = _query_db(
+        database_url,
+        "SELECT id, status FROM tasks WHERE plan_id = $1 ORDER BY id",
+        "plan-solo",
+    )
+    by_id = {row["id"]: row["status"] for row in rows}
+    assert by_id == {"T-OK-1": "PENDING", "T-BAD-EMPTY-AC": "SKIPPED"}
+
+    skip_events = _query_db(
+        database_url,
+        "SELECT task_id FROM events WHERE event_type = 'SKIP'",
+    )
+    assert {row["task_id"] for row in skip_events} == {"T-BAD-EMPTY-AC"}

--- a/whilly/cli/plan.py
+++ b/whilly/cli/plan.py
@@ -1212,12 +1212,50 @@ async def _async_apply(
     own per-row transactions inside :meth:`skip_task`. The gate
     iteration intentionally does *not* share the import transaction:
     we want every task imported even if a later ``skip_task`` raises.
+
+    Cross-plan safety (round-2 scrutiny fix)
+    ----------------------------------------
+    ``tasks.id`` is the schema's primary key — globally unique across
+    all plans. Combined with the import path's ``ON CONFLICT (id) DO
+    NOTHING`` semantics, a task id present in this plan's JSON file
+    might already exist in the database under a *different* ``plan_id``
+    (e.g. an operator copy-pasted ``T-OK-1`` between two plan files).
+    In that case the row in ``tasks`` belongs to the other plan, and
+    ``--strict`` calling :meth:`skip_task` against ``task.id`` would
+    flip *that* row to SKIPPED — a cross-plan mutation bug.
+
+    Mitigation: after the INSERT transaction commits, fetch the set of
+    task ids that actually live under *our* ``plan_id`` and gate-iterate
+    only those. Any parsed-from-file task whose id does not appear in
+    that set is reported as a collision warning (stderr) instead of
+    being skipped. This covers three observable scenarios cleanly:
+
+    * tasks freshly inserted by this apply → present in ``ours_ids``;
+    * tasks pre-existing for *this* plan (idempotent re-run) → present;
+    * tasks colliding with another plan's id → absent → never skipped.
+
+    The follow-up SELECT runs once per apply (cheap; one round trip
+    after the import transaction). It uses the same ``plan_id``
+    ``WHERE`` clause that ``_select_plan_with_tasks`` uses, so a future
+    refactor would only need to touch one SQL string.
     """
     pool = await create_pool(dsn)
     try:
         async with pool.acquire() as conn:
             async with conn.transaction():
                 await _insert_plan_and_tasks(conn, plan, tasks)
+
+            # Snapshot the set of task ids that actually live under
+            # our plan_id *after* the import committed. Used by the
+            # strict iteration below to refuse to skip tasks whose
+            # primary-key row belongs to a different plan (round-2
+            # scrutiny finding B1 — see the docstring section
+            # "Cross-plan safety" above).
+            owned_id_rows = await conn.fetch(
+                "SELECT id FROM tasks WHERE plan_id = $1",
+                plan.id,
+            )
+            owned_ids: set[TaskId] = {row["id"] for row in owned_id_rows}
 
         repo = TaskRepository(pool)
         skipped: list[TaskId] = []
@@ -1227,6 +1265,28 @@ async def _async_apply(
             if verdict.kind == GateVerdictKind.ALLOW:
                 continue
             if strict:
+                # Cross-plan safety guard: if the task id from the
+                # parsed file is not present under *our* plan_id in
+                # the database (because ``ON CONFLICT (id) DO NOTHING``
+                # left a pre-existing row owned by a different plan
+                # untouched), refuse to skip it — the SKIPPED transition
+                # would mutate the other plan's row. Surface a
+                # structured warning so the operator can investigate
+                # the id collision in their plan files.
+                if task.id not in owned_ids:
+                    logger.warning(
+                        "plan apply --strict: task %s not owned by plan %s "
+                        "(primary-key collision with another plan); refusing to skip",
+                        task.id,
+                        plan.id,
+                    )
+                    print(
+                        "whilly plan apply: warning: refusing to skip "
+                        f"{task.id!r} — task id collides with another plan's "
+                        f"row (this plan {plan.id!r} did not insert it).",
+                        file=sys.stderr,
+                    )
+                    continue
                 # ``task.version`` is the version we just inserted (0
                 # by default); the row was created in this same call
                 # so no other writer can have advanced it. The

--- a/whilly/config.py
+++ b/whilly/config.py
@@ -86,8 +86,12 @@ class WhillyConfig:
     HEADLESS: bool = False
     TIMEOUT: int = 0
     STATE_FILE: str = ".whilly_state.json"
-    WORKTREE: bool = False  # WHILLY_WORKTREE=1 — per-task git worktree (только при MAX_PARALLEL > 1)
-    USE_WORKSPACE: bool = False  # WHILLY_USE_WORKSPACE=1 (или --workspace) — включить plan-level worktree
+    # WHILLY_WORKTREE / WHILLY_USE_WORKSPACE were per-task / plan-level git
+    # worktree toggles in v3 — removed in v4 (TASK-107). The fields are
+    # retained as no-ops so legacy `.env` files / shell exports keep parsing
+    # without error; setting them has no behavioural effect on the v4 CLI.
+    WORKTREE: bool = False  # WHILLY_WORKTREE — removed no-op since v3.3+ (kept for backward .env compat)
+    USE_WORKSPACE: bool = False  # WHILLY_USE_WORKSPACE — removed no-op since v3.3+ (kept for backward .env compat)
 
     # Logging verbosity + retention
     VERBOSE: bool = False  # WHILLY_VERBOSE=1 (или --verbose/-v) — Whilly debug + ANTHROPIC_LOG=info

--- a/whilly/dashboard.py
+++ b/whilly/dashboard.py
@@ -1256,7 +1256,6 @@ class Dashboard:
             "  [dim]WHILLY_MODEL=opus-4-6[/]     Модель Claude\n"
             "  [dim]WHILLY_VOICE=0[/]            Отключить голосовые уведомления\n"
             "  [dim]WHILLY_WEB=1[/]              HTTP статус на localhost:9191\n"
-            "  [dim]WHILLY_WORKTREE=1[/]         Git worktree изоляция агентов\n"
             "  [dim]WHILLY_VERIFY=1[/]           Lint+test после каждой задачи\n\n"
             f"[bold]\u2666 Текущая сессия[/]\n"
             f"  Plan:       {plan_name}\n"


### PR DESCRIPTION
Closes M1 scrutiny round-2 cycle (3 findings B1/B2/B3 from synthesis report).

### What

**B1 — strict-gate cross-plan mutation risk**
- `whilly/cli/plan.py::_async_apply`: After the import transaction
  commits, snapshot the set of task ids that actually live under our
  `plan_id` (one extra `SELECT id FROM tasks WHERE plan_id = $1`) and
  refuse to call `repo.skip_task` on any id outside that set.
- Approach **(c)** from the feature spec: explicit plan_id check in
  the CLI before calling `skip_task`. Chosen over (a) (RETURNING from
  INSERT) because (c) preserves the operator workflow "tried default,
  now want strict" — re-runs against the same plan still gate-evaluate
  pre-existing rows, while cross-plan id collisions are rejected.
- Cross-plan colliding task ids surface as a structured stderr warning
  ("refusing to skip ... — task id collides with another plan's row").

**B2 — dashboard help text still advertised WHILLY_WORKTREE**
- `whilly/dashboard.py::_show_help`: removed the `WHILLY_WORKTREE=1`
  line from the v3 hotkey-help overlay so it no longer conflicts with
  VAL-LEGACY-009 (the env var is a removed no-op since v3.3+).
- `whilly --help` and `whilly dashboard --help` both already pass the
  feature's grep contract (no `worktree` / `workspace` mentions).

**B3 — config comments still described WORKTREE behavior as active**
- `whilly/config.py`: `WORKTREE` / `USE_WORKSPACE` field comments now
  document them as "removed no-op since v3.3+ (kept for backward .env
  compat)".
- `.env.example`: `WHILLY_USE_WORKSPACE` / `WHILLY_WORKTREE` entries
  documented as removed no-ops kept only for backward script compat.

### Validation contract
Fulfills (round-2 expected behavior, see feature spec):
- strict-mode apply on plan A does NOT mutate task statuses in plan B
  even if task_id collides
- new integration test creates two plans with shared task_id, strict-
  applies plan A, asserts plan B task still PENDING and no SKIP event
  row references plan B's task
- `whilly dashboard --help` / `whilly --help` do NOT advertise
  WHILLY_WORKTREE / WHILLY_USE_WORKSPACE as having any effect
- env vars documented as "removed no-op" wherever they appear in
  `.env.example` / `whilly/config.py`

### Test

```
$ pytest tests/integration/test_strict_flag.py tests/integration/test_strict_cross_plan.py -v
9 passed in 3.39s

$ pytest tests/integration -q --ignore=tests/integration/test_triz_live.py
159 passed in 83.16s

$ pytest -q --ignore=tests/integration/test_triz_live.py
1396 passed in 90.41s

$ ruff check whilly tests
All checks passed!

$ ruff format --check whilly tests
207 files already formatted

$ lint-imports
Contracts: 1 kept, 0 broken.

$ mypy --strict whilly/core
Success: no issues found in 7 source files

$ whilly --help | grep -i -E 'worktree|workspace'
(empty)

$ whilly dashboard --help | grep -i -E 'worktree|workspace'
(empty)
```
