### PR TITLE
fix(task-102): add reason+threshold_pct to plan.budget_exceeded payload (VAL-CROSS-013)

### DIFF
--- a/tests/integration/test_budget_concurrent.py
+++ b/tests/integration/test_budget_concurrent.py
@@ -36,7 +36,11 @@ import pytest
 
 from tests.conftest import DOCKER_REQUIRED
 from whilly.adapters.db import TaskRepository
-from whilly.adapters.db.repository import BUDGET_EXCEEDED_EVENT_TYPE
+from whilly.adapters.db.repository import (
+    BUDGET_EXCEEDED_EVENT_TYPE,
+    BUDGET_EXCEEDED_REASON,
+    BUDGET_EXCEEDED_THRESHOLD_PCT,
+)
 from whilly.core.models import PlanId
 
 pytestmark = DOCKER_REQUIRED
@@ -204,6 +208,10 @@ async def test_concurrent_crossing_emits_exactly_one_sentinel(db_pool: asyncpg.P
     assert payload["plan_id"] == "plan-bcc-cross"
     assert payload["crossing_task_id"] in set(task_ids)
     assert Decimal(payload["budget_usd"]) == budget
+    # VAL-CROSS-013: even under contention the SINGLE sentinel carries
+    # the contract-required reason / threshold_pct pins.
+    assert payload["reason"] == BUDGET_EXCEEDED_REASON == "budget_threshold"
+    assert payload["threshold_pct"] == BUDGET_EXCEEDED_THRESHOLD_PCT == 100
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/integration/test_budget_guard.py
+++ b/tests/integration/test_budget_guard.py
@@ -59,6 +59,8 @@ from tests.conftest import DOCKER_REQUIRED
 from whilly.adapters.db import TaskRepository
 from whilly.adapters.db.repository import (
     BUDGET_EXCEEDED_EVENT_TYPE,
+    BUDGET_EXCEEDED_REASON,
+    BUDGET_EXCEEDED_THRESHOLD_PCT,
     VersionConflictError,
 )
 from whilly.core.models import PlanId, TaskId
@@ -424,6 +426,9 @@ async def test_crossing_budget_emits_sentinel_once(db_pool: asyncpg.Pool, task_r
     assert Decimal(payload["budget_usd"]) == Decimal("1.0000")
     assert Decimal(payload["spent_usd"]) == Decimal("1.1000")
     assert payload["crossing_task_id"] == completed_id
+    # VAL-CROSS-013: crossing-condition pins.
+    assert payload["reason"] == BUDGET_EXCEEDED_REASON == "budget_threshold"
+    assert payload["threshold_pct"] == BUDGET_EXCEEDED_THRESHOLD_PCT == 100
 
 
 async def test_sentinel_event_shape_matches_contract(db_pool: asyncpg.Pool, task_repo: TaskRepository) -> None:
@@ -445,7 +450,52 @@ async def test_sentinel_event_shape_matches_contract(db_pool: asyncpg.Pool, task
     assert sentinel["task_id"] is None
     assert sentinel["plan_id"] == "plan-shape"
     payload = json.loads(sentinel["payload"])
-    assert set(payload.keys()) >= {"plan_id", "budget_usd", "spent_usd", "crossing_task_id"}
+    assert set(payload.keys()) >= {
+        "plan_id",
+        "budget_usd",
+        "spent_usd",
+        "crossing_task_id",
+        "reason",
+        "threshold_pct",
+    }
+
+
+async def test_budget_exceeded_payload_includes_reason_and_threshold_pct(
+    db_pool: asyncpg.Pool, task_repo: TaskRepository
+) -> None:
+    """The sentinel payload pins ``reason='budget_threshold'`` and ``threshold_pct=100`` (VAL-CROSS-013).
+
+    Independent of the wider sentinel-shape test: this is the verbatim
+    evidence query the user-testing validator runs —
+    ``SELECT payload->>'reason', (payload->>'threshold_pct')::int FROM
+    events WHERE plan_id=$1 AND event_type='plan.budget_exceeded'`` —
+    must return ``('budget_threshold', 100)``.
+    """
+    await _seed_plan(
+        db_pool,
+        "plan-cross-013",
+        budget_usd=Decimal("0.5000"),
+        spent_usd=Decimal("0"),
+    )
+    await _seed_task(db_pool, "T-cross-013", "plan-cross-013")
+    await _seed_worker(db_pool, "w-cross-013")
+
+    await _claim_start_complete(task_repo, "plan-cross-013", "w-cross-013", cost_usd=Decimal("0.5000"))
+
+    async with db_pool.acquire() as conn:
+        row = await conn.fetchrow(
+            (
+                "SELECT payload->>'reason' AS reason, "
+                "(payload->>'threshold_pct')::int AS threshold_pct "
+                "FROM events "
+                "WHERE plan_id = $1 AND event_type = $2"
+            ),
+            "plan-cross-013",
+            BUDGET_EXCEEDED_EVENT_TYPE,
+        )
+    assert row is not None
+    assert row["reason"] == "budget_threshold"
+    assert row["threshold_pct"] == 100
 
 
 async def test_unlimited_plan_never_emits_sentinel(db_pool: asyncpg.Pool, task_repo: TaskRepository) -> None:

--- a/whilly/adapters/db/repository.py
+++ b/whilly/adapters/db/repository.py
@@ -72,7 +72,13 @@ import asyncpg
 from whilly.core.models import PlanId, Priority, Task, TaskId, TaskStatus, WorkerId
 from whilly.core.state_machine import Transition
 
-__all__ = ["BUDGET_EXCEEDED_EVENT_TYPE", "TaskRepository", "VersionConflictError"]
+__all__ = [
+    "BUDGET_EXCEEDED_EVENT_TYPE",
+    "BUDGET_EXCEEDED_REASON",
+    "BUDGET_EXCEEDED_THRESHOLD_PCT",
+    "TaskRepository",
+    "VersionConflictError",
+]
 
 
 # Sentinel event type emitted exactly once when ``plans.spent_usd``
@@ -85,6 +91,15 @@ __all__ = ["BUDGET_EXCEEDED_EVENT_TYPE", "TaskRepository", "VersionConflictError
 # (``CLAIM`` / ``COMPLETE`` / ``FAIL``) which live on
 # :class:`whilly.core.state_machine.Transition`.
 BUDGET_EXCEEDED_EVENT_TYPE: str = "plan.budget_exceeded"
+
+# Contract pins for the ``plan.budget_exceeded`` payload (VAL-CROSS-013).
+# The v4.1 design only emits the sentinel on the 100%-of-budget crossing,
+# so ``reason`` is fixed to ``budget_threshold`` and ``threshold_pct`` to
+# ``100`` — defined as module-level constants here so future thresholds
+# (e.g. 50% / 90% pre-warnings) can extend the same path without a
+# literal-search across the codebase.
+BUDGET_EXCEEDED_REASON: str = "budget_threshold"
+BUDGET_EXCEEDED_THRESHOLD_PCT: int = 100
 
 
 # Quantum used to coerce a Python float-ish ``cost_usd`` into a stable
@@ -1025,6 +1040,8 @@ class TaskRepository:
                                 "budget_usd": str(spend_row["budget_usd"]),
                                 "spent_usd": str(spend_row["new_spent"]),
                                 "crossing_task_id": row["id"],
+                                "reason": BUDGET_EXCEEDED_REASON,
+                                "threshold_pct": BUDGET_EXCEEDED_THRESHOLD_PCT,
                             }
                         )
                         await conn.execute(


### PR DESCRIPTION
M2 user-testing round-1 unblocker for VAL-CROSS-013.

The user-testing validator passed 55/56 m2-auth-budget assertions; the
single failure was VAL-CROSS-013, which runs the verbatim evidence
query `SELECT payload->>'reason', (payload->>'threshold_pct')::int
FROM events WHERE plan_id=$1 AND event_type='plan.budget_exceeded'`
and expects `('budget_threshold', 100)`. The current implementation
emits a sentinel payload with `plan_id` / `budget_usd` / `spent_usd` /
`crossing_task_id` only — the two crossing-condition pins are missing.

### What
- `whilly/adapters/db/repository.py` — add module-level constants
  `BUDGET_EXCEEDED_REASON = "budget_threshold"` and
  `BUDGET_EXCEEDED_THRESHOLD_PCT = 100` next to
  `BUDGET_EXCEEDED_EVENT_TYPE`. Extend the sentinel `json.dumps(...)`
  in `complete_task`'s crossing branch with `reason` and
  `threshold_pct` fields wired to the constants. Re-export both from
  `__all__`.
- `tests/integration/test_budget_guard.py` — extend
  `test_crossing_budget_emits_sentinel_once` and
  `test_sentinel_event_shape_matches_contract` to assert the new
  fields. Add a dedicated
  `test_budget_exceeded_payload_includes_reason_and_threshold_pct`
  that issues the verbatim VAL-CROSS-013 SQL.
- `tests/integration/test_budget_concurrent.py` — pin the new fields
  on the SINGLE sentinel emitted across N concurrent crossings
  (VAL-BUDGET-051 + VAL-CROSS-013 intersection).

No schema change. No migration. No CLI surface change. Pure payload
extension; existing VAL-BUDGET-040 / 041 / 042 / 043 / 050 / 051 / 052
evidence queries still succeed because all previously-emitted fields
are preserved.

### Validation contract
Fulfills: VAL-CROSS-013 (and continues to satisfy VAL-BUDGET-040 /
041 / 042 / 043 / 050 / 051 / 052).

### Test
```
pytest tests/integration/test_budget_guard.py tests/integration/test_budget_concurrent.py -v
   25 passed in 6.03s
pytest tests/integration -q
   218 passed, 1 skipped in 119.52s
pytest -q
   1473 passed, 1 skipped in 133.16s
ruff check whilly tests
   All checks passed!
ruff format --check whilly tests
   215 files already formatted
mypy --strict whilly/core/
   Success: no issues found in 7 source files
lint-imports
   Contracts: 1 kept, 0 broken.
```
