### PR TITLE
fix(task-101-r1): bind bearer-token identity to request worker_id

### DIFF
--- a/tests/integration/test_per_worker_auth.py
+++ b/tests/integration/test_per_worker_auth.py
@@ -306,25 +306,260 @@ async def test_revocation_via_set_null_blocks_subsequent_rpc(
 
 
 # ---------------------------------------------------------------------------
-# VAL-AUTH-024 — cross-worker bearer on path-bound RPC returns 4xx
+# VAL-AUTH-024 — cross-worker bearer on every identity-bound RPC returns 403
 # ---------------------------------------------------------------------------
+#
+# Each of the five steady-state RPCs is exercised independently (heartbeat,
+# claim, complete, fail, release) — together with a sixth test that keeps
+# the body↔path 400 branch covered. This is the TASK-101 scrutiny round-1
+# fix: prior to the identity-binding change the only cross-worker test was
+# heartbeat with body!=path (which surfaces as 400, NOT a real token-owner
+# check). VAL-AUTH-024's evidence clause accepts ``(400, 401, 403)``;
+# token-owner mismatch is 403 ("auth succeeded, you can't do this") so
+# operator dashboards can split schema-validation 400s from authorisation
+# 403s cleanly.
 
 
-async def test_cross_worker_bearer_returns_4xx(
+async def test_cross_worker_bearer_on_heartbeat_returns_403(
     http_client_no_legacy: AsyncClient,
+    db_pool: asyncpg.Pool,
 ) -> None:
-    """Worker A's bearer on worker B's heartbeat path → 4xx (no heartbeat written for B)."""
+    """A's bearer on B's heartbeat (body=B, path=B) → 403; B's last_heartbeat unchanged."""
     worker_a, token_a = await _register(http_client_no_legacy, "host-cross-a")
     worker_b, _ = await _register(http_client_no_legacy, "host-cross-b")
 
-    # A's bearer authenticates as A; the body's worker_id (=B per the
-    # path) doesn't match, so the handler returns 400.
+    async with db_pool.acquire() as conn:
+        before = await conn.fetchval(
+            "SELECT last_heartbeat FROM workers WHERE worker_id = $1",
+            worker_b,
+        )
+
     response = await http_client_no_legacy.post(
         f"/workers/{worker_b}/heartbeat",
-        json={"worker_id": worker_a},  # body says A, path says B
+        json={"worker_id": worker_b},  # body and path both B; only bearer differs
         headers={"Authorization": f"Bearer {token_a}"},
     )
-    assert response.status_code in (400, 401, 403)
+
+    assert response.status_code == 403, response.text
+    assert worker_a in response.text or worker_b in response.text
+
+    async with db_pool.acquire() as conn:
+        after = await conn.fetchval(
+            "SELECT last_heartbeat FROM workers WHERE worker_id = $1",
+            worker_b,
+        )
+    assert after == before, "rejected heartbeat must not advance workers.last_heartbeat"
+
+
+async def test_cross_worker_bearer_on_claim_returns_403(
+    http_client_no_legacy: AsyncClient,
+    db_pool: asyncpg.Pool,
+) -> None:
+    """A's bearer + body{worker_id:B, plan_id:...} → 403; task stays PENDING; no events."""
+    plan_id = "PLAN-CROSS-CLAIM"
+    task_id = "T-cross-claim-1"
+    await _seed_task(db_pool, plan_id, task_id)
+    _worker_a, token_a = await _register(http_client_no_legacy, "host-cross-claim-a")
+    worker_b, _ = await _register(http_client_no_legacy, "host-cross-claim-b")
+
+    response = await http_client_no_legacy.post(
+        CLAIM_PATH,
+        json={"worker_id": worker_b, "plan_id": plan_id},
+        headers={"Authorization": f"Bearer {token_a}"},
+    )
+    assert response.status_code == 403, response.text
+
+    async with db_pool.acquire() as conn:
+        row = await conn.fetchrow(
+            "SELECT status, claimed_by, version FROM tasks WHERE id = $1",
+            task_id,
+        )
+        events_count = await conn.fetchval(
+            "SELECT count(*) FROM events WHERE task_id = $1",
+            task_id,
+        )
+    assert row is not None
+    assert row["status"] == "PENDING", "task must remain PENDING after rejected claim"
+    assert row["claimed_by"] is None
+    assert row["version"] == 0
+    assert events_count == 0, "no event row may be written on a rejected claim"
+
+
+async def test_cross_worker_bearer_on_complete_returns_403(
+    http_client_no_legacy: AsyncClient,
+    db_pool: asyncpg.Pool,
+) -> None:
+    """B legitimately claims; A's bearer + body{worker_id:B} on /complete → 403; task unchanged."""
+    plan_id = "PLAN-CROSS-COMPLETE"
+    task_id = "T-cross-complete-1"
+    await _seed_task(db_pool, plan_id, task_id)
+    _worker_a, token_a = await _register(http_client_no_legacy, "host-cross-complete-a")
+    worker_b, token_b = await _register(http_client_no_legacy, "host-cross-complete-b")
+
+    # B claims legitimately.
+    r_claim = await http_client_no_legacy.post(
+        CLAIM_PATH,
+        json={"worker_id": worker_b, "plan_id": plan_id},
+        headers={"Authorization": f"Bearer {token_b}"},
+    )
+    assert r_claim.status_code == 200, r_claim.text
+    claimed_version = r_claim.json()["task"]["version"]
+
+    async with db_pool.acquire() as conn:
+        before = await conn.fetchrow(
+            "SELECT status, version FROM tasks WHERE id = $1",
+            task_id,
+        )
+        events_before = await conn.fetchval(
+            "SELECT count(*) FROM events WHERE task_id = $1",
+            task_id,
+        )
+
+    response = await http_client_no_legacy.post(
+        f"/tasks/{task_id}/complete",
+        json={"worker_id": worker_b, "version": claimed_version, "cost_usd": "0.01"},
+        headers={"Authorization": f"Bearer {token_a}"},
+    )
+    assert response.status_code == 403, response.text
+
+    async with db_pool.acquire() as conn:
+        after = await conn.fetchrow(
+            "SELECT status, version FROM tasks WHERE id = $1",
+            task_id,
+        )
+        events_after = await conn.fetchval(
+            "SELECT count(*) FROM events WHERE task_id = $1",
+            task_id,
+        )
+    assert after == before, "task row must not change on rejected complete"
+    assert events_after == events_before, "no event row may be written on rejected complete"
+
+
+async def test_cross_worker_bearer_on_fail_returns_403(
+    http_client_no_legacy: AsyncClient,
+    db_pool: asyncpg.Pool,
+) -> None:
+    """B legitimately claims; A's bearer + body{worker_id:B} on /fail → 403; task unchanged."""
+    plan_id = "PLAN-CROSS-FAIL"
+    task_id = "T-cross-fail-1"
+    await _seed_task(db_pool, plan_id, task_id)
+    _worker_a, token_a = await _register(http_client_no_legacy, "host-cross-fail-a")
+    worker_b, token_b = await _register(http_client_no_legacy, "host-cross-fail-b")
+
+    r_claim = await http_client_no_legacy.post(
+        CLAIM_PATH,
+        json={"worker_id": worker_b, "plan_id": plan_id},
+        headers={"Authorization": f"Bearer {token_b}"},
+    )
+    assert r_claim.status_code == 200, r_claim.text
+    claimed_version = r_claim.json()["task"]["version"]
+
+    async with db_pool.acquire() as conn:
+        before = await conn.fetchrow(
+            "SELECT status, version FROM tasks WHERE id = $1",
+            task_id,
+        )
+        events_before = await conn.fetchval(
+            "SELECT count(*) FROM events WHERE task_id = $1",
+            task_id,
+        )
+
+    response = await http_client_no_legacy.post(
+        f"/tasks/{task_id}/fail",
+        json={
+            "worker_id": worker_b,
+            "version": claimed_version,
+            "reason": "cross-worker-fail-test",
+        },
+        headers={"Authorization": f"Bearer {token_a}"},
+    )
+    assert response.status_code == 403, response.text
+
+    async with db_pool.acquire() as conn:
+        after = await conn.fetchrow(
+            "SELECT status, version FROM tasks WHERE id = $1",
+            task_id,
+        )
+        events_after = await conn.fetchval(
+            "SELECT count(*) FROM events WHERE task_id = $1",
+            task_id,
+        )
+    assert after == before, "task row must not change on rejected fail"
+    assert events_after == events_before, "no event row may be written on rejected fail"
+
+
+async def test_cross_worker_bearer_on_release_returns_403(
+    http_client_no_legacy: AsyncClient,
+    db_pool: asyncpg.Pool,
+) -> None:
+    """B legitimately claims; A's bearer + body{worker_id:B} on /release → 403; task unchanged."""
+    plan_id = "PLAN-CROSS-RELEASE"
+    task_id = "T-cross-release-1"
+    await _seed_task(db_pool, plan_id, task_id)
+    _worker_a, token_a = await _register(http_client_no_legacy, "host-cross-release-a")
+    worker_b, token_b = await _register(http_client_no_legacy, "host-cross-release-b")
+
+    r_claim = await http_client_no_legacy.post(
+        CLAIM_PATH,
+        json={"worker_id": worker_b, "plan_id": plan_id},
+        headers={"Authorization": f"Bearer {token_b}"},
+    )
+    assert r_claim.status_code == 200, r_claim.text
+    claimed_version = r_claim.json()["task"]["version"]
+
+    async with db_pool.acquire() as conn:
+        before = await conn.fetchrow(
+            "SELECT status, version FROM tasks WHERE id = $1",
+            task_id,
+        )
+        events_before = await conn.fetchval(
+            "SELECT count(*) FROM events WHERE task_id = $1",
+            task_id,
+        )
+
+    response = await http_client_no_legacy.post(
+        f"/tasks/{task_id}/release",
+        json={
+            "worker_id": worker_b,
+            "version": claimed_version,
+            "reason": "cross-worker-release-test",
+        },
+        headers={"Authorization": f"Bearer {token_a}"},
+    )
+    assert response.status_code == 403, response.text
+
+    async with db_pool.acquire() as conn:
+        after = await conn.fetchrow(
+            "SELECT status, version FROM tasks WHERE id = $1",
+            task_id,
+        )
+        events_after = await conn.fetchval(
+            "SELECT count(*) FROM events WHERE task_id = $1",
+            task_id,
+        )
+    assert after == before, "task row must not change on rejected release"
+    assert events_after == events_before, "no event row may be written on rejected release"
+
+
+async def test_heartbeat_body_path_mismatch_returns_400(
+    http_client_no_legacy: AsyncClient,
+) -> None:
+    """Body↔path mismatch is its own branch — independently exercised from the 403 token-owner check.
+
+    Register A; POST /workers/{A}/heartbeat with body {worker_id: <other>}
+    and bearer token_a. The body↔path 400 check fires AHEAD of the
+    token-owner 403 check (server.py heartbeat handler), so this case
+    must surface as 400 even though the bearer is valid for A.
+    """
+    worker_a, token_a = await _register(http_client_no_legacy, "host-bp-mismatch")
+
+    response = await http_client_no_legacy.post(
+        f"/workers/{worker_a}/heartbeat",
+        json={"worker_id": "w-other"},  # body != path
+        headers={"Authorization": f"Bearer {token_a}"},
+    )
+    assert response.status_code == 400, response.text
+    assert "does not match" in response.json()["detail"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_bearer_dep.py
+++ b/tests/unit/test_bearer_dep.py
@@ -60,6 +60,8 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Iterator
+from types import SimpleNamespace
+from typing import Any
 
 import pytest
 from fastapi import HTTPException
@@ -71,6 +73,19 @@ from whilly.adapters.transport.auth import (
     make_db_bearer_auth,
     reset_legacy_warning_state,
 )
+
+
+def _request_stub() -> Any:
+    """Build a stand-in for :class:`fastapi.Request`.
+
+    :func:`make_db_bearer_auth` reads / writes only ``request.state``
+    (Starlette's free-form attribute bag), so a :class:`SimpleNamespace`
+    carrying its own nested ``state`` namespace is functionally
+    identical to the real Starlette ``State`` object for our purposes.
+    Avoids constructing a full Starlette ``Request`` (which needs an
+    ASGI ``scope`` dict that would add no signal here).
+    """
+    return SimpleNamespace(state=SimpleNamespace())
 
 
 class _FakeTaskRepository:
@@ -127,10 +142,16 @@ async def test_db_bearer_auth_accepts_registered_token() -> None:
     repo.register("plaintext-A", "w-alpha")
 
     dep = make_db_bearer_auth(repo)
-    result = await dep("Bearer plaintext-A")
+    request = _request_stub()
+    result = await dep(request, "Bearer plaintext-A")
 
     assert result is None
     assert repo.hits == 1, "DB lookup should have run exactly once"
+    # Identity-binding contract (TASK-101 scrutiny round-1 fix):
+    # successful per-worker hash hit stashes worker_id on request.state
+    # so the route handler's ``_require_token_owner`` check can compare
+    # against the body / path identity (see VAL-AUTH-024).
+    assert request.state.authenticated_worker_id == "w-alpha"
 
 
 # ---------------------------------------------------------------------------
@@ -146,7 +167,7 @@ async def test_db_bearer_auth_rejects_unknown_token() -> None:
 
     dep = make_db_bearer_auth(repo)
     with pytest.raises(HTTPException) as exc_info:
-        await dep("Bearer some-other-bearer")
+        await dep(_request_stub(), "Bearer some-other-bearer")
 
     assert exc_info.value.status_code == 401
     assert exc_info.value.detail == "invalid token"
@@ -162,7 +183,7 @@ async def test_db_bearer_auth_rejects_missing_header_without_db_lookup() -> None
 
     dep = make_db_bearer_auth(repo)
     with pytest.raises(HTTPException) as exc_info:
-        await dep(None)
+        await dep(_request_stub(), None)
 
     assert exc_info.value.status_code == 401
     assert exc_info.value.detail == "missing bearer token"
@@ -182,7 +203,7 @@ async def test_db_bearer_auth_rejects_non_bearer_scheme_without_db_lookup() -> N
 
     dep = make_db_bearer_auth(repo)
     with pytest.raises(HTTPException) as exc_info:
-        await dep("Basic dXNlcjpwYXNz")
+        await dep(_request_stub(), "Basic dXNlcjpwYXNz")
 
     assert exc_info.value.status_code == 401
     assert exc_info.value.detail == "invalid authorization scheme"
@@ -196,7 +217,7 @@ async def test_db_bearer_auth_rejects_empty_token_after_prefix() -> None:
 
     dep = make_db_bearer_auth(repo)
     with pytest.raises(HTTPException) as exc_info:
-        await dep("Bearer    ")
+        await dep(_request_stub(), "Bearer    ")
 
     assert exc_info.value.status_code == 401
     assert exc_info.value.detail == "empty bearer token"
@@ -217,9 +238,13 @@ async def test_db_bearer_auth_legacy_match_emits_deprecation_warning(
     dep = make_db_bearer_auth(repo, legacy_token="shared-xyz")
 
     with caplog.at_level(logging.WARNING, logger="whilly.adapters.transport.auth"):
-        result = await dep("Bearer shared-xyz")
+        request = _request_stub()
+        result = await dep(request, "Bearer shared-xyz")
 
     assert result is None
+    # Legacy fallback explicitly stamps identity as None — the shared
+    # cluster bearer cannot identify a specific worker.
+    assert request.state.authenticated_worker_id is None
     deprecation_records = [rec for rec in caplog.records if "deprecated" in rec.getMessage().lower()]
     assert len(deprecation_records) == 1, "exactly one WARNING should mention 'deprecated'"
     assert deprecation_records[0].levelno == logging.WARNING
@@ -234,8 +259,8 @@ async def test_db_bearer_auth_legacy_warning_is_one_shot(
     dep = make_db_bearer_auth(repo, legacy_token="shared-xyz")
 
     with caplog.at_level(logging.WARNING, logger="whilly.adapters.transport.auth"):
-        await dep("Bearer shared-xyz")
-        await dep("Bearer shared-xyz")
+        await dep(_request_stub(), "Bearer shared-xyz")
+        await dep(_request_stub(), "Bearer shared-xyz")
 
     deprecation_records = [rec for rec in caplog.records if "deprecated" in rec.getMessage().lower()]
     assert len(deprecation_records) == 1, "the deprecation warning must be emitted at most once per process"
@@ -257,7 +282,7 @@ async def test_db_bearer_auth_legacy_warning_suppressed_by_env(
     dep = make_db_bearer_auth(repo, legacy_token="shared-xyz")
 
     with caplog.at_level(logging.WARNING, logger="whilly.adapters.transport.auth"):
-        result = await dep("Bearer shared-xyz")
+        result = await dep(_request_stub(), "Bearer shared-xyz")
 
     assert result is None
     deprecation_records = [rec for rec in caplog.records if "deprecated" in rec.getMessage().lower()]
@@ -271,7 +296,7 @@ async def test_db_bearer_auth_legacy_disabled_when_token_is_none() -> None:
     dep = make_db_bearer_auth(repo, legacy_token=None)
 
     with pytest.raises(HTTPException) as exc_info:
-        await dep("Bearer would-have-matched-shared-token")
+        await dep(_request_stub(), "Bearer would-have-matched-shared-token")
 
     assert exc_info.value.status_code == 401
     assert exc_info.value.detail == "invalid token"
@@ -295,9 +320,13 @@ async def test_db_bearer_auth_per_worker_takes_precedence_over_legacy(
     dep = make_db_bearer_auth(repo, legacy_token="plaintext-A")
 
     with caplog.at_level(logging.WARNING, logger="whilly.adapters.transport.auth"):
-        result = await dep("Bearer plaintext-A")
+        request = _request_stub()
+        result = await dep(request, "Bearer plaintext-A")
 
     assert result is None
+    # Per-worker precedence: identity stamped to the resolved worker_id,
+    # NOT to None (which would have indicated a legacy fallback hit).
+    assert request.state.authenticated_worker_id == "w-alpha"
     deprecation_records = [rec for rec in caplog.records if "deprecated" in rec.getMessage().lower()]
     assert deprecation_records == [], "per-worker authentication must NOT trigger the legacy deprecation log"
 
@@ -315,7 +344,7 @@ async def test_db_bearer_auth_legacy_token_constant_time_compare() -> None:
     dep = make_db_bearer_auth(repo, legacy_token="shared-xyz")
 
     with pytest.raises(HTTPException) as exc_info:
-        await dep("Bearer shared-xy")  # one char short
+        await dep(_request_stub(), "Bearer shared-xy")  # one char short
 
     assert exc_info.value.status_code == 401
     assert exc_info.value.detail == "invalid token"
@@ -380,11 +409,11 @@ async def test_reset_legacy_warning_state_re_arms_warning(
     dep = make_db_bearer_auth(repo, legacy_token="shared-xyz")
 
     with caplog.at_level(logging.WARNING, logger="whilly.adapters.transport.auth"):
-        await dep("Bearer shared-xyz")
-        await dep("Bearer shared-xyz")  # second hit — flag set, no log
+        await dep(_request_stub(), "Bearer shared-xyz")
+        await dep(_request_stub(), "Bearer shared-xyz")  # second hit — flag set, no log
 
         reset_legacy_warning_state()
-        await dep("Bearer shared-xyz")  # third hit — flag cleared, log fires
+        await dep(_request_stub(), "Bearer shared-xyz")  # third hit — flag cleared, log fires
 
     deprecation_records = [rec for rec in caplog.records if "deprecated" in rec.getMessage().lower()]
     assert len(deprecation_records) == 2, "reset_legacy_warning_state should re-arm the one-shot guard"

--- a/tests/unit/test_transport_auth.py
+++ b/tests/unit/test_transport_auth.py
@@ -25,7 +25,8 @@ load-bearing. These tests exercise the AC for TASK-021a2:
 from __future__ import annotations
 
 from collections.abc import Iterator
-from typing import cast
+from types import SimpleNamespace
+from typing import Any, cast
 
 import pytest
 from fastapi import Depends, FastAPI, HTTPException
@@ -37,9 +38,12 @@ from whilly.adapters.transport.auth import (
     WORKER_TOKEN_ENV,
     bearer_auth,
     bootstrap_auth,
+    hash_bearer_token,
     make_bearer_auth,
     make_bootstrap_auth,
+    make_db_bearer_auth,
     reset_lazy_dependencies,
+    reset_legacy_warning_state,
 )
 
 # ---------------------------------------------------------------------------
@@ -376,3 +380,99 @@ def test_dependency_factory_returns_callable() -> None:
     """
     dep = cast(object, make_bearer_auth("s3cr3t"))
     assert callable(dep)
+
+
+# ---------------------------------------------------------------------------
+# make_db_bearer_auth — identity binding (TASK-101 scrutiny round-1 fix)
+# ---------------------------------------------------------------------------
+#
+# Unit-level coverage of the request.state contract. The full
+# integration tests (cross-worker bearer → 403) live in
+# tests/integration/test_per_worker_auth.py and exercise the same
+# behaviour via a real Postgres + httpx round-trip; these unit tests
+# pin the contract narrowly so a regression in the dep itself is
+# caught without needing testcontainers.
+
+
+class _FakeRepo:
+    """Minimal fake of ``TaskRepository.get_worker_id_by_token_hash``.
+
+    Maps known hashes → worker_id, returns ``None`` for the rest. Only
+    the one method exists because :func:`make_db_bearer_auth` only
+    calls that one method (see auth.py docstring: "the only method
+    the dep calls — keeps the auth surface narrow and easy to fake in
+    tests").
+    """
+
+    def __init__(self, mapping: dict[str, str]) -> None:
+        self._mapping = mapping
+
+    async def get_worker_id_by_token_hash(self, token_hash: str) -> str | None:
+        return self._mapping.get(token_hash)
+
+
+def _make_request_stub() -> Any:
+    """Build a stand-in for :class:`fastapi.Request`.
+
+    The dep only touches ``request.state`` (Starlette's free-form
+    attribute bag), so a :class:`SimpleNamespace` carrying its own
+    nested ``state`` namespace is functionally identical to the real
+    Starlette ``State`` object for our purposes — and avoids the
+    starlette/Request constructor's scope-dict requirement that adds
+    no signal here.
+    """
+    return SimpleNamespace(state=SimpleNamespace())
+
+
+@pytest.mark.asyncio
+async def test_db_bearer_auth_stashes_worker_id_on_request_state() -> None:
+    """Per-worker hash hit → request.state.authenticated_worker_id == resolved id."""
+    plaintext = "per-worker-token-known"
+    known_hash = hash_bearer_token(plaintext)
+    repo = _FakeRepo({known_hash: "w-known"})
+    dep = make_db_bearer_auth(cast(Any, repo))
+
+    request = _make_request_stub()
+    result = await dep(request, f"Bearer {plaintext}")
+
+    assert result is None  # gate-keeping shape preserved
+    assert request.state.authenticated_worker_id == "w-known"
+
+
+@pytest.mark.asyncio
+async def test_db_bearer_auth_legacy_fallback_sets_identity_none() -> None:
+    """Legacy ``WHILLY_WORKER_TOKEN`` match (no DB hash) → request.state.authenticated_worker_id is None.
+
+    The shared cluster bearer cannot identify a specific worker, so
+    the dep marks the identity as unknown. ``server._require_token_owner``
+    treats ``None`` as a no-op, preserving the one-minor-version
+    legacy compat window (VAL-AUTH-030/031/034).
+    """
+    reset_legacy_warning_state()
+    legacy_plaintext = "legacy-shared-bearer-xyz"
+    # Repo returns None for every hash — only the legacy fallback can hit.
+    repo = _FakeRepo({})
+    dep = make_db_bearer_auth(cast(Any, repo), legacy_token=legacy_plaintext)
+
+    request = _make_request_stub()
+    result = await dep(request, f"Bearer {legacy_plaintext}")
+
+    assert result is None
+    # Sentinel is exactly None (not "absent" — the dep must explicitly
+    # write None on the legacy path so a stray earlier write to
+    # request.state can't survive into the route handler).
+    assert hasattr(request.state, "authenticated_worker_id")
+    assert request.state.authenticated_worker_id is None
+
+
+@pytest.mark.asyncio
+async def test_db_bearer_auth_unknown_token_raises_401_without_state_write() -> None:
+    """Invalid bearer → 401 + request.state untouched (handler never runs)."""
+    repo = _FakeRepo({})
+    dep = make_db_bearer_auth(cast(Any, repo))
+
+    request = _make_request_stub()
+    with pytest.raises(HTTPException) as exc_info:
+        await dep(request, "Bearer totally-unknown-token")
+    assert exc_info.value.status_code == 401
+    assert not hasattr(request.state, "authenticated_worker_id")

--- a/whilly/adapters/transport/auth.py
+++ b/whilly/adapters/transport/auth.py
@@ -73,7 +73,7 @@ import secrets
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Final
 
-from fastapi import Header, HTTPException, status
+from fastapi import Header, HTTPException, Request, status
 
 if TYPE_CHECKING:
     from whilly.adapters.db import TaskRepository
@@ -117,11 +117,32 @@ _BEARER_PREFIX: Final[str] = "bearer "
 #: per-realm see this as the namespace.
 _BEARER_REALM: Final[str] = "whilly"
 
-# Public type alias for the dependency callables this module produces. A
-# FastAPI dependency is any callable; ours are async because they may grow
-# DB lookups in TASK-021b (per-worker token-hash verification) without a
-# breaking signature change.
+# Public type alias for the *gate-keeping* dependency callables this module
+# produces — :func:`make_bearer_auth` and :func:`make_bootstrap_auth`. Both
+# receive only the ``Authorization`` header and return ``None`` on success.
+# FastAPI dependencies are arbitrary callables; we keep the alias narrow so
+# the call sites that don't need identity binding stay typed accordingly.
 AuthDependency = Callable[[str | None], Awaitable[None]]
+
+# Public type alias for the *identity-binding* dependency that
+# :func:`make_db_bearer_auth` produces. The dep takes both
+# :class:`fastapi.Request` (so it can stash the resolved
+# ``worker_id`` on ``request.state.authenticated_worker_id`` for the
+# route handler's :func:`_require_token_owner` check — see
+# :mod:`whilly.adapters.transport.server`) and the ``Authorization``
+# header. Returns ``None`` on success: the gate-keeping shape stays
+# unchanged so existing handlers can keep declaring
+# ``dependencies=[Depends(bearer_dep)]`` without wiring the dep result
+# through a parameter.
+#
+# Why a separate alias?
+#     Mixing the two signatures under a single type would force every
+#     route that consumes :data:`AuthDependency` (e.g. tests that build
+#     ad-hoc gate-keeping deps via :func:`make_bearer_auth`) to also
+#     accept the wider :class:`Request` parameter. Splitting keeps each
+#     factory's contract narrow and makes it obvious at a glance which
+#     dependencies write to ``request.state`` and which don't.
+IdentityBindingAuthDependency = Callable[[Request, str | None], Awaitable[None]]
 
 
 # ---------------------------------------------------------------------------
@@ -347,7 +368,7 @@ def make_db_bearer_auth(
     repo: TaskRepository,
     *,
     legacy_token: str | None = None,
-) -> AuthDependency:
+) -> IdentityBindingAuthDependency:
     """Build a per-worker bearer ``Depends`` callable backed by the workers table.
 
     This is the v4.1 successor to :func:`make_bearer_auth` for the
@@ -414,16 +435,33 @@ def make_db_bearer_auth(
         successful match logs the one-shot deprecation warning
         (suppressible via :data:`SUPPRESS_WORKER_TOKEN_WARNING_ENV`).
 
+    Identity binding (TASK-101 scrutiny round-1 fix)
+    ------------------------------------------------
+    On a successful per-worker hash hit the dep stashes the resolved
+    ``worker_id`` on ``request.state.authenticated_worker_id`` so the
+    route handler's :func:`whilly.adapters.transport.server._require_token_owner`
+    check can reject cross-worker calls (worker A's bearer used to act
+    as worker B) with a 403 — VAL-AUTH-024. On the legacy
+    ``WHILLY_WORKER_TOKEN`` fallback path, ``authenticated_worker_id`` is
+    set to ``None`` (identity unknown — the shared cluster token cannot
+    name a specific worker), and the route-level helper treats that as
+    a no-op so the one-minor-version legacy compat window
+    (VAL-AUTH-030/031/034) stays green. A dep raise (401) does not
+    write to ``request.state`` — Starlette unwinds the request before
+    a handler runs, so unauthenticated requests never observe a
+    half-set state.
+
     Returns
     -------
-    AuthDependency
-        An async callable suitable for ``Depends(...)``. Returns
-        ``None`` on success (matching the
-        :func:`make_bearer_auth` shape so route handlers remain
-        compatible). Worker-identity-aware handlers can opt-in to
-        the resolved worker_id in a future revision by reading from
-        ``request.state``; today's handlers carry the worker_id in
-        the request body and the dep's role is gate-keeping only.
+    IdentityBindingAuthDependency
+        An async callable suitable for ``Depends(...)`` that takes a
+        :class:`fastapi.Request` and the ``Authorization`` header.
+        Returns ``None`` on success (matching the
+        :func:`make_bearer_auth` shape so handlers can continue to
+        declare it as ``dependencies=[Depends(bearer_dep)]`` without
+        consuming a return value); side-effect is the
+        ``request.state.authenticated_worker_id`` write described
+        above.
     """
     # Whitespace-stripped legacy token guards against operators
     # leaving the env value as a stray space — same rule as
@@ -438,7 +476,10 @@ def make_db_bearer_auth(
             "(use None to disable the legacy WHILLY_WORKER_TOKEN fallback)."
         )
 
-    async def db_bearer_auth(authorization: str | None = Header(default=None)) -> None:
+    async def db_bearer_auth(
+        request: Request,
+        authorization: str | None = Header(default=None),
+    ) -> None:
         token = _extract_bearer(authorization)
         token_hash = hash_bearer_token(token)
         worker_id = await repo.get_worker_id_by_token_hash(token_hash)
@@ -447,18 +488,22 @@ def make_db_bearer_auth(
             # happens to equal ``legacy_token``, the deprecation warning
             # is NOT emitted on this path — VAL-AUTH-034 pins the
             # contract that "valid per-worker token never logs the
-            # deprecation". The route handler can correlate the
-            # bearer-resolved identity with the body's ``worker_id``
-            # echo (defence-in-depth), but the dep stays gate-keeping
-            # only.
+            # deprecation". Stash the DB-resolved identity on
+            # ``request.state`` so the route handlers'
+            # ``_require_token_owner`` helper can compare it against
+            # the body / path identity and reject cross-worker calls
+            # with a 403 (VAL-AUTH-024).
+            request.state.authenticated_worker_id = worker_id
             return None
         if legacy_token_clean is not None and secrets.compare_digest(token, legacy_token_clean):
-            # Legacy fallback hit. Emit the one-shot deprecation
-            # warning (suppressible) and accept the request. We hash
-            # the legacy token through the same code path as a
-            # safety check that ``compare_digest`` is the only
-            # constant-time comparison surface — nothing leaks
-            # whether the legacy token was "close" to a real one.
+            # Legacy fallback hit. The shared ``WHILLY_WORKER_TOKEN``
+            # cannot identify a specific worker, so we explicitly mark
+            # the identity as unknown; the route-level
+            # ``_require_token_owner`` helper treats ``None`` as a
+            # no-op and lets the legacy bearer act as "any worker" for
+            # one minor version (VAL-AUTH-030/031/034). Emit the
+            # one-shot deprecation warning (suppressible).
+            request.state.authenticated_worker_id = None
             _maybe_warn_legacy_worker_token()
             return None
         raise _bearer_401("invalid token")
@@ -562,6 +607,7 @@ __all__ = [
     "SUPPRESS_WORKER_TOKEN_WARNING_ENV",
     "WORKER_TOKEN_ENV",
     "AuthDependency",
+    "IdentityBindingAuthDependency",
     "bearer_auth",
     "bootstrap_auth",
     "hash_bearer_token",

--- a/whilly/adapters/transport/server.py
+++ b/whilly/adapters/transport/server.py
@@ -160,7 +160,7 @@ from contextlib import asynccontextmanager
 from typing import Any, Final
 
 import asyncpg
-from fastapi import Depends, FastAPI, HTTPException, Response, status
+from fastapi import Depends, FastAPI, HTTPException, Request, Response, status
 from fastapi.responses import JSONResponse
 
 from whilly.adapters.db import TaskRepository, VersionConflictError
@@ -168,6 +168,7 @@ from whilly.adapters.transport.auth import (
     BOOTSTRAP_TOKEN_ENV,
     WORKER_TOKEN_ENV,
     AuthDependency,
+    IdentityBindingAuthDependency,
     hash_bearer_token,
     make_bootstrap_auth,
     make_db_bearer_auth,
@@ -714,7 +715,7 @@ def create_app(
     # 401 in production. ``make_db_bearer_auth`` is the per-worker
     # bearer surface (TASK-101); legacy ``WHILLY_WORKER_TOKEN`` rides
     # along as the optional one-minor-version fallback.
-    bearer_dep: AuthDependency = make_db_bearer_auth(repo, legacy_token=legacy_worker_token)
+    bearer_dep: IdentityBindingAuthDependency = make_db_bearer_auth(repo, legacy_token=legacy_worker_token)
     bootstrap_dep: AuthDependency = make_bootstrap_auth(resolved_bootstrap_token)
 
     @asynccontextmanager
@@ -907,7 +908,7 @@ def create_app(
         response_model=HeartbeatResponse,
         dependencies=[Depends(bearer_dep)],
     )
-    async def heartbeat(worker_id: str, payload: HeartbeatRequest) -> HeartbeatResponse:
+    async def heartbeat(request: Request, worker_id: str, payload: HeartbeatRequest) -> HeartbeatResponse:
         """Refresh ``workers.last_heartbeat`` for ``worker_id`` (PRD FR-1.6).
 
         Gated by the per-worker bearer dependency — the cluster-shared
@@ -930,10 +931,19 @@ def create_app(
             # URL). 422 would be a pure schema violation; this is a
             # cross-field validation that FastAPI can't catch via
             # pydantic alone.
+            #
+            # Order matters: the body↔path 400 check stays AHEAD of
+            # the token-owner 403 check below so VAL-AUTH-024's
+            # ``(400, 401, 403)`` envelope keeps both branches
+            # independently exercised (one test for the 400 schema
+            # mismatch, one test for the 403 cross-worker bearer).
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=(f"worker_id in body does not match path: path={worker_id!r} body={payload.worker_id!r}"),
             )
+        # Token-owner check (TASK-101 scrutiny round-1 fix): worker A's
+        # bearer cannot heartbeat worker B even when body == path == B.
+        _require_token_owner(request, worker_id)
         ok = await repo.update_heartbeat(worker_id)
         return HeartbeatResponse(ok=ok)
 
@@ -955,7 +965,7 @@ def create_app(
         },
         dependencies=[Depends(bearer_dep)],
     )
-    async def claim(payload: ClaimRequest) -> Response | ClaimResponse:
+    async def claim(request: Request, payload: ClaimRequest) -> Response | ClaimResponse:
         """Long-polled task acquisition (PRD FR-1.3).
 
         Wraps :meth:`TaskRepository.claim_task` in a server-side poll
@@ -990,6 +1000,10 @@ def create_app(
             unconditional final ``claim_task`` so a row that arrived
             in the trailing window is still returned rather than 204'd.
         """
+        # Token-owner check (TASK-101 scrutiny round-1 fix): worker A's
+        # bearer cannot claim a task on behalf of worker B even though
+        # the path carries no identity.
+        _require_token_owner(request, payload.worker_id)
         deadline = time.monotonic() + claim_long_poll_timeout
         while True:
             claimed = await repo.claim_task(payload.worker_id, payload.plan_id)
@@ -1043,7 +1057,9 @@ def create_app(
         },
         dependencies=[Depends(bearer_dep)],
     )
-    async def complete_task(task_id: str, payload: CompleteRequest) -> CompleteResponse | JSONResponse:
+    async def complete_task(
+        request: Request, task_id: str, payload: CompleteRequest
+    ) -> CompleteResponse | JSONResponse:
         """Terminal-state RPC: IN_PROGRESS → DONE (PRD FR-1.1, FR-2.4).
 
         Thin wrapper over :meth:`TaskRepository.complete_task`. The
@@ -1085,6 +1101,10 @@ def create_app(
             ``responses`` map declared on the route, so /docs shows
             the correct shape on the conflict path.
         """
+        # Token-owner check (TASK-101 scrutiny round-1 fix): worker A's
+        # bearer cannot complete a task on behalf of worker B even if
+        # B legitimately claimed it.
+        _require_token_owner(request, payload.worker_id)
         try:
             updated = await repo.complete_task(task_id, payload.version, payload.cost_usd)
         except VersionConflictError as exc:
@@ -1123,7 +1143,7 @@ def create_app(
         },
         dependencies=[Depends(bearer_dep)],
     )
-    async def fail_task(task_id: str, payload: FailRequest) -> FailResponse | JSONResponse:
+    async def fail_task(request: Request, task_id: str, payload: FailRequest) -> FailResponse | JSONResponse:
         """Terminal-state RPC: CLAIMED | IN_PROGRESS → FAILED (PRD FR-1.1, FR-2.4).
 
         Mirrors :func:`complete_task` exactly except for the extra
@@ -1140,6 +1160,9 @@ def create_app(
         owns that policy and the 409 envelope surfaces the actual
         status when the transition is rejected.
         """
+        # Token-owner check (TASK-101 scrutiny round-1 fix): worker A's
+        # bearer cannot fail a task on behalf of worker B.
+        _require_token_owner(request, payload.worker_id)
         try:
             updated = await repo.fail_task(task_id, payload.version, payload.reason)
         except VersionConflictError as exc:
@@ -1178,7 +1201,7 @@ def create_app(
         },
         dependencies=[Depends(bearer_dep)],
     )
-    async def release_task(task_id: str, payload: ReleaseRequest) -> ReleaseResponse | JSONResponse:
+    async def release_task(request: Request, task_id: str, payload: ReleaseRequest) -> ReleaseResponse | JSONResponse:
         """Worker-driven release: CLAIMED | IN_PROGRESS → PENDING (TASK-022b3, PRD FR-1.6, NFR-1).
 
         HTTP analogue of :meth:`TaskRepository.release_task` — wraps the
@@ -1215,6 +1238,9 @@ def create_app(
           handler reached this RPC (extremely narrow race); the
           terminal status wins.
         """
+        # Token-owner check (TASK-101 scrutiny round-1 fix): worker A's
+        # bearer cannot release a task on behalf of worker B.
+        _require_token_owner(request, payload.worker_id)
         try:
             updated = await repo.release_task(task_id, payload.version, payload.reason)
         except VersionConflictError as exc:
@@ -1237,6 +1263,58 @@ def create_app(
         return ReleaseResponse(task=TaskPayload.from_task(updated))
 
     return app
+
+
+def _require_token_owner(request: Request, claimed_worker_id: str) -> None:
+    """Reject cross-worker bearer use with 403 (TASK-101 scrutiny round-1 fix / VAL-AUTH-024).
+
+    :func:`whilly.adapters.transport.auth.make_db_bearer_auth` stashes
+    the DB-resolved ``worker_id`` on
+    ``request.state.authenticated_worker_id`` when the per-worker hash
+    lookup hits. This helper compares that resolved identity against
+    the ``claimed_worker_id`` the route handler observed (from the
+    request body or path) and raises 403 on mismatch — i.e. worker A's
+    token cannot be used to ``heartbeat``/``claim``/``complete``/
+    ``fail``/``release`` as worker B.
+
+    Why 403 (not 401)?
+        RFC 7235 §3.1 / RFC 6750 §3: 401 means "I don't know who you
+        are"; 403 means "I know who you are, you can't do this". The
+        token authenticated successfully — auth is *not* the failure;
+        the *operation* is forbidden. VAL-AUTH-024's evidence clause
+        accepts ``(400, 401, 403)``, so 403 is contract-compliant; we
+        choose 403 to keep schema-validation 400s separate from
+        authorisation 403s in operator dashboards / log queries.
+
+    Legacy fallback (``WHILLY_WORKER_TOKEN`` shared bearer) — no-op
+        On the legacy path the dep stashes ``None`` because the
+        shared cluster token cannot identify a specific worker. We
+        treat ``None`` as a no-op so the one-minor-version legacy
+        compat window (VAL-AUTH-030/031/034) stays green: the legacy
+        bearer is allowed to act as "any worker" exactly because
+        identity is unknown. When the legacy fallback is removed in
+        v4.2 this branch collapses (the dep itself will raise 401 on
+        every non-DB-resolved request).
+
+    Why a module-level helper rather than a FastAPI dependency?
+        Each handler already extracts ``payload.worker_id`` from a
+        typed request schema, so the comparison is one expression at
+        the top of the handler. A separate ``Depends`` would have to
+        re-parse the body or read the path parameter via ``Request``
+        — twice the work for the same outcome. Inlining the call
+        keeps the auth boundary explicit at the call site.
+    """
+    authenticated = getattr(request.state, "authenticated_worker_id", None)
+    if authenticated is None:
+        # Legacy fallback path (identity unknown) or an unauthenticated
+        # request that somehow reached the handler — neither case can
+        # be enforced here without regressing VAL-AUTH-030/031/034.
+        return
+    if authenticated != claimed_worker_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(f"token owner {authenticated!r} cannot act as worker {claimed_worker_id!r}"),
+        )
 
 
 def _conflict_response(exc: VersionConflictError) -> JSONResponse:


### PR DESCRIPTION
M2 scrutiny round-1 unblocker for TASK-101 (B1 + B2).

### What

**Part A — code change (B1).**
`whilly/adapters/transport/auth.py`:
- `make_db_bearer_auth`'s returned dependency now takes a `fastapi.Request` parameter.
- On per-worker hash hit → stashes the resolved `worker_id` on `request.state.authenticated_worker_id`.
- On legacy `WHILLY_WORKER_TOKEN` fallback → sets `request.state.authenticated_worker_id = None` (identity unknown — the shared cluster token cannot name a specific worker, so VAL-AUTH-030/031/034 stay green).
- New `IdentityBindingAuthDependency` type alias names the new dep signature; existing `AuthDependency` alias still names the gate-keeping factories.

`whilly/adapters/transport/server.py`:
- Adds private `_require_token_owner(request, claimed_worker_id)` helper.
- Compares `request.state.authenticated_worker_id` to the claimed identity; raises `HTTPException(403, 'token owner ... cannot act as worker ...')` on mismatch; no-op when `authenticated_worker_id is None` (legacy fallback).
- Wired into all five identity-bound handlers: `heartbeat`, `claim`, `complete_task`, `fail_task`, `release_task`.
- For `heartbeat`, the existing body↔path 400 check stays **AHEAD** of the token-owner 403 check so VAL-AUTH-024's `(400, 401, 403)` envelope is preserved with both branches independently exercised.

**Part B — contract amendment (B2). ALREADY DONE.**
The `task-101-per-worker-bearer` feature description in `features.json` was amended upstream to read `heartbeat/claim/complete/fail/release` (the five steady-state RPCs per VAL-AUTH-012) and to explicitly state `/workers/register` stays bootstrap-gated per VAL-AUTH-010. No code change required for Part B.

### Validation contract

Fulfills (implementation, not new): VAL-AUTH-024.
Preserves green: VAL-AUTH-010, VAL-AUTH-011, VAL-AUTH-012, VAL-AUTH-020/021/022/023, VAL-AUTH-030/031/032/033/034, VAL-AUTH-052.

### Tests

**New integration tests** in `tests/integration/test_per_worker_auth.py`:
- `test_cross_worker_bearer_on_heartbeat_returns_403` — A's bearer + body=B + path=B → 403; `workers.last_heartbeat` unchanged for B.
- `test_cross_worker_bearer_on_claim_returns_403` — 403; targeted task stays PENDING; no events row.
- `test_cross_worker_bearer_on_complete_returns_403` — B legitimately claims; A submits /complete with body=B → 403; task row unchanged; no events row written.
- `test_cross_worker_bearer_on_fail_returns_403` — symmetric for /fail.
- `test_cross_worker_bearer_on_release_returns_403` — symmetric for /release.
- `test_heartbeat_body_path_mismatch_returns_400` — keeps the body↔path 400 path covered independently from the token-owner 403 check.

**Replaced**: `test_cross_worker_bearer_returns_4xx` (was a body↔path test masquerading as cross-worker; now split into the focused 403 tests above + the dedicated 400 test).

**New unit tests** in `tests/unit/test_transport_auth.py`:
- `test_db_bearer_auth_stashes_worker_id_on_request_state` — fake repo resolves a known hash; `request.state.authenticated_worker_id == 'w-known'` after the dep runs.
- `test_db_bearer_auth_legacy_fallback_sets_identity_none` — legacy WHILLY_WORKER_TOKEN match with no DB hash → `request.state.authenticated_worker_id is None`.
- `test_db_bearer_auth_unknown_token_raises_401_without_state_write` — invalid bearer → 401 + `request.state` untouched.

**Updated**: `tests/unit/test_bearer_dep.py` to thread the new request stub through every `make_db_bearer_auth` call; pinned the `request.state.authenticated_worker_id` contract on the per-worker hit and per-worker-precedence paths.

### Verification

```
pytest tests/unit/test_transport_auth.py -v          # 30 passed
pytest tests/unit/test_bearer_dep.py -v              # 15 passed
pytest tests/integration/test_per_worker_auth.py -v  # 18 passed
pytest tests/integration -q                          # 217 passed, 1 skipped
pytest -q                                            # 1472 passed, 1 skipped (live_llm gated)
ruff check whilly tests                              # All checks passed!
ruff format --check whilly tests                     # 215 files already formatted
mypy --strict whilly/core/                           # Success: no issues found in 7 source files
lint-imports                                         # 1 contract kept, 0 broken
```

NO stacked PRs — branched from `main` at `15f118d` (post PR #231).