### PR TITLE
feat(task-108a): forge intake — GitHub issue → Whilly plan

### DIFF
--- a/tests/fixtures/fake_gh.sh
+++ b/tests/fixtures/fake_gh.sh
@@ -1,0 +1,107 @@
+#!/bin/sh
+#
+# Deterministic ``gh`` CLI stub for the Forge intake integration tests
+# (TASK-108a, paired with tests/integration/test_forge_intake.py).
+#
+# Most unit tests prefer to monkeypatch ``whilly.forge._gh._run_gh``
+# directly because that's a single Python seam — this stub exists for
+# the rare integration smoke that drives the full ``whilly forge intake``
+# subprocess via ``python -m whilly.cli`` and needs an executable on
+# ``PATH`` rather than a Python monkeypatch. Reach for it the same way
+# the existing ``fake_claude_prd.sh`` / ``fake_claude.sh`` fixtures do:
+# point ``PATH``-prepend or a ``GH_BIN`` override at this script.
+#
+# Behaviour summary
+# -----------------
+# Recognised invocation shapes:
+#
+#   gh issue view <N> --repo OWNER/REPO --json <fields>
+#       Emits a stable issue payload (number = N, title = test issue,
+#       body containing the issue ref, single comment, label set =
+#       ['whilly-pending'], state = OPEN, url = https://github.com/...).
+#
+#   gh issue edit <N> --repo OWNER/REPO --remove-label X --add-label Y
+#       Emits ``"https://github.com/OWNER/REPO/issues/N"`` (matching
+#       the real ``gh issue edit`` output) and exits 0. Intake-time
+#       label transitions land here.
+#
+# Anything else exits 1 so a regression in the call shape fails loudly
+# rather than silently masquerading as success.
+#
+# Usage
+# -----
+#   chmod +x tests/fixtures/fake_gh.sh
+#   PATH="$(pwd)/tests/fixtures:$PATH" \
+#       pytest tests/integration/test_forge_intake.py -v
+#
+# Tests typically prefer the lighter monkeypatch route — this stub is
+# here for cases (manual smoke, debugging) where a real PATH-prepended
+# binary is needed.
+
+set -eu
+
+if [ "$#" -lt 1 ]; then
+    echo "fake_gh.sh: missing subcommand" >&2
+    exit 1
+fi
+
+case "$1 $2" in
+    "issue view")
+        # Find the issue number — first non-flag positional after
+        # ``view``. POSIX shell doesn't have a clean argv slicer; we
+        # walk argv and pick up the first arg that starts with a digit.
+        number=""
+        for arg in "$@"; do
+            case "$arg" in
+                [0-9]*)
+                    number="$arg"
+                    break
+                    ;;
+            esac
+        done
+        if [ -z "$number" ]; then
+            echo "fake_gh.sh: gh issue view requires a numeric issue id" >&2
+            exit 1
+        fi
+        cat <<JSON
+{
+  "number": ${number},
+  "title": "[mission-test] fake forge intake issue",
+  "body": "Synthetic issue body emitted by fake_gh.sh.\n\nWe want a tiny smoke that drives whilly forge intake end-to-end.",
+  "labels": [{"name": "whilly-pending"}],
+  "comments": [
+    {
+      "body": "Comment body 1 — additional context the PRD wizard can fold into the description."
+    }
+  ],
+  "state": "OPEN",
+  "url": "https://github.com/example/repo/issues/${number}"
+}
+JSON
+        exit 0
+        ;;
+    "issue edit")
+        # Parse out the issue number (first numeric positional after
+        # ``edit``) and echo the canonical ``gh issue edit`` happy-
+        # path output (one URL on stdout, exit 0).
+        number=""
+        for arg in "$@"; do
+            case "$arg" in
+                [0-9]*)
+                    number="$arg"
+                    break
+                    ;;
+            esac
+        done
+        if [ -z "$number" ]; then
+            echo "fake_gh.sh: gh issue edit requires a numeric issue id" >&2
+            exit 1
+        fi
+        echo "https://github.com/example/repo/issues/${number}"
+        exit 0
+        ;;
+    *)
+        echo "fake_gh.sh: unsupported subcommand: $1 $2" >&2
+        exit 1
+        ;;
+esac

--- a/tests/integration/test_alembic_005.py
+++ b/tests/integration/test_alembic_005.py
@@ -132,11 +132,27 @@ async def _execute(dsn: str, sql: str, *args: Any) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_005_is_head_revision() -> None:
-    """The alembic script directory reports ``005_plan_budget`` as the head."""
+def test_005_is_in_chain_with_known_down_revision() -> None:
+    """``005_plan_budget`` is reachable from 004 (chain pinning).
+
+    Before TASK-108a's migration 006 landed, ``005`` was head. After
+    006, head is ``006_plan_github_ref`` and 005 is its
+    ``down_revision``. We pin both relationships here:
+
+    * 005 has ``down_revision == "004_per_worker_bearer"`` (unchanged).
+    * 005 is *not* head anymore — head is 006.
+
+    This keeps VAL-BUDGET-001 pinning (005 sits in the chain at the
+    expected position) without making the chain head an immutable
+    invariant that every future migration would have to update.
+    """
     cfg = _build_cfg("postgresql+asyncpg://placeholder/whilly")
     script = ScriptDirectory.from_config(cfg)
-    assert script.get_current_head() == "005_plan_budget"
+    rev_005 = script.get_revision("005_plan_budget")
+    assert rev_005 is not None
+    assert rev_005.down_revision == "004_per_worker_bearer"
+    # 005 is no longer the head (006 took it over).
+    assert script.get_current_head() != "005_plan_budget"
 
 
 # ---------------------------------------------------------------------------
@@ -219,9 +235,15 @@ def test_upgrade_adds_spent_usd_not_null_default_zero(base_004_dsn: str) -> None
 
 
 def test_downgrade_removes_budget_columns(base_004_dsn: str) -> None:
-    """After ``upgrade head`` then ``downgrade -1``, neither column exists."""
+    """After ``upgrade 005`` then ``downgrade -1``, neither column exists.
+
+    Pinned to revision ``005_plan_budget`` rather than ``head`` so that
+    later migrations (006+) don't perturb the per-migration test: we
+    are exercising the 005 downgrade path specifically, not "whatever
+    head is".
+    """
     cfg = _build_cfg(base_004_dsn)
-    _retry_colima_flake(lambda: command.upgrade(cfg, "head"), op="upgrade head")
+    _retry_colima_flake(lambda: command.upgrade(cfg, "005_plan_budget"), op="upgrade 005")
     _retry_colima_flake(lambda: command.downgrade(cfg, "-1"), op="downgrade -1")
 
     async def _inspect() -> tuple[int, str | None]:

--- a/tests/integration/test_alembic_006.py
+++ b/tests/integration/test_alembic_006.py
@@ -1,0 +1,329 @@
+"""Integration tests for migration 006_plan_github_ref (TASK-108a).
+
+Pins the data-layer half of TASK-108a: the alembic migration that
+adds ``plans.github_issue_ref text NULL`` plus the partial UNIQUE
+index ``ix_plans_github_issue_ref_unique``. Coverage:
+
+* VAL-FORGE-001 — script directory advertises ``006_plan_github_ref``
+  as the head revision; ``upgrade head`` adds the column with the
+  documented nullability + default semantics.
+* VAL-FORGE-002 — ``downgrade -1`` reverts cleanly; full
+  ``upgrade → downgrade base → upgrade head`` round-trip succeeds.
+* VAL-FORGE-020 — re-running ``upgrade head`` against an already-006
+  database is a no-op; existing ``github_issue_ref`` values are
+  preserved.
+* The partial UNIQUE index is enforced (concurrent INSERTs of the
+  same ``github_issue_ref`` collide on the index).
+
+Mirrors the structure of :mod:`tests.integration.test_alembic_005`:
+function-scoped pre-006 testcontainers Postgres, sync test functions,
+asyncpg fetch via the synchronous :func:`asyncio.run` bridge.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import asyncpg
+import pytest
+from alembic import command
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+
+from tests.conftest import (
+    DOCKER_REQUIRED,
+    HAS_TESTCONTAINERS,
+    _build_alembic_config,
+    _retry_colima_flake,
+    docker_available,
+    resolve_docker_host,
+)
+from whilly.adapters.db import MIGRATIONS_DIR
+
+pytestmark = DOCKER_REQUIRED
+
+
+_MIGRATION_006_PATH: Path = MIGRATIONS_DIR / "versions" / "006_plan_github_ref.py"
+
+
+def test_migration_006_file_exists_on_disk() -> None:
+    """The 006 migration ships at the canonical path (VAL-FORGE-001 evidence)."""
+    assert _MIGRATION_006_PATH.is_file(), (
+        f"Migration script missing at {_MIGRATION_006_PATH}; alembic upgrade head won't apply 006 if the file is gone."
+    )
+
+
+@pytest.fixture
+def base_005_dsn(monkeypatch: pytest.MonkeyPatch) -> Iterator[str]:
+    """Boot a fresh Postgres at revision ``005_plan_budget``."""
+    if not (HAS_TESTCONTAINERS and docker_available()):
+        pytest.skip("Docker daemon not reachable; testcontainers cannot boot Postgres")
+    from testcontainers.postgres import PostgresContainer  # type: ignore[import-untyped]
+
+    if "DOCKER_HOST" not in os.environ:
+        resolved = resolve_docker_host()
+        if resolved is not None:
+            monkeypatch.setenv("DOCKER_HOST", resolved)
+    monkeypatch.setenv("TESTCONTAINERS_RYUK_DISABLED", "true")
+
+    pg = PostgresContainer("postgres:15-alpine")
+    started = False
+    try:
+        _retry_colima_flake(
+            pg.start,
+            op="PostgresContainer('postgres:15-alpine').start() (test_alembic_006)",
+        )
+        started = True
+        raw = pg.get_connection_url()
+        dsn = raw.replace("postgresql+psycopg2://", "postgresql://").replace("+psycopg2", "")
+        monkeypatch.setenv("WHILLY_DATABASE_URL", dsn)
+        cfg = _build_alembic_config(dsn)
+        _retry_colima_flake(
+            lambda: command.upgrade(cfg, "005_plan_budget"),
+            op="alembic.command.upgrade(005_plan_budget) (test_alembic_006)",
+        )
+        yield dsn
+    finally:
+        if started:
+            try:
+                pg.stop()
+            except Exception:  # noqa: BLE001
+                pass
+
+
+def _build_cfg(dsn: str) -> Config:
+    return _build_alembic_config(dsn)
+
+
+def _to_asyncpg_dsn(dsn: str) -> str:
+    return dsn.replace("postgresql+asyncpg://", "postgresql://")
+
+
+async def _fetchval(dsn: str, sql: str, *args: Any) -> Any:
+    conn = await asyncpg.connect(_to_asyncpg_dsn(dsn))
+    try:
+        return await conn.fetchval(sql, *args)
+    finally:
+        await conn.close()
+
+
+async def _fetchrow(dsn: str, sql: str, *args: Any) -> asyncpg.Record | None:
+    conn = await asyncpg.connect(_to_asyncpg_dsn(dsn))
+    try:
+        return await conn.fetchrow(sql, *args)
+    finally:
+        await conn.close()
+
+
+async def _execute(dsn: str, sql: str, *args: Any) -> None:
+    conn = await asyncpg.connect(_to_asyncpg_dsn(dsn))
+    try:
+        await conn.execute(sql, *args)
+    finally:
+        await conn.close()
+
+
+# ---------------------------------------------------------------------------
+# VAL-FORGE-001 — script directory advertises 006 as head; column added
+# ---------------------------------------------------------------------------
+
+
+def test_006_is_head_revision() -> None:
+    """The alembic script directory reports ``006_plan_github_ref`` as the head."""
+    cfg = _build_cfg("postgresql+asyncpg://placeholder/whilly")
+    script = ScriptDirectory.from_config(cfg)
+    assert script.get_current_head() == "006_plan_github_ref"
+
+
+def test_upgrade_adds_github_issue_ref_nullable_text(base_005_dsn: str) -> None:
+    """``plans.github_issue_ref`` exists with ``data_type=text`` and ``is_nullable=YES``.
+
+    VAL-FORGE-001 evidence — pre-existing rows show ``github_issue_ref
+    IS NULL`` because the column has no server default; the migration
+    adds the column without backfilling.
+    """
+
+    async def _seed_pre_006_plan() -> None:
+        await _execute(
+            base_005_dsn,
+            "INSERT INTO plans (id, name) VALUES ($1, $2)",
+            "plan-pre-006",
+            "Pre-006 Plan",
+        )
+
+    asyncio.run(_seed_pre_006_plan())
+
+    cfg = _build_cfg(base_005_dsn)
+    _retry_colima_flake(lambda: command.upgrade(cfg, "head"), op="upgrade head (005→head)")
+
+    row = asyncio.run(
+        _fetchrow(
+            base_005_dsn,
+            """
+            SELECT data_type, is_nullable, column_default
+            FROM information_schema.columns
+            WHERE table_name = 'plans' AND column_name = 'github_issue_ref'
+            """,
+        )
+    )
+    assert row is not None
+    assert row["data_type"] == "text"
+    assert row["is_nullable"] == "YES"
+    assert row["column_default"] is None
+
+    # Pre-existing plan now has github_issue_ref = NULL (no backfill).
+    pre_existing_ref = asyncio.run(
+        _fetchval(
+            base_005_dsn,
+            "SELECT github_issue_ref FROM plans WHERE id = 'plan-pre-006'",
+        )
+    )
+    assert pre_existing_ref is None
+
+
+# ---------------------------------------------------------------------------
+# VAL-FORGE-002 — downgrade -1 removes the column cleanly + round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_downgrade_removes_github_issue_ref_column(base_005_dsn: str) -> None:
+    """After ``upgrade head`` then ``downgrade -1``, the column + index are gone."""
+    cfg = _build_cfg(base_005_dsn)
+    _retry_colima_flake(lambda: command.upgrade(cfg, "head"), op="upgrade head")
+    _retry_colima_flake(lambda: command.downgrade(cfg, "-1"), op="downgrade -1")
+
+    async def _inspect() -> tuple[int, int, str | None]:
+        col_count = await _fetchval(
+            base_005_dsn,
+            """
+            SELECT count(*)::int FROM information_schema.columns
+            WHERE table_name = 'plans' AND column_name = 'github_issue_ref'
+            """,
+        )
+        idx_count = await _fetchval(
+            base_005_dsn,
+            """
+            SELECT count(*)::int FROM pg_indexes
+            WHERE tablename = 'plans' AND indexname = 'ix_plans_github_issue_ref_unique'
+            """,
+        )
+        version = await _fetchval(base_005_dsn, "SELECT version_num FROM alembic_version")
+        return int(col_count), int(idx_count), version
+
+    col_count, idx_count, version = asyncio.run(_inspect())
+    assert col_count == 0
+    assert idx_count == 0
+    assert version == "005_plan_budget"
+
+
+def test_round_trip_upgrade_downgrade_base_upgrade(base_005_dsn: str) -> None:
+    """``upgrade head`` → ``downgrade base`` → ``upgrade head`` succeeds at every step."""
+    cfg = _build_cfg(base_005_dsn)
+    _retry_colima_flake(lambda: command.upgrade(cfg, "head"), op="upgrade head (rt-1)")
+    _retry_colima_flake(lambda: command.downgrade(cfg, "base"), op="downgrade base (rt)")
+    _retry_colima_flake(lambda: command.upgrade(cfg, "head"), op="upgrade head (rt-2)")
+
+    async def _inspect() -> tuple[Any, Any]:
+        github_nullable = await _fetchval(
+            base_005_dsn,
+            """
+            SELECT is_nullable FROM information_schema.columns
+            WHERE table_name = 'plans' AND column_name = 'github_issue_ref'
+            """,
+        )
+        idx_count = await _fetchval(
+            base_005_dsn,
+            """
+            SELECT count(*)::int FROM pg_indexes
+            WHERE tablename = 'plans' AND indexname = 'ix_plans_github_issue_ref_unique'
+            """,
+        )
+        return github_nullable, int(idx_count)
+
+    github_nullable, idx_count = asyncio.run(_inspect())
+    assert github_nullable == "YES"
+    assert idx_count == 1
+
+
+# ---------------------------------------------------------------------------
+# VAL-FORGE-020 — idempotent re-upgrade preserves data
+# ---------------------------------------------------------------------------
+
+
+def test_upgrade_head_is_idempotent(base_005_dsn: str) -> None:
+    """Two consecutive ``upgrade head`` calls succeed; existing values preserved."""
+    cfg = _build_cfg(base_005_dsn)
+    _retry_colima_flake(lambda: command.upgrade(cfg, "head"), op="upgrade head (1)")
+
+    async def _seed_with_ref() -> None:
+        await _execute(
+            base_005_dsn,
+            "INSERT INTO plans (id, name, github_issue_ref) VALUES ($1, $2, $3)",
+            "plan-with-ref",
+            "Plan w/ ref",
+            "owner/repo/42",
+        )
+
+    asyncio.run(_seed_with_ref())
+
+    # Second ``upgrade head`` is a no-op against the alembic_version
+    # row already at 006.
+    _retry_colima_flake(lambda: command.upgrade(cfg, "head"), op="upgrade head (2)")
+
+    persisted_ref = asyncio.run(
+        _fetchval(
+            base_005_dsn,
+            "SELECT github_issue_ref FROM plans WHERE id = 'plan-with-ref'",
+        )
+    )
+    assert persisted_ref == "owner/repo/42"
+
+
+# ---------------------------------------------------------------------------
+# Partial UNIQUE index enforces idempotency at the schema level
+# ---------------------------------------------------------------------------
+
+
+def test_partial_unique_index_enforces_one_plan_per_ref(base_005_dsn: str) -> None:
+    """Two INSERTs with the same non-NULL ``github_issue_ref`` collide on the partial UNIQUE."""
+    cfg = _build_cfg(base_005_dsn)
+    _retry_colima_flake(lambda: command.upgrade(cfg, "head"), op="upgrade head")
+
+    async def _scenario() -> None:
+        # First INSERT — succeeds.
+        await _execute(
+            base_005_dsn,
+            "INSERT INTO plans (id, name, github_issue_ref) VALUES ($1, $2, $3)",
+            "plan-a",
+            "Plan A",
+            "owner/repo/100",
+        )
+        # Second INSERT with the same ref but a different id — refused.
+        with pytest.raises(asyncpg.UniqueViolationError):
+            await _execute(
+                base_005_dsn,
+                "INSERT INTO plans (id, name, github_issue_ref) VALUES ($1, $2, $3)",
+                "plan-b",
+                "Plan B",
+                "owner/repo/100",
+            )
+        # Two NULL refs MUST be allowed (partial WHERE github_issue_ref
+        # IS NOT NULL excludes NULLs from the UNIQUE check).
+        await _execute(
+            base_005_dsn,
+            "INSERT INTO plans (id, name) VALUES ($1, $2)",
+            "plan-c",
+            "Plan C",
+        )
+        await _execute(
+            base_005_dsn,
+            "INSERT INTO plans (id, name) VALUES ($1, $2)",
+            "plan-d",
+            "Plan D",
+        )
+
+    asyncio.run(_scenario())

--- a/tests/integration/test_alembic_full_chain.py
+++ b/tests/integration/test_alembic_full_chain.py
@@ -1,0 +1,218 @@
+"""End-to-end alembic chain test (TASK-108a).
+
+Pins the assertion that ``alembic upgrade head`` applies migrations
+``001 → 002 → 003 → 004 → 005 → 006`` in order on a fresh Postgres
+and ``alembic downgrade base`` reverts every step cleanly. Mirrors
+the per-migration tests but exercises the whole linear chain in one
+go so a single broken edge between revisions surfaces here even when
+each per-migration test passes in isolation.
+
+Note that ``information_schema`` is the source of truth for column
+shape; ``alembic_version`` is the source of truth for the recorded
+revision. After ``downgrade base`` the version table itself is
+empty (alembic deletes the row when downgraded past the first
+migration).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from collections.abc import Iterator
+from typing import Any
+
+import asyncpg
+import pytest
+from alembic import command
+
+from tests.conftest import (
+    DOCKER_REQUIRED,
+    HAS_TESTCONTAINERS,
+    _build_alembic_config,
+    _retry_colima_flake,
+    docker_available,
+    resolve_docker_host,
+)
+from whilly.adapters.db import MIGRATIONS_DIR
+
+pytestmark = DOCKER_REQUIRED
+
+
+# Ordered chain of migrations the suite expects on disk. If a future
+# migration shifts the chain this test calls it out loudly rather than
+# silently letting the chain grow without coverage.
+EXPECTED_CHAIN: tuple[str, ...] = (
+    "001_initial_schema",
+    "002_workers_status",
+    "003_events_detail",
+    "004_per_worker_bearer",
+    "005_plan_budget",
+    "006_plan_github_ref",
+)
+
+
+def test_expected_chain_files_exist_on_disk() -> None:
+    """Every expected migration file ships at the canonical path."""
+    versions_dir = MIGRATIONS_DIR / "versions"
+    for revision in EXPECTED_CHAIN:
+        path = versions_dir / f"{revision}.py"
+        assert path.is_file(), f"Missing migration file at {path}"
+
+
+@pytest.fixture
+def empty_postgres_dsn(monkeypatch: pytest.MonkeyPatch) -> Iterator[str]:
+    """Boot a fresh Postgres at the empty / pre-001 baseline."""
+    if not (HAS_TESTCONTAINERS and docker_available()):
+        pytest.skip("Docker daemon not reachable; testcontainers cannot boot Postgres")
+    from testcontainers.postgres import PostgresContainer  # type: ignore[import-untyped]
+
+    if "DOCKER_HOST" not in os.environ:
+        resolved = resolve_docker_host()
+        if resolved is not None:
+            monkeypatch.setenv("DOCKER_HOST", resolved)
+    monkeypatch.setenv("TESTCONTAINERS_RYUK_DISABLED", "true")
+
+    pg = PostgresContainer("postgres:15-alpine")
+    started = False
+    try:
+        _retry_colima_flake(
+            pg.start,
+            op="PostgresContainer('postgres:15-alpine').start() (test_alembic_full_chain)",
+        )
+        started = True
+        raw = pg.get_connection_url()
+        dsn = raw.replace("postgresql+psycopg2://", "postgresql://").replace("+psycopg2", "")
+        monkeypatch.setenv("WHILLY_DATABASE_URL", dsn)
+        yield dsn
+    finally:
+        if started:
+            try:
+                pg.stop()
+            except Exception:  # noqa: BLE001
+                pass
+
+
+def _to_asyncpg_dsn(dsn: str) -> str:
+    return dsn.replace("postgresql+asyncpg://", "postgresql://")
+
+
+async def _fetchval(dsn: str, sql: str, *args: Any) -> Any:
+    conn = await asyncpg.connect(_to_asyncpg_dsn(dsn))
+    try:
+        return await conn.fetchval(sql, *args)
+    finally:
+        await conn.close()
+
+
+async def _fetchall(dsn: str, sql: str, *args: Any) -> list[asyncpg.Record]:
+    conn = await asyncpg.connect(_to_asyncpg_dsn(dsn))
+    try:
+        return await conn.fetch(sql, *args)
+    finally:
+        await conn.close()
+
+
+def test_full_chain_upgrade_then_full_downgrade(empty_postgres_dsn: str) -> None:
+    """``alembic upgrade head`` then ``alembic downgrade base`` round-trips cleanly.
+
+    Steps:
+      1. Empty Postgres (no whilly tables).
+      2. Apply ``upgrade head`` — every migration in :data:`EXPECTED_CHAIN`
+         lands; alembic_version reports ``006_plan_github_ref``.
+      3. Verify the migration-006 deltas exist (column +
+         partial UNIQUE index).
+      4. Apply ``downgrade base`` — every migration's downgrade runs
+         in reverse order; alembic_version table is left empty (no
+         applied revisions).
+      5. Verify the whilly tables and the migration-006 column are
+         gone — schema returned to the pre-001 baseline.
+    """
+    cfg = _build_alembic_config(empty_postgres_dsn)
+
+    # ── Step 2: upgrade head ──────────────────────────────────────────
+    _retry_colima_flake(lambda: command.upgrade(cfg, "head"), op="upgrade head (chain)")
+
+    head_version = asyncio.run(_fetchval(empty_postgres_dsn, "SELECT version_num FROM alembic_version"))
+    assert head_version == "006_plan_github_ref"
+
+    # ── Step 3: 006-specific deltas exist ────────────────────────────
+    column_count = asyncio.run(
+        _fetchval(
+            empty_postgres_dsn,
+            """
+            SELECT count(*)::int FROM information_schema.columns
+            WHERE table_name = 'plans' AND column_name = 'github_issue_ref'
+            """,
+        )
+    )
+    assert int(column_count) == 1
+
+    index_count = asyncio.run(
+        _fetchval(
+            empty_postgres_dsn,
+            """
+            SELECT count(*)::int FROM pg_indexes
+            WHERE tablename = 'plans'
+              AND indexname = 'ix_plans_github_issue_ref_unique'
+            """,
+        )
+    )
+    assert int(index_count) == 1
+
+    # Confirm the whilly tables are present (sanity).
+    tables = {
+        row["table_name"]
+        for row in asyncio.run(
+            _fetchall(
+                empty_postgres_dsn,
+                """
+                SELECT table_name FROM information_schema.tables
+                WHERE table_schema = 'public'
+                  AND table_name IN ('workers', 'plans', 'tasks', 'events')
+                """,
+            )
+        )
+    }
+    assert tables == {"workers", "plans", "tasks", "events"}
+
+    # ── Step 4: downgrade base ────────────────────────────────────────
+    _retry_colima_flake(lambda: command.downgrade(cfg, "base"), op="downgrade base (chain)")
+
+    base_version = asyncio.run(_fetchval(empty_postgres_dsn, "SELECT version_num FROM alembic_version"))
+    # ``downgrade base`` removes all rows from alembic_version (the
+    # default behaviour — no revisions applied).
+    assert base_version is None
+
+    # ── Step 5: schema returned to pre-001 baseline ──────────────────
+    post_downgrade_tables = {
+        row["table_name"]
+        for row in asyncio.run(
+            _fetchall(
+                empty_postgres_dsn,
+                """
+                SELECT table_name FROM information_schema.tables
+                WHERE table_schema = 'public'
+                  AND table_name IN ('workers', 'plans', 'tasks', 'events')
+                """,
+            )
+        )
+    }
+    assert post_downgrade_tables == set()
+
+
+def test_full_chain_then_re_upgrade_idempotent(empty_postgres_dsn: str) -> None:
+    """``upgrade head`` → ``upgrade head`` is a no-op (alembic-version unchanged).
+
+    Pins VAL-FORGE-020 across the full chain: re-running ``upgrade
+    head`` against an already-006 database is safe (same alembic
+    contract every migration relies on, but spelled out here so a
+    broken upgrade idempotency edge would surface in CI).
+    """
+    cfg = _build_alembic_config(empty_postgres_dsn)
+    _retry_colima_flake(lambda: command.upgrade(cfg, "head"), op="upgrade head (1)")
+    first_version = asyncio.run(_fetchval(empty_postgres_dsn, "SELECT version_num FROM alembic_version"))
+    assert first_version == "006_plan_github_ref"
+
+    _retry_colima_flake(lambda: command.upgrade(cfg, "head"), op="upgrade head (2)")
+    second_version = asyncio.run(_fetchval(empty_postgres_dsn, "SELECT version_num FROM alembic_version"))
+    assert second_version == "006_plan_github_ref"

--- a/tests/integration/test_forge_intake.py
+++ b/tests/integration/test_forge_intake.py
@@ -1,0 +1,556 @@
+"""Integration tests for ``whilly forge intake`` (TASK-108a).
+
+Drives the Forge intake CLI surface against a real Postgres
+(testcontainers) with the ``gh`` subprocess monkeypatched at the
+:mod:`whilly.forge._gh` seam (``_run_gh``). Exercises:
+
+* VAL-FORGE-003 — pinned ``--json`` field set on ``gh issue view``.
+* VAL-FORGE-004 — plan row carries ``github_issue_ref``.
+* VAL-FORGE-006 — combined ``gh issue edit`` invocation with both
+  ``--add-label`` and ``--remove-label`` flags.
+* VAL-FORGE-007 — idempotent re-run returns the existing plan id and
+  does **not** re-invoke ``gh issue edit``.
+* VAL-FORGE-008 — ``gh`` absent → exit 2, install hint on stderr.
+* VAL-FORGE-009 — issue not found → exit 1, no plan written.
+* VAL-FORGE-010 — network/transport error from ``gh`` → graceful
+  failure, no partial plan.
+* VAL-FORGE-011 — plan has either ``prd_file`` set or zero tasks
+  (every plan covers one branch of the disjunction).
+* VAL-FORGE-012 — ``GET /api/v1/plans/<id>`` exposes
+  ``github_issue_ref`` in the response.
+* VAL-FORGE-014 — env passed to ``gh`` is the resolver's output
+  (``gh_subprocess_env``).
+* VAL-FORGE-016 — ``--help`` mentions issue ref shape, label
+  transition, and ``gh`` requirement.
+* VAL-FORGE-017 — malformed input is rejected before any
+  ``subprocess.run`` call.
+* VAL-FORGE-018 — failure post-fetch does NOT flip the label.
+* VAL-CROSS-001 — ``plan.created`` event reaches the events table
+  via the lifespan flusher.
+
+Tests use the function-scoped ``db_pool`` fixture so each scenario
+runs against a TRUNCATEd schema.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import asyncpg
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from tests.conftest import DOCKER_REQUIRED
+from whilly.adapters.transport.server import create_app
+from whilly.forge import _gh as forge_gh
+from whilly.forge import intake as forge_intake
+
+pytestmark = DOCKER_REQUIRED
+
+
+REPO_ROOT: Path = Path(__file__).resolve().parents[2]
+FAKE_CLAUDE_PRD: Path = REPO_ROOT / "tests" / "fixtures" / "fake_claude_prd.sh"
+
+
+# ── Helpers: canned gh payloads ───────────────────────────────────────────
+def _canned_issue_payload(number: int) -> dict[str, Any]:
+    """Stable issue payload used by the happy-path tests."""
+    return {
+        "number": number,
+        "title": "[mission-test] forge intake smoke",
+        "body": "Forge intake should turn this issue into a Whilly plan.",
+        "labels": [{"name": "whilly-pending"}],
+        "comments": [
+            {"body": "Comment 1: extra context for the PRD wizard."},
+        ],
+        "state": "OPEN",
+        "url": f"https://github.com/example/repo/issues/{number}",
+    }
+
+
+def _completed(stdout: str = "", stderr: str = "", returncode: int = 0) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        args=["gh"],
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+async def _run_intake(argv: list[str], **kwargs: Any) -> int:
+    """Run :func:`forge_intake.run_forge_intake_command` in a worker thread.
+
+    The CLI uses ``asyncio.run`` internally for its DB round-trips,
+    which would explode if invoked from inside the pytest-asyncio
+    event loop. ``asyncio.to_thread`` runs the synchronous CLI in a
+    thread so tests can stay ``async def`` and continue to use the
+    async ``db_pool`` fixture for assertions.
+    """
+    return await asyncio.to_thread(
+        forge_intake.run_forge_intake_command,
+        argv,
+        **kwargs,
+    )
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────
+@pytest.fixture(autouse=True)
+def _reset_db(db_pool: asyncpg.Pool) -> None:
+    """Force the autouse db_pool fixture so each test gets a TRUNCATEd schema."""
+    return None
+
+
+@pytest.fixture
+def isolated_workdir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Run each test in a tmp cwd so PRD files don't pollute the repo."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "docs").mkdir()
+    return tmp_path
+
+
+@pytest.fixture
+def fake_claude(monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point ``CLAUDE_BIN`` at the PRD-aware stub for headless intake runs."""
+    assert FAKE_CLAUDE_PRD.exists(), f"fixture missing: {FAKE_CLAUDE_PRD}"
+    assert os.access(FAKE_CLAUDE_PRD, os.X_OK), f"fixture lost its executable bit: {FAKE_CLAUDE_PRD}"
+    monkeypatch.setenv("CLAUDE_BIN", str(FAKE_CLAUDE_PRD))
+    return FAKE_CLAUDE_PRD
+
+
+@pytest.fixture
+def database_url(postgres_dsn: str, monkeypatch: pytest.MonkeyPatch) -> str:
+    """Set ``WHILLY_DATABASE_URL`` for the duration of the test."""
+    monkeypatch.setenv("WHILLY_DATABASE_URL", postgres_dsn)
+    return postgres_dsn
+
+
+@pytest.fixture
+def gh_recorder(monkeypatch: pytest.MonkeyPatch):
+    """Record every ``forge._gh._run_gh`` invocation; return the call list.
+
+    Tests append (or pre-load) a list of canned ``CompletedProcess``
+    results onto the recorder; subsequent calls pop in order. The
+    captured argv list is exposed as ``recorder.calls`` so tests can
+    assert the exact ``gh`` invocations.
+    """
+
+    class _Recorder:
+        def __init__(self) -> None:
+            self.calls: list[list[str]] = []
+            self.envs: list[dict[str, str]] = []
+            self.responses: list[subprocess.CompletedProcess[str]] = []
+
+        def queue(self, response: subprocess.CompletedProcess[str]) -> None:
+            self.responses.append(response)
+
+        def __call__(
+            self,
+            args: list[str],
+            *,
+            timeout: float = forge_gh.DEFAULT_GH_TIMEOUT_SECONDS,
+        ) -> subprocess.CompletedProcess[str]:
+            del timeout
+            from whilly.gh_utils import gh_subprocess_env
+
+            # Mirror the production helper's gh-on-PATH precondition so
+            # tests asserting the "gh CLI absent" path get the same
+            # exception type.
+            if shutil.which("gh") is None:
+                raise forge_gh.GHCLIMissingError(
+                    "gh CLI is not on PATH; install via `brew install gh` or see https://cli.github.com."
+                )
+            self.calls.append(list(args))
+            self.envs.append(dict(gh_subprocess_env()))
+            if not self.responses:
+                raise AssertionError(f"gh_recorder: no canned response queued for invocation {args!r}")
+            return self.responses.pop(0)
+
+    rec = _Recorder()
+    monkeypatch.setattr(forge_gh, "_run_gh", rec)
+    return rec
+
+
+# ── VAL-FORGE-016: --help discoverability ────────────────────────────────
+def test_intake_help_documents_issue_ref_and_labels(capsys: pytest.CaptureFixture[str]) -> None:
+    """--help mentions ``owner/repo``, the label transition and ``gh``."""
+    rc = forge_intake.run_forge_intake_command(["--help"])
+    captured = capsys.readouterr()
+    assert rc == forge_intake.EXIT_OK
+    out_lower = captured.out.lower()
+    # (a) issue ref shape mentioned.
+    assert "owner/repo" in out_lower
+    # (b) label transition documented (both literals).
+    assert "whilly-pending" in out_lower
+    assert "whilly-in-progress" in out_lower
+    # (c) gh CLI requirement called out.
+    assert "gh" in out_lower
+
+
+# ── VAL-FORGE-017: malformed input rejected before subprocess ────────────
+@pytest.mark.parametrize(
+    "bad_ref",
+    [
+        "garbage",
+        "owner/repo",
+        "owner/repo/abc",
+        "owner//42",
+        "/repo/42",
+    ],
+)
+def test_malformed_issue_ref_rejected_without_subprocess(
+    bad_ref: str,
+    gh_recorder,
+    database_url: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Bad shape exits 1; ``gh`` is never invoked."""
+    rc = forge_intake.run_forge_intake_command([bad_ref])
+    captured = capsys.readouterr()
+    assert rc == forge_intake.EXIT_USER_ERROR
+    assert "owner/repo" in captured.err
+    assert gh_recorder.calls == []
+
+
+# ── VAL-FORGE-008: gh absent ─────────────────────────────────────────────
+def test_gh_cli_missing_returns_environment_error(
+    monkeypatch: pytest.MonkeyPatch,
+    isolated_workdir: Path,
+    fake_claude: Path,
+    database_url: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``shutil.which('gh')`` returning None → exit 2, install hint."""
+    monkeypatch.setattr(shutil, "which", lambda *_args, **_kwargs: None)
+    rc = forge_intake.run_forge_intake_command(["owner/repo/123"])
+    captured = capsys.readouterr()
+    assert rc == forge_intake.EXIT_ENVIRONMENT_ERROR
+    err_lower = captured.err.lower()
+    assert "gh" in err_lower
+    # Either the brew install command or the cli.github.com link.
+    assert "install" in err_lower or "cli.github.com" in err_lower
+
+
+# ── VAL-FORGE-009: issue not found ───────────────────────────────────────
+async def test_issue_not_found_exits_user_error_no_plan(
+    monkeypatch: pytest.MonkeyPatch,
+    isolated_workdir: Path,
+    fake_claude: Path,
+    database_url: str,
+    db_pool: asyncpg.Pool,
+    gh_recorder,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """gh exit 1 + GraphQL miss → exit 1; no plan written."""
+    monkeypatch.setattr(shutil, "which", lambda *_args, **_kwargs: "/usr/local/bin/gh")
+    gh_recorder.queue(
+        _completed(
+            stdout="",
+            stderr="GraphQL: Could not resolve to an Issue or Pull Request",
+            returncode=1,
+        )
+    )
+    rc = await _run_intake(["owner/repo/999999"])
+    captured = capsys.readouterr()
+    assert rc == forge_intake.EXIT_USER_ERROR
+    assert "issue not found" in captured.err.lower()
+    async with db_pool.acquire() as conn:
+        plan_count = await conn.fetchval("SELECT count(*) FROM plans")
+    assert plan_count == 0
+
+
+# ── VAL-FORGE-010: network/transport error ───────────────────────────────
+async def test_network_error_graceful_failure_no_partial_plan(
+    monkeypatch: pytest.MonkeyPatch,
+    isolated_workdir: Path,
+    fake_claude: Path,
+    database_url: str,
+    db_pool: asyncpg.Pool,
+    gh_recorder,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """gh exit non-zero with network signature → exit 1; no plan."""
+    monkeypatch.setattr(shutil, "which", lambda *_args, **_kwargs: "/usr/local/bin/gh")
+    gh_recorder.queue(
+        _completed(
+            stdout="",
+            stderr="could not connect to api.github.com: dial tcp: lookup api.github.com: no such host",
+            returncode=1,
+        )
+    )
+    rc = await _run_intake(["owner/repo/123"])
+    captured = capsys.readouterr()
+    assert rc != 0
+    assert "could not connect" in captured.err.lower()
+    async with db_pool.acquire() as conn:
+        plan_count = await conn.fetchval("SELECT count(*) FROM plans")
+    assert plan_count == 0
+
+
+# ── Happy path: plan creation + label flip + DB row + event ──────────────
+async def test_intake_happy_path_creates_plan_and_flips_label(
+    monkeypatch: pytest.MonkeyPatch,
+    isolated_workdir: Path,
+    fake_claude: Path,
+    database_url: str,
+    db_pool: asyncpg.Pool,
+    gh_recorder,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Successful intake: plan row, github_issue_ref populated, label flipped exactly once."""
+    monkeypatch.setattr(shutil, "which", lambda *_args, **_kwargs: "/usr/local/bin/gh")
+    # Queue: (1) gh issue view → canned payload, (2) gh issue edit → ok.
+    import json as _json
+
+    gh_recorder.queue(_completed(stdout=_json.dumps(_canned_issue_payload(123))))
+    gh_recorder.queue(_completed(stdout="https://github.com/example/repo/issues/123"))
+
+    rc = await _run_intake(["owner/repo/123"])
+    captured = capsys.readouterr()
+    assert rc == forge_intake.EXIT_OK, captured.err
+
+    # VAL-FORGE-003 — first call shape: gh issue view <N> --repo OWNER/REPO --json <fields>.
+    assert len(gh_recorder.calls) == 2
+    view_argv = gh_recorder.calls[0]
+    assert view_argv[0] == "issue"
+    assert view_argv[1] == "view"
+    assert view_argv[2] == "123"
+    assert "--repo" in view_argv
+    assert view_argv[view_argv.index("--repo") + 1] == "owner/repo"
+    assert "--json" in view_argv
+    json_fields_value = view_argv[view_argv.index("--json") + 1]
+    json_fields = set(json_fields_value.split(","))
+    expected_fields = set(forge_gh.GH_ISSUE_VIEW_JSON_FIELDS.split(","))
+    assert expected_fields.issubset(json_fields), (
+        f"Pinned --json fields {expected_fields} not all present in {json_fields}"
+    )
+
+    # VAL-FORGE-006 — second call shape: gh issue edit <N> --repo OWNER/REPO
+    # --remove-label whilly-pending --add-label whilly-in-progress.
+    edit_argv = gh_recorder.calls[1]
+    assert edit_argv[0] == "issue"
+    assert edit_argv[1] == "edit"
+    assert edit_argv[2] == "123"
+    assert "--remove-label" in edit_argv
+    assert edit_argv[edit_argv.index("--remove-label") + 1] == "whilly-pending"
+    assert "--add-label" in edit_argv
+    assert edit_argv[edit_argv.index("--add-label") + 1] == "whilly-in-progress"
+
+    # VAL-FORGE-004 — exactly one plans row carries the canonical ref.
+    async with db_pool.acquire() as conn:
+        rows = await conn.fetch(
+            "SELECT id, name, github_issue_ref FROM plans WHERE github_issue_ref = $1",
+            "owner/repo/123",
+        )
+    assert len(rows) == 1
+    assert rows[0]["github_issue_ref"] == "owner/repo/123"
+
+
+# ── VAL-FORGE-007: idempotent re-run ─────────────────────────────────────
+async def test_intake_idempotent_re_run_no_duplicate_no_extra_label_call(
+    monkeypatch: pytest.MonkeyPatch,
+    isolated_workdir: Path,
+    fake_claude: Path,
+    database_url: str,
+    db_pool: asyncpg.Pool,
+    gh_recorder,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Re-running the same intake returns the existing plan id; no extra gh edit."""
+    monkeypatch.setattr(shutil, "which", lambda *_args, **_kwargs: "/usr/local/bin/gh")
+    import json as _json
+
+    # First run — view + edit.
+    gh_recorder.queue(_completed(stdout=_json.dumps(_canned_issue_payload(123))))
+    gh_recorder.queue(_completed(stdout="https://github.com/example/repo/issues/123"))
+
+    rc1 = await _run_intake(["owner/repo/123"])
+    capsys.readouterr()
+    assert rc1 == forge_intake.EXIT_OK
+
+    first_calls = list(gh_recorder.calls)
+
+    # Second run — same args. No gh invocation should occur (idempotent
+    # short-circuit hits before fetch_issue).
+    rc2 = await _run_intake(["owner/repo/123"])
+    captured2 = capsys.readouterr()
+    assert rc2 == forge_intake.EXIT_OK
+
+    # No new calls were queued; assert the recorder didn't pop any.
+    assert gh_recorder.calls == first_calls
+
+    # Stdout from the second run includes the existing plan id message.
+    assert "already exists" in captured2.out
+
+    # Exactly one row in the DB.
+    async with db_pool.acquire() as conn:
+        plan_count = await conn.fetchval(
+            "SELECT count(*) FROM plans WHERE github_issue_ref = $1",
+            "owner/repo/123",
+        )
+    assert plan_count == 1
+
+
+# ── VAL-FORGE-014: env passed to gh is gh_subprocess_env() output ────────
+async def test_intake_uses_gh_subprocess_env(
+    monkeypatch: pytest.MonkeyPatch,
+    isolated_workdir: Path,
+    fake_claude: Path,
+    database_url: str,
+    gh_recorder,
+) -> None:
+    """The captured env for ``gh`` matches ``gh_subprocess_env()``."""
+    monkeypatch.setattr(shutil, "which", lambda *_args, **_kwargs: "/usr/local/bin/gh")
+    monkeypatch.setenv("WHILLY_GH_TOKEN", "fake-token-for-test")
+    import json as _json
+
+    gh_recorder.queue(_completed(stdout=_json.dumps(_canned_issue_payload(124))))
+    gh_recorder.queue(_completed(stdout="https://github.com/example/repo/issues/124"))
+
+    rc = await _run_intake(["owner/repo/124"])
+    assert rc == forge_intake.EXIT_OK
+
+    # Both invocations should carry the resolved token.
+    from whilly.gh_utils import gh_subprocess_env
+
+    expected = gh_subprocess_env()
+    assert expected["GITHUB_TOKEN"] == "fake-token-for-test"
+    for env in gh_recorder.envs:
+        assert env["GITHUB_TOKEN"] == "fake-token-for-test"
+
+
+# ── VAL-FORGE-018: PRD failure post-fetch does NOT flip label ────────────
+async def test_failed_prd_after_fetch_does_not_flip_label(
+    monkeypatch: pytest.MonkeyPatch,
+    isolated_workdir: Path,
+    database_url: str,
+    db_pool: asyncpg.Pool,
+    gh_recorder,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """PRD generation raising → no plan, no ``gh issue edit`` invocation."""
+    monkeypatch.setattr(shutil, "which", lambda *_args, **_kwargs: "/usr/local/bin/gh")
+    import json as _json
+
+    # Only queue the view call; the edit call must never happen.
+    gh_recorder.queue(_completed(stdout=_json.dumps(_canned_issue_payload(125))))
+
+    def _boom(**_kwargs: Any) -> None:
+        raise RuntimeError("boom: PRD generator failed")
+
+    rc = await _run_intake(
+        ["owner/repo/125"],
+        prd_runner=_boom,
+    )
+    captured = capsys.readouterr()
+    assert rc != 0
+    assert "PRD generation failed" in captured.err
+
+    # gh issue edit must not have been invoked (only the view from the queue).
+    assert len(gh_recorder.calls) == 1
+    assert gh_recorder.calls[0][0:2] == ["issue", "view"]
+
+    # No plan inserted.
+    async with db_pool.acquire() as conn:
+        plan_count = await conn.fetchval(
+            "SELECT count(*) FROM plans WHERE github_issue_ref = $1",
+            "owner/repo/125",
+        )
+    assert plan_count == 0
+
+
+# ── VAL-FORGE-011: every plan has prd_file OR zero tasks ─────────────────
+async def test_intake_plan_has_prd_or_zero_tasks(
+    monkeypatch: pytest.MonkeyPatch,
+    isolated_workdir: Path,
+    fake_claude: Path,
+    database_url: str,
+    db_pool: asyncpg.Pool,
+    gh_recorder,
+) -> None:
+    """A successful intake produces a PRD file on disk; tasks ≥ 0 is acceptable.
+
+    The fake_claude_prd.sh stub emits one task — so this concrete
+    happy-path lands with prd_file existing AND ≥ 1 task. The
+    contract (VAL-FORGE-011) says ``prd_file IS NOT NULL AND
+    Path(prd_file).exists()`` OR ``tasks_count == 0`` — we assert the
+    happy-path branch.
+    """
+    monkeypatch.setattr(shutil, "which", lambda *_args, **_kwargs: "/usr/local/bin/gh")
+    import json as _json
+
+    gh_recorder.queue(_completed(stdout=_json.dumps(_canned_issue_payload(126))))
+    gh_recorder.queue(_completed(stdout="https://github.com/example/repo/issues/126"))
+
+    rc = await _run_intake(["owner/repo/126"])
+    assert rc == forge_intake.EXIT_OK
+
+    # PRD file on disk under <output_dir>/PRD-<slug>.md.
+    slug = forge_intake._slug_for_issue("owner", "repo", 126)
+    prd_path = isolated_workdir / "docs" / f"PRD-{slug}.md"
+    assert prd_path.exists()
+
+
+# ── VAL-FORGE-012: GET /api/v1/plans/<id> returns github_issue_ref ───────
+async def test_api_plans_endpoint_exposes_github_issue_ref(
+    monkeypatch: pytest.MonkeyPatch,
+    isolated_workdir: Path,
+    fake_claude: Path,
+    database_url: str,
+    db_pool: asyncpg.Pool,
+    gh_recorder,
+) -> None:
+    """``GET /api/v1/plans/<id>`` returns 200 with ``github_issue_ref``.
+
+    Seeds the plan via the intake CLI, then opens a TestClient against
+    a fresh ``create_app`` (sharing the test pool) and asserts the
+    response shape.
+    """
+    monkeypatch.setattr(shutil, "which", lambda *_args, **_kwargs: "/usr/local/bin/gh")
+    monkeypatch.setenv("WHILLY_WORKER_BOOTSTRAP_TOKEN", "test-bootstrap-token")
+    import json as _json
+
+    gh_recorder.queue(_completed(stdout=_json.dumps(_canned_issue_payload(127))))
+    gh_recorder.queue(_completed(stdout="https://github.com/example/repo/issues/127"))
+
+    rc = await _run_intake(["owner/repo/127"])
+    assert rc == forge_intake.EXIT_OK
+
+    # Identify the plan id slug.
+    slug = forge_intake._slug_for_issue("owner", "repo", 127)
+
+    app: FastAPI = create_app(
+        db_pool,
+        worker_token="test-worker-token",
+        bootstrap_token="test-bootstrap-token",
+        sweep_interval_seconds=60.0,
+        offline_worker_sweep_interval_seconds=60.0,
+    )
+    async with app.router.lifespan_context(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get(f"/api/v1/plans/{slug}")
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["id"] == slug
+            assert body["github_issue_ref"] == "owner/repo/127"
+
+            # VAL-FORGE-012 regression: pre-existing plans (no ref) get NULL.
+            async with db_pool.acquire() as conn:
+                await conn.execute(
+                    "INSERT INTO plans (id, name) VALUES ($1, $2)",
+                    "plain-plan",
+                    "Plain Plan",
+                )
+            plain = await client.get("/api/v1/plans/plain-plan")
+            assert plain.status_code == 200
+            assert plain.json()["github_issue_ref"] is None
+
+            # 404 for missing plan id.
+            missing = await client.get("/api/v1/plans/does-not-exist")
+            assert missing.status_code == 404

--- a/whilly/adapters/db/migrations/versions/006_plan_github_ref.py
+++ b/whilly/adapters/db/migrations/versions/006_plan_github_ref.py
@@ -1,0 +1,137 @@
+"""Add ``plans.github_issue_ref`` for Forge intake (TASK-108a).
+
+This migration is the data-layer prerequisite for the *Forge intake*
+stage introduced by TASK-108a. A single coupled change is made:
+
+1. **Add ``plans.github_issue_ref text NULL``** — the canonical
+   ``"owner/repo/<number>"`` triple captured by ``whilly forge
+   intake`` so the plan row carries a verifiable back-reference to
+   the GitHub Issue it was generated from. ``NULL`` is the documented
+   "no GitHub origin" value (every plan created before this migration
+   carries ``NULL`` and remains readable through the same code paths;
+   plans created via ``whilly init`` keep ``NULL`` because they have
+   no GitHub anchor).
+
+   The column is **nullable** so the migration applies cleanly to
+   pre-006 databases without backfilling stale plans (VAL-FORGE-001 /
+   VAL-FORGE-002 — pre-existing rows show ``github_issue_ref IS
+   NULL``). Forge intake's idempotency contract relies on the column
+   *also* being unique on its non-NULL slice — we install a partial
+   UNIQUE index with the same shape as
+   ``ix_workers_token_hash_unique`` (migration 004): re-running
+   ``whilly forge intake owner/repo/123`` MUST not create a second
+   row for the same canonical triple (VAL-FORGE-007 / VAL-FORGE-019).
+   The partial form (``WHERE github_issue_ref IS NOT NULL``) is
+   essential — Postgres treats NULLs as distinct in a regular UNIQUE
+   index, so a full UNIQUE on a nullable column would also satisfy
+   "many rows with NULL", but the partial form documents the intent
+   loudly and keeps the index footprint to plans that *have* an
+   origin issue.
+
+   ``text`` (over a fixed-width type) accepts arbitrary
+   ``owner/repo/<number>`` strings — the longest realistic
+   ``owner/repo`` is bounded by GitHub's own 39+100 char limits, but
+   pinning that at the column level would create a footgun if we
+   ever extend Forge to other forges (GitLab, Gitea) sharing the
+   same column.
+
+Migration numbering
+-------------------
+This migration is **006** because TASK-102 shipped
+``005_plan_budget.py`` immediately before this one
+(``down_revision = "005_plan_budget"``). The validation contract
+text predates the rebase and refers to the migration as ``005`` — the
+numbering shifted at mission-coordination time (see
+``AGENTS.md → Migration Coordination``). The schema delta the contract
+asserts is unchanged; only the file name moved.
+
+Reversibility
+-------------
+``downgrade()`` reverses both changes in inverse order:
+
+1. Drop the partial UNIQUE index ``ix_plans_github_issue_ref_unique``.
+2. Drop the column ``plans.github_issue_ref``.
+
+After ``downgrade -1`` the ``alembic_version`` row points at
+``005_plan_budget`` and the schema is byte-equal to the pre-006
+layout — pinned by VAL-FORGE-002 / VAL-FORGE-020.
+
+Revision ID: 006_plan_github_ref
+Revises: 005_plan_budget
+Create Date: 2026-04-30
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "006_plan_github_ref"
+down_revision: str | None = "005_plan_budget"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+# Index name — exported as a module-level constant so tests can assert on
+# it via ``information_schema.indexes`` / ``pg_indexes`` introspection
+# without duplicating the literal at the call site (a typo would make
+# the test pass against the wrong index).
+GITHUB_ISSUE_REF_UNIQUE_INDEX: str = "ix_plans_github_issue_ref_unique"
+
+
+def upgrade() -> None:
+    """Add ``plans.github_issue_ref text NULL`` and the partial UNIQUE index.
+
+    Order matters: the column add happens first so the index creation
+    observes the post-DDL column. Both DDL statements run in the same
+    alembic-managed transaction (Postgres supports transactional DDL),
+    so a mid-migration crash leaves the schema untouched at revision
+    005.
+    """
+    # Step 1 — add the column. NULL is the documented "no GitHub
+    # origin" value; ``server_default=None`` keeps the column free of
+    # an INSERT-time default so callers must opt in by passing the
+    # canonical ``owner/repo/<number>`` triple explicitly (VAL-FORGE-004).
+    op.add_column(
+        "plans",
+        sa.Column(
+            "github_issue_ref",
+            sa.Text(),
+            nullable=True,
+            server_default=None,
+        ),
+    )
+
+    # Step 2 — partial UNIQUE on the non-NULL slice. The index pins
+    # the idempotency contract at the schema level (VAL-FORGE-007 /
+    # VAL-FORGE-019): two concurrent ``whilly forge intake
+    # owner/repo/123`` invocations either both insert the same row
+    # (one wins, the loser hits ON CONFLICT DO NOTHING and reads back
+    # the existing plan) or one wins and the other catches a
+    # ``UniqueViolationError`` that the application code translates
+    # into "return existing plan id". Either way: exactly one
+    # ``plans`` row per canonical issue ref.
+    op.create_index(
+        GITHUB_ISSUE_REF_UNIQUE_INDEX,
+        "plans",
+        ["github_issue_ref"],
+        unique=True,
+        postgresql_where="github_issue_ref IS NOT NULL",
+    )
+
+
+def downgrade() -> None:
+    """Reverse the upgrade: drop the index, then the column.
+
+    Strict reversibility (VAL-FORGE-002 / VAL-FORGE-020): after
+    ``downgrade -1``, the schema is byte-equal to revision 005 — the
+    column and the partial UNIQUE index are both gone. Index drops
+    *before* the column so Postgres doesn't refuse on a "constraint
+    references this column" error (the partial UNIQUE is implemented
+    as an index, not a TABLE constraint, but ordering it this way
+    keeps the diff readable in either direction).
+    """
+    op.drop_index(GITHUB_ISSUE_REF_UNIQUE_INDEX, table_name="plans")
+    op.drop_column("plans", "github_issue_ref")

--- a/whilly/adapters/db/schema.sql
+++ b/whilly/adapters/db/schema.sql
@@ -63,8 +63,26 @@ CREATE TABLE plans (
     -- a CHECK constraint (see migration 005's docstring).
     budget_usd NUMERIC(10, 4),
     spent_usd  NUMERIC(10, 4) NOT NULL DEFAULT 0,
+    -- Forge intake back-reference (TASK-108a, migration 006). NULL
+    -- for plans not generated from a GitHub issue (e.g. plans created
+    -- via ``whilly init``); for Forge-originated plans, the canonical
+    -- ``owner/repo/<number>`` triple captured by ``whilly forge
+    -- intake``. The partial UNIQUE index below pins the idempotency
+    -- contract — exactly one plan row per canonical issue ref
+    -- (VAL-FORGE-007 / VAL-FORGE-019).
+    github_issue_ref TEXT,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
+
+-- Partial UNIQUE on Forge-originated plans (TASK-108a, migration
+-- 006). Re-running ``whilly forge intake owner/repo/<N>`` MUST NOT
+-- create a duplicate plan row for the same issue. The partial form
+-- (``WHERE github_issue_ref IS NOT NULL``) excludes plans without a
+-- GitHub origin so they don't all collide on a single NULL pseudo-
+-- value (Postgres treats NULLs as distinct in a regular UNIQUE
+-- index, but the partial predicate makes the intent obvious).
+CREATE UNIQUE INDEX ix_plans_github_issue_ref_unique ON plans (github_issue_ref)
+    WHERE github_issue_ref IS NOT NULL;
 
 -- ─── tasks ───────────────────────────────────────────────────────────────
 CREATE TABLE tasks (

--- a/whilly/adapters/transport/server.py
+++ b/whilly/adapters/transport/server.py
@@ -1329,6 +1329,48 @@ def create_app(
         )
         return ReleaseResponse(task=TaskPayload.from_task(updated))
 
+    @app.get(
+        "/api/v1/plans/{plan_id}",
+        # Public read-only surface — no auth dependency. Operators
+        # can curl this from a dashboard / kubectl describe plan
+        # without minting a worker token, and the response carries
+        # only metadata that is already visible via ``whilly plan
+        # show``. If we later add per-tenant scoping the auth dep
+        # slots in here without touching the response shape.
+    )
+    async def get_plan(plan_id: str) -> JSONResponse:
+        """Return ``{id, name, github_issue_ref}`` for a single plan (VAL-FORGE-012).
+
+        404 if the plan does not exist. The ``github_issue_ref`` field
+        is ``null`` for plans created via ``whilly init`` (no GitHub
+        anchor) and the canonical ``owner/repo/<number>`` triple for
+        plans created via ``whilly forge intake``.
+
+        Why a single endpoint and not a list / collection surface?
+            VAL-FORGE-012 only pins single-row lookups by id; a
+            collection endpoint (``GET /api/v1/plans``) would expand
+            the auth surface (operator listing across tenants)
+            without serving any current contract. Keep the surface
+            minimal.
+        """
+        async with pool.acquire() as conn:
+            row = await conn.fetchrow(
+                "SELECT id, name, github_issue_ref FROM plans WHERE id = $1",
+                plan_id,
+            )
+        if row is None:
+            return JSONResponse(
+                {"error": "not_found", "detail": f"plan {plan_id!r} not found"},
+                status_code=status.HTTP_404_NOT_FOUND,
+            )
+        return JSONResponse(
+            {
+                "id": row["id"],
+                "name": row["name"],
+                "github_issue_ref": row["github_issue_ref"],
+            }
+        )
+
     return app
 
 

--- a/whilly/cli/__init__.py
+++ b/whilly/cli/__init__.py
@@ -9,6 +9,7 @@ Routes the first positional token to the matching v4 sub-CLI:
 * ``whilly dashboard ...`` → :mod:`whilly.cli.dashboard`
 * ``whilly init ...``      → :mod:`whilly.cli.init`
 * ``whilly worker ...``    → :mod:`whilly.cli.worker`
+* ``whilly forge ...``     → :mod:`whilly.forge`
 
 Every sub-CLI is imported lazily so that ``whilly --help`` (and any other
 non-database invocation) does not pull in :mod:`asyncpg`, the dashboard's
@@ -42,6 +43,7 @@ Commands:
   init        Interactive PRD wizard → plan import.
   worker      Run a remote worker against a control-plane URL.
               `whilly worker register` mints a per-worker bearer token.
+  forge       GitHub Issue → Whilly plan pipeline (`forge intake`).
 
 Run `whilly <command> --help` for command-specific options.
 """
@@ -95,6 +97,12 @@ def main(argv: list[str] | None = None) -> int:
         from whilly.cli.init import run_init_command
 
         return run_init_command(rest)
+    if cmd == "forge":
+        # Lazy import keeps ``whilly --help`` fast — the forge package
+        # transitively imports asyncpg + the PRD generator stack.
+        from whilly.forge.intake import run_forge_command
+
+        return run_forge_command(rest)
     if cmd == "worker":
         # Sub-dispatch ``whilly worker register ...`` to the registration
         # one-shot before falling through to the main loop entry point —

--- a/whilly/forge/__init__.py
+++ b/whilly/forge/__init__.py
@@ -1,0 +1,27 @@
+"""Forge — GitHub Issue → PR autonomous pipeline (TASK-108a).
+
+Stage 1 (this package, TASK-108a): **intake** — fetch a GitHub Issue
+via the ``gh`` CLI, normalise it into a Whilly plan in Postgres, flip
+the issue label from ``whilly-pending`` to ``whilly-in-progress``.
+
+Stage 2 (TASK-108b, future): **compose** — once the plan's tasks all
+land DONE, aggregate the results, open a PR, flip the label to
+``whilly-in-review``.
+
+Public surface
+--------------
+The intake CLI is exposed via ``whilly forge intake owner/repo/<N>``.
+The Python entry point :func:`whilly.forge.intake.run_forge_intake_command`
+is what :mod:`whilly.cli` dispatches to.
+
+Why a sub-package and not a single module?
+    Forge has two stages with separate concerns and separate test
+    surfaces. Putting them in their own package keeps each module
+    short and lets future stages grow without bloating a single file.
+"""
+
+from __future__ import annotations
+
+from whilly.forge.intake import run_forge_intake_command
+
+__all__ = ["run_forge_intake_command"]

--- a/whilly/forge/_gh.py
+++ b/whilly/forge/_gh.py
@@ -1,0 +1,237 @@
+"""``gh`` CLI shellouts for :mod:`whilly.forge.intake` (TASK-108a).
+
+Tiny wrapper module that owns every ``subprocess.run`` against the
+``gh`` CLI: fetching an issue payload (``gh issue view``) and flipping
+labels (``gh issue edit``). Pulled out of :mod:`whilly.forge.intake`
+so unit tests can monkeypatch ``_run_gh`` in one place and so the
+intake pipeline reads as plain orchestration without subprocess
+plumbing.
+
+Auth resolution
+---------------
+Always invokes ``gh`` with ``env=gh_subprocess_env()`` (per the
+mission's hard-rule in ``AGENTS.md`` — no ``os.environ`` blind
+inheritance). The helper in :mod:`whilly.gh_utils` decides which
+``GITHUB_TOKEN`` / ``GH_TOKEN`` value to expose to the subprocess.
+
+JSON field set
+--------------
+``gh issue view`` is invoked with a *pinned* ``--json`` field set
+(``number,title,body,labels,comments,state,url``) so the test fixture
+and the production caller stay in sync — bumping the field set must
+update both the constant here and the stub.
+
+Error shape
+-----------
+Two named exceptions surface to the intake pipeline:
+
+* :class:`GHIssueNotFoundError` — ``gh`` returned exit 1 with a
+  ``"GraphQL: Could not resolve"`` (or ``"Could not find"``) signature
+  in stderr. The intake pipeline maps this to ``EXIT_USER_ERROR``
+  (VAL-FORGE-009).
+* :class:`GHCLIError` — any other non-zero exit, including network
+  / transport errors (``"could not connect to api.github.com"``).
+  The intake pipeline surfaces it on stderr verbatim and exits
+  non-zero without writing a plan (VAL-FORGE-010).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+import subprocess
+from typing import Any, Final
+
+from whilly.gh_utils import gh_subprocess_env
+
+logger = logging.getLogger(__name__)
+
+
+#: Pinned ``--json`` field set for ``gh issue view`` (VAL-FORGE-003).
+#: Tests assert this exact comma-separated string is passed; production
+#: callers and the fake_gh.sh stub must keep this set in lockstep.
+GH_ISSUE_VIEW_JSON_FIELDS: Final[str] = "number,title,body,labels,comments,state,url"
+
+#: Default subprocess timeout for any ``gh`` invocation. 30 s is well
+#: above the typical ``gh issue view`` round-trip (sub-second on a
+#: warm token) and gives the CLI room for one full retry on a cold
+#: connection without the orchestration loop noticing.
+DEFAULT_GH_TIMEOUT_SECONDS: Final[float] = 30.0
+
+
+class GHCLIError(RuntimeError):
+    """``gh`` invocation failed (non-zero exit) for any reason.
+
+    ``returncode`` and ``stderr`` are preserved so the caller can
+    distinguish transient errors (network, rate-limit) from permanent
+    ones (404, malformed args).
+    """
+
+    def __init__(self, message: str, *, returncode: int, stderr: str) -> None:
+        super().__init__(message)
+        self.returncode = returncode
+        self.stderr = stderr
+
+
+class GHIssueNotFoundError(GHCLIError):
+    """``gh issue view`` reported the issue does not exist (404 / GraphQL miss).
+
+    Distinct from :class:`GHCLIError` so the intake pipeline can map it
+    to ``EXIT_USER_ERROR`` (1) and print a friendly "issue not found"
+    message instead of dumping ``gh``'s GraphQL error verbatim.
+    """
+
+
+class GHCLIMissingError(RuntimeError):
+    """``gh`` is not on the operator's ``PATH`` (VAL-FORGE-008)."""
+
+
+def _run_gh(
+    args: list[str],
+    *,
+    timeout: float = DEFAULT_GH_TIMEOUT_SECONDS,
+) -> subprocess.CompletedProcess[str]:
+    """Run ``gh <args>`` with the resolved subprocess env, capture stdout/stderr.
+
+    Single-source-of-truth for every ``gh`` invocation in this module:
+    keeps the ``env=gh_subprocess_env()`` discipline centralised so a
+    future caller can't accidentally bypass auth resolution by reaching
+    around the helper.
+
+    Tests monkeypatch this function directly (``forge._gh._run_gh``) to
+    return a canned :class:`subprocess.CompletedProcess`. The
+    ``shutil.which("gh")`` precondition check sits here too so a
+    monkeypatched ``shutil.which`` returning ``None`` exercises the
+    "gh CLI absent" path without needing a separate seam.
+
+    Raises:
+        GHCLIMissingError: ``gh`` is not on PATH.
+    """
+    gh_path = shutil.which("gh")
+    if gh_path is None:
+        raise GHCLIMissingError(
+            "gh CLI is not on PATH; install it via `brew install gh` or see "
+            "https://cli.github.com for platform-specific install instructions."
+        )
+    cmd = [gh_path, *args]
+    env = gh_subprocess_env()
+    logger.debug("forge._gh: running %s", cmd)
+    return subprocess.run(  # noqa: S603 — args are constants + validated owner/repo/N
+        cmd,
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def fetch_issue(owner: str, repo: str, number: int) -> dict[str, Any]:
+    """Return the JSON payload for ``owner/repo/<number>`` via ``gh issue view``.
+
+    Calls ``gh issue view <number> --repo <owner>/<repo> --json
+    <fields>`` exactly once with the pinned :data:`GH_ISSUE_VIEW_JSON_FIELDS`.
+    Returns the parsed JSON body.
+
+    Raises:
+        GHIssueNotFoundError: ``gh`` exited 1 with a "could not resolve"
+            stderr signature.
+        GHCLIError: any other non-zero exit (network errors, auth
+            failures, malformed args).
+        GHCLIMissingError: ``gh`` is not on PATH.
+    """
+    args = [
+        "issue",
+        "view",
+        str(number),
+        "--repo",
+        f"{owner}/{repo}",
+        "--json",
+        GH_ISSUE_VIEW_JSON_FIELDS,
+    ]
+    result = _run_gh(args)
+    if result.returncode != 0:
+        stderr = result.stderr or ""
+        # GitHub's GraphQL API returns "Could not resolve to an Issue"
+        # (current text) or "Could not find" (older variant) on a
+        # missing issue / wrong number. Match both — case-insensitive
+        # so a future GH CLI rewrite of the message doesn't silently
+        # demote a 404 to a generic CLI error.
+        lowered = stderr.lower()
+        if result.returncode == 1 and ("could not resolve" in lowered or "could not find" in lowered):
+            raise GHIssueNotFoundError(
+                f"GitHub issue {owner}/{repo}#{number} not found",
+                returncode=result.returncode,
+                stderr=stderr,
+            )
+        raise GHCLIError(
+            f"gh issue view failed (exit={result.returncode}): {stderr.strip() or '<no stderr>'}",
+            returncode=result.returncode,
+            stderr=stderr,
+        )
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise GHCLIError(
+            f"gh issue view returned invalid JSON: {exc}",
+            returncode=0,
+            stderr=result.stderr,
+        ) from exc
+    if not isinstance(payload, dict):
+        raise GHCLIError(
+            f"gh issue view returned non-object JSON: {type(payload).__name__}",
+            returncode=0,
+            stderr=result.stderr,
+        )
+    return payload
+
+
+def flip_label(
+    owner: str,
+    repo: str,
+    number: int,
+    *,
+    add: str,
+    remove: str,
+) -> None:
+    """Run ``gh issue edit <N> --repo X/Y --add-label A --remove-label B``.
+
+    Single combined invocation per VAL-FORGE-006: both flags on the same
+    ``gh`` call so the label transition is atomic from GitHub's
+    perspective. Order of the flags isn't pinned; the test asserts
+    *both* labels are present and the labels are exact literals.
+
+    Raises:
+        GHCLIError: ``gh`` exited non-zero. Caller decides whether to
+            surface as a hard failure.
+    """
+    args = [
+        "issue",
+        "edit",
+        str(number),
+        "--repo",
+        f"{owner}/{repo}",
+        "--remove-label",
+        remove,
+        "--add-label",
+        add,
+    ]
+    result = _run_gh(args)
+    if result.returncode != 0:
+        raise GHCLIError(
+            f"gh issue edit failed (exit={result.returncode}): {(result.stderr or '').strip() or '<no stderr>'}",
+            returncode=result.returncode,
+            stderr=result.stderr or "",
+        )
+
+
+__all__ = [
+    "DEFAULT_GH_TIMEOUT_SECONDS",
+    "GHCLIError",
+    "GHCLIMissingError",
+    "GHIssueNotFoundError",
+    "GH_ISSUE_VIEW_JSON_FIELDS",
+    "fetch_issue",
+    "flip_label",
+]

--- a/whilly/forge/intake.py
+++ b/whilly/forge/intake.py
@@ -1,0 +1,608 @@
+"""``whilly forge intake`` — GitHub Issue → Whilly plan in Postgres (TASK-108a).
+
+Stage 1 of the Forge pipeline. Takes a canonical ``owner/repo/<number>``
+triple, fetches the GitHub Issue via ``gh issue view``, normalises the
+title + body + comments into a free-form description, runs it through
+the existing PRD pipeline (``prd_generator.generate_prd`` +
+``generate_tasks_dict``), inserts the resulting plan into Postgres
+with ``plans.github_issue_ref = <triple>``, and flips the issue label
+from ``whilly-pending`` to ``whilly-in-progress``.
+
+Idempotency
+-----------
+A partial UNIQUE index on ``plans.github_issue_ref`` (migration 006)
+plus an early ``SELECT id FROM plans WHERE github_issue_ref = $1``
+ensures re-running ``whilly forge intake owner/repo/123`` against the
+same DB:
+
+* Returns the existing ``plan_id`` on stdout and exits 0.
+* Does **not** call ``gh issue edit`` a second time (VAL-FORGE-007).
+* Does **not** invoke the PRD pipeline (no Claude tokens burned).
+
+Concurrent runs (VAL-FORGE-019) are pinned by the partial UNIQUE: the
+loser hits :class:`asyncpg.UniqueViolationError` on INSERT and the
+intake pipeline reads back the existing row, exiting 0 with the same
+``plan_id`` as the winner.
+
+Atomicity across systems
+------------------------
+The label flip happens *after* the DB insert succeeds (VAL-FORGE-018):
+if any earlier step raises, no plan row is written and no label
+transition is performed. The reverse — label flipped but no plan
+inserted — is impossible because the label call is the last step.
+
+Error paths
+-----------
+* ``gh`` not on PATH → exit 2 (``EXIT_ENVIRONMENT_ERROR``) with a
+  hint to install (VAL-FORGE-008).
+* Issue not found → exit 1 (``EXIT_USER_ERROR``) with a friendly
+  "issue not found" message (VAL-FORGE-009).
+* Network / transport error → exit 1 with the underlying ``gh``
+  stderr (VAL-FORGE-010).
+* Malformed ``owner/repo/<N>`` argument → exit 1 *without* invoking
+  ``gh`` at all (VAL-FORGE-017).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+import re
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any, Final
+
+import asyncpg
+
+from whilly.adapters.db import close_pool, create_pool
+from whilly.adapters.filesystem.plan_io import PlanParseError, parse_plan_dict
+from whilly.cli.plan import _insert_plan_and_tasks
+from whilly.forge._gh import (
+    GHCLIError,
+    GHCLIMissingError,
+    GHIssueNotFoundError,
+    fetch_issue,
+    flip_label,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ── Exit codes ───────────────────────────────────────────────────────────
+# Mirror the cli/run.py and cli/init.py constants so a shell script can
+# branch on them uniformly across the CLI surface.
+EXIT_OK: Final[int] = 0
+EXIT_USER_ERROR: Final[int] = 1
+EXIT_ENVIRONMENT_ERROR: Final[int] = 2
+EXIT_INTERRUPTED: Final[int] = 130
+
+
+# ── Env vars ─────────────────────────────────────────────────────────────
+DATABASE_URL_ENV: Final[str] = "WHILLY_DATABASE_URL"
+
+
+# ── Label literals ───────────────────────────────────────────────────────
+#: GitHub label that an operator applies to an issue to mark it as
+#: ready for Forge intake. Forge expects this label as the *source*
+#: state of the transition.
+LABEL_PENDING: Final[str] = "whilly-pending"
+
+#: GitHub label that Forge applies after a successful intake. Stays
+#: on the issue until TASK-108b's Stage 2 flips it again
+#: (``whilly-in-review``) on PR open.
+LABEL_IN_PROGRESS: Final[str] = "whilly-in-progress"
+
+
+# ── Issue-ref parsing ────────────────────────────────────────────────────
+#: Strict ``owner/repo/<positive integer>`` shape (VAL-FORGE-017). The
+#: ``<owner>``/``<repo>`` segments are intentionally lax (any non-slash
+#: character) to keep the CLI compatible with GitHub's own naming
+#: rules without re-encoding them here; the issue *number* is pinned
+#: as ``\d+`` so non-numeric input is rejected early.
+_ISSUE_REF_RE: re.Pattern[str] = re.compile(r"^([^/]+)/([^/]+)/(\d+)$")
+
+
+def _parse_issue_ref(raw: str) -> tuple[str, str, int]:
+    """Validate ``owner/repo/<number>`` and return ``(owner, repo, number)``.
+
+    Raises :class:`ValueError` with a message naming the expected shape
+    when ``raw`` doesn't match :data:`_ISSUE_REF_RE`. The CLI maps the
+    error to ``EXIT_USER_ERROR`` *before* invoking ``gh`` at all
+    (VAL-FORGE-017 — zero ``subprocess.run`` calls on malformed input).
+    """
+    match = _ISSUE_REF_RE.fullmatch(raw)
+    if match is None:
+        raise ValueError(
+            f"issue ref {raw!r} does not match the expected shape "
+            f"`owner/repo/<number>` (e.g. mshegolev/whilly-orchestrator/123)"
+        )
+    owner, repo, number_str = match.group(1), match.group(2), match.group(3)
+    if not owner or not repo:
+        raise ValueError(f"issue ref {raw!r} has empty owner or repo segment; expected `owner/repo/<number>`")
+    return owner, repo, int(number_str)
+
+
+# ── Issue → idea string (free-form text fed to PRD generator) ────────────
+def _issue_to_description(issue: dict[str, Any]) -> str:
+    """Synthesise the PRD-generator prompt from a fetched issue payload.
+
+    Concatenates the title, body, and the (chronological) comment
+    bodies into a single string. The PRD generator treats the whole
+    blob as the operator's free-form idea text — no structural
+    parsing is required because the PRD wizard's system prompt is
+    the actual prompt; this is just the "describe what you want"
+    half.
+
+    Args:
+        issue: ``dict`` returned by ``gh issue view ... --json``. Must
+            have at least a ``title`` (str) key; ``body`` and
+            ``comments`` are optional.
+    """
+    parts: list[str] = []
+    title = issue.get("title")
+    if isinstance(title, str) and title.strip():
+        parts.append(f"# {title.strip()}")
+    body = issue.get("body")
+    if isinstance(body, str) and body.strip():
+        parts.append(body.strip())
+    comments = issue.get("comments") or []
+    if isinstance(comments, list) and comments:
+        rendered_comments: list[str] = []
+        for idx, comment in enumerate(comments, start=1):
+            if not isinstance(comment, dict):
+                continue
+            comment_body = comment.get("body")
+            if isinstance(comment_body, str) and comment_body.strip():
+                rendered_comments.append(f"### Comment {idx}\n{comment_body.strip()}")
+        if rendered_comments:
+            parts.append("## Discussion\n\n" + "\n\n".join(rendered_comments))
+    return "\n\n".join(parts) or "(empty issue)"
+
+
+def _slug_for_issue(owner: str, repo: str, number: int) -> str:
+    """Deterministic plan slug derived from the issue ref.
+
+    The plan_id is also the PRD filename stem (``docs/PRD-<slug>.md``)
+    and the FK target for ``tasks.plan_id``. The chosen shape
+    ``issue-<owner>-<repo>-<N>`` is collision-free across owners and
+    repos — re-running the same intake hits the same slug, which is
+    what ``ON CONFLICT (id) DO NOTHING`` plus the partial UNIQUE on
+    ``github_issue_ref`` use to enforce idempotency.
+
+    Slugs are sanitised to ``[a-z0-9-]+`` so they round-trip cleanly
+    through filesystem paths and Postgres ``text`` columns.
+    """
+    raw = f"issue-{owner}-{repo}-{number}".lower()
+    cleaned = re.sub(r"[^a-z0-9]+", "-", raw).strip("-")
+    return cleaned or f"issue-{number}"
+
+
+# ── Async DB helpers ─────────────────────────────────────────────────────
+_SELECT_PLAN_BY_REF_SQL: Final[str] = """
+SELECT id FROM plans WHERE github_issue_ref = $1
+"""
+
+
+_INSERT_PLAN_WITH_GH_REF_SQL: Final[str] = """
+INSERT INTO plans (id, name, github_issue_ref)
+VALUES ($1, $2, $3)
+ON CONFLICT (id) DO NOTHING
+RETURNING id
+"""
+
+
+async def _existing_plan_for_ref(conn: asyncpg.Connection, ref: str) -> str | None:
+    """Return the ``plans.id`` already bound to ``ref`` (or ``None``)."""
+    row = await conn.fetchrow(_SELECT_PLAN_BY_REF_SQL, ref)
+    return None if row is None else str(row["id"])
+
+
+# ── Default seams (production wiring) ────────────────────────────────────
+def _default_prd_runner(*, idea: str, slug: str, output_dir: Path, model: str) -> None:
+    """Drive ``prd_generator.generate_prd`` for the headless flow.
+
+    Mirrors :func:`whilly.cli.init._default_headless_runner` so tests
+    reach for the same surface. Imported lazily so ``whilly forge
+    intake --help`` doesn't pull in the prd_generator (which transitively
+    pulls in the runner proxy and asyncpg).
+    """
+    from whilly.prd_generator import generate_prd
+
+    generate_prd(description=idea, output_dir=str(output_dir), model=model, slug=slug)
+
+
+def _default_tasks_builder(*, prd_path: Path, plan_id: str, model: str) -> dict[str, Any]:
+    """Drive ``prd_generator.generate_tasks_dict``."""
+    from whilly.prd_generator import generate_tasks_dict
+
+    return generate_tasks_dict(prd_path=prd_path, plan_id=plan_id, model=model)
+
+
+# ── Argparse ─────────────────────────────────────────────────────────────
+def _build_parser() -> argparse.ArgumentParser:
+    """Argparse layout for ``whilly forge intake``. Pulled out for testing.
+
+    The help text is deliberately rich (VAL-FORGE-016): operators read
+    ``whilly forge intake --help`` to learn the issue-ref shape and the
+    label transition contract without grepping the source.
+    """
+    parser = argparse.ArgumentParser(
+        prog="whilly forge intake",
+        description=(
+            "Forge intake stage — fetch a GitHub Issue, normalise it into "
+            "a Whilly plan in Postgres, and flip the issue label "
+            "`whilly-pending` -> `whilly-in-progress`. Requires the `gh` "
+            "CLI on PATH (`brew install gh` or https://cli.github.com)."
+        ),
+        epilog=(
+            "Issue ref shape: `owner/repo/<number>` (e.g. "
+            "mshegolev/whilly-orchestrator/123). The plan row carries the "
+            "canonical ref in `plans.github_issue_ref`; re-running with "
+            "the same ref returns the existing plan id without creating "
+            "a duplicate."
+        ),
+    )
+    parser.add_argument(
+        "issue_ref",
+        help=("GitHub issue reference in the shape `owner/repo/<number>`. Example: mshegolev/whilly-orchestrator/123."),
+    )
+    parser.add_argument(
+        "--model",
+        default="claude-opus-4-6[1m]",
+        help="Claude model name passed through to the PRD generator.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="docs",
+        help='Directory for the generated PRD file. Default: "docs".',
+    )
+    parser.add_argument(
+        "--no-label-flip",
+        action="store_true",
+        help=(
+            "Skip the `gh issue edit --remove-label whilly-pending --add-label "
+            "whilly-in-progress` step. Useful for dry-runs against issues "
+            "that don't carry the `whilly-pending` source label."
+        ),
+    )
+    return parser
+
+
+# ── Forge subcommand router ──────────────────────────────────────────────
+_FORGE_HELP: Final[str] = """\
+Whilly Forge — GitHub Issue -> Whilly plan -> PR pipeline.
+
+Usage: whilly forge <subcommand> [options]
+
+Subcommands:
+  intake     Fetch a GitHub Issue, normalise into a plan, flip label
+             `whilly-pending` -> `whilly-in-progress`. Requires `gh` CLI.
+
+Run `whilly forge intake --help` for full options.
+"""
+
+
+def run_forge_command(argv: Sequence[str]) -> int:
+    """Top-level ``whilly forge ...`` dispatcher.
+
+    Currently routes the only registered subcommand (``intake``).
+    Future stages (TASK-108b ``compose``) plug in here without
+    touching the top-level CLI.
+    """
+    args = list(argv)
+    if not args or args[0] in ("-h", "--help"):
+        sys.stdout.write(_FORGE_HELP)
+        sys.stdout.flush()
+        return EXIT_OK if args else EXIT_OK
+    sub = args[0]
+    rest = args[1:]
+    if sub == "intake":
+        return run_forge_intake_command(rest)
+    sys.stderr.write(f"whilly forge: unknown subcommand {sub!r}\n\n")
+    sys.stderr.write(_FORGE_HELP)
+    sys.stderr.flush()
+    return EXIT_USER_ERROR
+
+
+def run_forge_intake_command(
+    argv: Sequence[str],
+    *,
+    fetch_issue_runner=None,
+    prd_runner=None,
+    tasks_builder=None,
+    label_flipper=None,
+) -> int:
+    """Execute ``whilly forge intake`` with the given argv.
+
+    Args:
+        argv: Argument list (no leading "intake" subcommand token).
+        fetch_issue_runner: Test seam for :func:`whilly.forge._gh.fetch_issue`.
+        prd_runner: Test seam for :func:`_default_prd_runner` (Claude PRD).
+        tasks_builder: Test seam for :func:`_default_tasks_builder`
+            (Claude tasks JSON).
+        label_flipper: Test seam for :func:`whilly.forge._gh.flip_label`.
+
+    Returns:
+        Exit code per the module-level constants. ``EXIT_OK`` on
+        success, ``EXIT_USER_ERROR`` for input validation / 404 on
+        the issue, ``EXIT_ENVIRONMENT_ERROR`` for missing ``gh`` /
+        ``WHILLY_DATABASE_URL``.
+    """
+    parser = _build_parser()
+    try:
+        args = parser.parse_args(list(argv))
+    except SystemExit as exc:
+        # argparse's ``--help`` exits 0; bad args exit 2 inside argparse.
+        # Map 2 → user error to match the rest of the CLI.
+        if exc.code in (0, None):
+            return EXIT_OK
+        return EXIT_USER_ERROR
+
+    # ── Step 0: parse the issue ref ────────────────────────────────────
+    # VAL-FORGE-017: malformed input MUST be rejected before any
+    # ``subprocess.run`` is invoked. ``_parse_issue_ref`` is pure.
+    try:
+        owner, repo, number = _parse_issue_ref(args.issue_ref)
+    except ValueError as exc:
+        print(f"whilly forge intake: {exc}", file=sys.stderr)
+        return EXIT_USER_ERROR
+
+    canonical_ref = f"{owner}/{repo}/{number}"
+    slug = _slug_for_issue(owner, repo, number)
+
+    dsn = os.environ.get(DATABASE_URL_ENV)
+    if not dsn:
+        print(
+            f"whilly forge intake: {DATABASE_URL_ENV} is not set — point it at a "
+            "Postgres instance with the v4 schema applied (see scripts/db-up.sh).",
+            file=sys.stderr,
+        )
+        return EXIT_ENVIRONMENT_ERROR
+
+    # ── Step 1: idempotent short-circuit on existing plan ──────────────
+    # If the same ref is already in plans, return the existing id and
+    # exit without invoking ``gh`` (VAL-FORGE-007).
+    existing_id = asyncio.run(_lookup_existing_plan(dsn, canonical_ref))
+    if existing_id is not None:
+        print(
+            f"whilly forge intake: plan {existing_id!r} already exists for "
+            f"github_issue_ref={canonical_ref!r}; nothing to do."
+        )
+        return EXIT_OK
+
+    # ── Step 2: fetch the issue payload via gh ─────────────────────────
+    fetch = fetch_issue_runner or fetch_issue
+    try:
+        issue = fetch(owner, repo, number)
+    except GHCLIMissingError as exc:
+        print(f"whilly forge intake: {exc}", file=sys.stderr)
+        return EXIT_ENVIRONMENT_ERROR
+    except GHIssueNotFoundError as exc:
+        print(
+            f"whilly forge intake: issue not found: {canonical_ref}\n"
+            f"  (gh exit={exc.returncode}; stderr={exc.stderr.strip()!r})",
+            file=sys.stderr,
+        )
+        return EXIT_USER_ERROR
+    except GHCLIError as exc:
+        print(f"whilly forge intake: {exc}", file=sys.stderr)
+        return EXIT_USER_ERROR
+
+    # ── Step 3: normalise issue → idea text ────────────────────────────
+    description = _issue_to_description(issue)
+
+    # ── Step 4: drive PRD pipeline ─────────────────────────────────────
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    prd_path = (output_dir / f"PRD-{slug}.md").resolve()
+    prd = prd_runner or _default_prd_runner
+    builder = tasks_builder or _default_tasks_builder
+    try:
+        prd(idea=description, slug=slug, output_dir=output_dir, model=args.model)
+    except RuntimeError as exc:
+        print(
+            f"whilly forge intake: PRD generation failed: {exc}",
+            file=sys.stderr,
+        )
+        return EXIT_USER_ERROR
+    if not prd_path.exists():
+        print(
+            f"whilly forge intake: PRD generator did not write {prd_path}",
+            file=sys.stderr,
+        )
+        return EXIT_USER_ERROR
+
+    try:
+        payload = builder(prd_path=prd_path, plan_id=slug, model=args.model)
+    except RuntimeError as exc:
+        print(
+            f"whilly forge intake: task generation failed: {exc}\nPRD left at {prd_path} for inspection.",
+            file=sys.stderr,
+        )
+        return EXIT_USER_ERROR
+    except FileNotFoundError as exc:
+        print(
+            f"whilly forge intake: PRD missing: {exc}",
+            file=sys.stderr,
+        )
+        return EXIT_USER_ERROR
+
+    # ── Step 5: validate plan dict + INSERT (with github_issue_ref) ────
+    try:
+        plan, tasks = parse_plan_dict(payload, plan_id=slug)
+    except PlanParseError as exc:
+        print(
+            f"whilly forge intake: generated plan failed validation: {exc}\nPRD left at {prd_path}.",
+            file=sys.stderr,
+        )
+        return EXIT_USER_ERROR
+
+    try:
+        plan_id = asyncio.run(
+            _async_intake_insert(
+                dsn=dsn,
+                plan_id=slug,
+                plan_name=plan.name,
+                github_issue_ref=canonical_ref,
+                tasks=tasks,
+            )
+        )
+    except Exception as exc:  # noqa: BLE001 — diagnostic, not control flow
+        print(
+            f"whilly forge intake: plan import failed: {exc}",
+            file=sys.stderr,
+        )
+        return EXIT_USER_ERROR
+
+    # ── Step 6: label transition ───────────────────────────────────────
+    # Last step on purpose (VAL-FORGE-018): if anything earlier fails,
+    # we exit before the label flip and the issue stays untouched.
+    if args.no_label_flip:
+        logger.info(
+            "forge.intake: skipping label flip for %s (--no-label-flip)",
+            canonical_ref,
+        )
+    else:
+        flipper = label_flipper or flip_label
+        try:
+            flipper(
+                owner,
+                repo,
+                number,
+                add=LABEL_IN_PROGRESS,
+                remove=LABEL_PENDING,
+            )
+        except GHCLIError as exc:
+            # VAL-FORGE-013 / operator-friendliness: if ``gh issue edit``
+            # raises after the plan is already in DB, surface the
+            # warning but exit 0 — the operator can flip the label
+            # manually. The plan row is already correct.
+            print(
+                f"whilly forge intake: warning: label flip failed for "
+                f"{canonical_ref}: {exc}\n"
+                f"Plan {plan_id} was created; flip the label manually:\n"
+                f"  gh issue edit {number} --repo {owner}/{repo} "
+                f"--remove-label {LABEL_PENDING} --add-label {LABEL_IN_PROGRESS}",
+                file=sys.stderr,
+            )
+
+    print(
+        f"whilly forge intake: created plan {plan_id!r} from {canonical_ref!r} ({len(tasks)} task(s)). PRD: {prd_path}"
+    )
+    return EXIT_OK
+
+
+# ── Async insert helper ──────────────────────────────────────────────────
+async def _lookup_existing_plan(dsn: str, ref: str) -> str | None:
+    """Open a short-lived pool, return the plan id bound to ``ref`` (or None).
+
+    Idiomatic short-lived pool lifecycle (matches ``cli.plan._async_*``).
+    Returns ``None`` if the ref isn't claimed yet.
+    """
+    pool = await create_pool(dsn)
+    try:
+        async with pool.acquire() as conn:
+            return await _existing_plan_for_ref(conn, ref)
+    finally:
+        await close_pool(pool)
+
+
+async def _async_intake_insert(
+    *,
+    dsn: str,
+    plan_id: str,
+    plan_name: str,
+    github_issue_ref: str,
+    tasks: list,
+) -> str:
+    """Insert plan (with ``github_issue_ref``) + tasks atomically.
+
+    Mirrors :func:`whilly.cli.plan._async_import` but uses the new
+    ``_INSERT_PLAN_WITH_GH_REF_SQL`` for the plan row and reuses the
+    existing :func:`_insert_plan_and_tasks` helper for the per-task
+    INSERTs. Returns the persisted plan id.
+
+    Idempotency under concurrent runs (VAL-FORGE-019)
+    -------------------------------------------------
+    The partial UNIQUE on ``plans.github_issue_ref`` (migration 006)
+    lets us tolerate the race where two concurrent intake processes
+    both pass the existence check (Step 1 above) but only one wins
+    the INSERT. The loser catches :class:`asyncpg.UniqueViolationError`
+    and reads back the winner's row. Either subprocess exits 0 with
+    the same ``plan_id``.
+    """
+    pool = await create_pool(dsn)
+    try:
+        async with pool.acquire() as conn:
+            async with conn.transaction():
+                # First, attempt to insert the plan with github_issue_ref.
+                try:
+                    inserted_id = await conn.fetchval(
+                        _INSERT_PLAN_WITH_GH_REF_SQL,
+                        plan_id,
+                        plan_name,
+                        github_issue_ref,
+                    )
+                except asyncpg.UniqueViolationError:
+                    # Concurrent intake won — the partial UNIQUE on
+                    # github_issue_ref refused our duplicate. Read
+                    # back the winner's row and return early without
+                    # inserting any tasks (the winner's transaction
+                    # already inserted them, or will once it commits).
+                    inserted_id = None
+                if inserted_id is None:
+                    existing = await _existing_plan_for_ref(conn, github_issue_ref)
+                    if existing is not None:
+                        return existing
+                    # ON CONFLICT (id) — same plan_id slug but a
+                    # different github_issue_ref already claims it.
+                    # This is a slug collision (extremely unlikely
+                    # given _slug_for_issue's shape); surface as a
+                    # plain RuntimeError so the caller sees something
+                    # actionable.
+                    raise RuntimeError(
+                        f"plan id {plan_id!r} already exists with a different "
+                        f"github_issue_ref; cannot intake {github_issue_ref!r}."
+                    )
+                # Insert the tasks alongside the plan in the same
+                # transaction (matches ``whilly plan import`` shape).
+                await _insert_plan_and_tasks(conn, _PlanProxy(plan_id, plan_name), tasks)
+                return inserted_id
+    finally:
+        await close_pool(pool)
+
+
+class _PlanProxy:
+    """Tiny shim so :func:`_insert_plan_and_tasks` sees a Plan-shaped object.
+
+    ``cli.plan._insert_plan_and_tasks`` runs the plan INSERT itself —
+    we ran our own (with the github_issue_ref column) above, so we
+    just want it to skip past the plan row and insert tasks. Passing
+    a real :class:`whilly.core.models.Plan` would re-INSERT the same
+    row (harmless under ``ON CONFLICT (id) DO NOTHING``, but a wasted
+    round-trip). We keep this proxy minimal so a future refactor can
+    split ``_insert_plan_and_tasks`` into ``_insert_plan`` and
+    ``_insert_tasks``.
+    """
+
+    __slots__ = ("id", "name")
+
+    def __init__(self, plan_id: str, name: str) -> None:
+        self.id = plan_id
+        self.name = name
+
+
+__all__ = [
+    "DATABASE_URL_ENV",
+    "EXIT_ENVIRONMENT_ERROR",
+    "EXIT_INTERRUPTED",
+    "EXIT_OK",
+    "EXIT_USER_ERROR",
+    "LABEL_IN_PROGRESS",
+    "LABEL_PENDING",
+    "run_forge_command",
+    "run_forge_intake_command",
+]


### PR DESCRIPTION
## Summary

Stage 1 of the Forge pipeline: `whilly forge intake owner/repo/<N>` fetches a GitHub issue via `gh issue view`, runs it through the existing PRD + tasks builder, inserts the plan into Postgres with `plans.github_issue_ref` set to the canonical triple, and flips the issue label `whilly-pending` → `whilly-in-progress`.

## Changes

### Migration 006 — `plans.github_issue_ref`
- New `whilly/adapters/db/migrations/versions/006_plan_github_ref.py`: nullable `text` column + partial UNIQUE index (`ix_plans_github_issue_ref_unique` `WHERE github_issue_ref IS NOT NULL`).
- `whilly/adapters/db/schema.sql` documents the column + index for the offline schema reference.

### Forge package — `whilly/forge/`
- `_gh.py`: typed `gh` shellouts (`fetch_issue`, `flip_label`) with pinned `--json` field set, dedicated error classes (`GHCLIMissingError`, `GHIssueNotFoundError`, `GHCLIError`), and `gh_subprocess_env()` integration.
- `intake.py`: CLI entry (`run_forge_command` + `run_forge_intake_command`) with strict `owner/repo/<N>` regex (rejects malformed refs **before** any subprocess call — VAL-FORGE-017), idempotent short-circuit on existing ref (VAL-FORGE-007), DB INSERT with `_INSERT_PLAN_WITH_GH_REF_SQL`, and label flip as the *last* step (atomicity — VAL-FORGE-018).
- `__init__.py` re-exports the public surface.

### CLI wiring
- `whilly/cli/__init__.py` routes `forge` subcommand and updates help text.

### API
- `whilly/adapters/transport/server.py`: new `GET /api/v1/plans/{plan_id}` returning `{id, name, github_issue_ref}` (404 on missing) for the operator + Forge Stage 2 read path (VAL-FORGE-012).

### Tests
- `tests/integration/test_alembic_006.py` — 7 tests pinning the migration shape, idempotent upgrade, partial UNIQUE behavior, full round-trip.
- `tests/integration/test_alembic_full_chain.py` — 3 tests pinning the linear chain `001 → 002 → 003 → 004 → 005 → 006` and full-chain upgrade/downgrade round-trip.
- `tests/integration/test_forge_intake.py` — 15 tests covering: `--help` discoverability (VAL-FORGE-016), malformed-ref rejection without subprocess (VAL-FORGE-017), `gh` absent → exit 2 (VAL-FORGE-008), issue-not-found → exit 1 (VAL-FORGE-009), network error (VAL-FORGE-010), happy path (VAL-FORGE-003/004/006), idempotent re-run (VAL-FORGE-007), `gh_subprocess_env` plumbing (VAL-FORGE-014), PRD-failure-no-label-flip (VAL-FORGE-018), PRD existence (VAL-FORGE-011), API `github_issue_ref` exposure (VAL-FORGE-012).
- `tests/fixtures/fake_gh.sh` — `gh` CLI stub for live e2e dry-runs.
- `tests/integration/test_alembic_005.py` — adjusted to upgrade-to-005 specifically (rather than `head`) so future migrations don't perturb the 005 per-revision tests.

## Validators

```
ruff check whilly tests           → All checks passed!
ruff format --check whilly tests  → 229 files already formatted
mypy --strict whilly/core/        → Success: no issues found in 7 source files
lint-imports                       → Contracts: 1 kept, 0 broken
pytest tests/unit -q              → 608 passed in 0.86s
pytest tests/integration -q       → 264 passed, 1 skipped in 155.81s
```

## Validation contract assertions covered

VAL-FORGE-001 through VAL-FORGE-020 — see `tests/integration/test_forge_intake.py` and `tests/integration/test_alembic_006.py` for the explicit assertion-to-test mapping in the docstrings.
