### PR TITLE
chore(release): v4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,63 @@ All notable changes to Whilly Orchestrator will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] — v4.1 work in progress
+## [4.1.0] - 2026-04-30
+
+> **v4.1 cleanup release.** Builds on the v4.0 distributed orchestrator with a
+> pure Decision Gate, per-task TRIZ contradiction analyzer, per-worker bearer
+> auth, plan-level budget guard, lifespan-managed event flusher, GitHub-issue
+> Forge intake, the `whilly init` PRD pipeline port, and Claude HTTPS_PROXY
+> support. The v3.x legacy CLI (`whilly/cli_legacy.py`) is removed and the
+> `WHILLY_WORKTREE` / `WHILLY_USE_WORKSPACE` env vars are now silent no-ops.
+
+### Added
+
+- **TASK-104c — pure Decision Gate.** New `whilly/core/gates.py` keeps the
+  gate logic dependency-free. New `whilly plan apply --strict` rejects plans
+  that contain skip-flagged tasks; non-strict mode warns and continues.
+  `repo.skip_task` emits `task.skipped` events scoped to the current
+  `plan_id` so audit trails stay plan-local.
+- **TASK-104b — per-task TRIZ analyzer.** New `whilly/core/triz.py` runs a
+  TRIZ contradiction pass per task; results land in the new `events.detail
+  jsonb` column. Gated by `WHILLY_TRIZ_ENABLED`; subprocess timeout 25 s;
+  fail-open on missing/timeout/malformed JSON (a `triz.error` event with
+  `detail.reason="timeout"` is still emitted on timeout per the validation
+  contract).
+- **TASK-101 — per-worker bearer auth.** Migration `004_per_worker_bearer`
+  makes `workers.token_hash` nullable and adds a partial UNIQUE index on
+  non-NULL values. Deprecates the global `WHILLY_WORKER_TOKEN` (one-shot
+  log warning, suppress with `WHILLY_SUPPRESS_WORKER_TOKEN_WARNING=1`).
+  New `whilly worker register` CLI mints per-worker tokens; bearer-token
+  identity is now bound to the request `worker_id` (cross-worker mismatch
+  → 403). `POST /workers/register` stays bootstrap-gated by
+  `WHILLY_WORKER_BOOTSTRAP_TOKEN`.
+- **TASK-102 — plan budget guard.** Migration `005_plan_budget` adds
+  `plans.budget_usd` / `plans.spent_usd`, makes `events.plan_id NOT NULL`,
+  and relaxes `events.task_id` to nullable for plan-scoped sentinels. New
+  `whilly plan create --budget USD` flag. Atomic spend accumulator via
+  `_INCREMENT_SPEND_SQL` with `FOR UPDATE OF t SKIP LOCKED`. A
+  `plan.budget_exceeded` sentinel is emitted exactly once per crossing
+  with payload `{plan_id, budget_usd, spent_usd, crossing_task_id, reason:
+  "budget_threshold", threshold_pct: 100}`.
+- **TASK-106 — lifespan-managed event flusher.** New
+  `whilly/api/event_flusher.py` runs as a FastAPI lifespan task. Bounded
+  `asyncio.Queue`, flushes on (100 ms timer OR 500-row threshold)
+  whichever-first via an `asyncio.Event` wake. Checkpoint persistence uses
+  tempfile + `os.replace` for atomicity; SIGTERM/SIGINT trigger a graceful
+  drain.
+- **TASK-108a — GitHub-issue Forge intake.** Migrations `006_plan_github_ref`
+  (`plans.github_issue_ref text NULL` + partial UNIQUE) and
+  `007_plan_prd_file` (`plans.prd_file text NULL`). New
+  `whilly forge intake owner/repo/N` subcommand shells out to `gh` via
+  `gh_subprocess_env()`. Idempotent re-run via the partial UNIQUE; concurrent
+  intake is at-most-once `gh issue edit` via creator-vs-loser flag. A
+  `plan.created` event is emitted with payload `{github_issue_ref, name,
+  tasks_count, prd_file}`. Label transitions `whilly-pending` →
+  `whilly-in-progress`. `GET /api/v1/plans/{id}` now exposes
+  `github_issue_ref` and `prd_file`.
+- **Cross-area events.** A `task.created` event is emitted per inserted
+  task row, and a `plan.applied` event is emitted per `whilly plan apply`
+  invocation with `{tasks_count, skipped_count, warned_count, strict}`.
 
 ### Added — Claude HTTPS_PROXY support (TASK-109)
 
@@ -61,6 +117,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   keyword. Default (`None`) preserves the v3 auto-derivation path
   so the legacy `whilly --prd-wizard` flow stays unchanged.
 
+### Removed
+
+- **TASK-107 — v3 legacy CLI removed.** `whilly/cli_legacy.py` is gone, one
+  release after the v4.0 deprecation window. The `WHILLY_WORKTREE` and
+  `WHILLY_USE_WORKSPACE` env vars are now silent no-ops (kept for backward
+  compatibility with shell wrappers that set them unconditionally).
+
+### Migration chain
+
+- Final state after v4.1: `001 → 002 → 003_events_detail → 004_per_worker_bearer
+  → 005_plan_budget → 006_plan_github_ref → 007_plan_prd_file`.
+
 ### Quality
 
 - 47 new unit tests in `tests/unit/test_cli_init.py` covering FR-1..FR-8
@@ -73,6 +141,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 3 new integration tests in `tests/integration/test_init_e2e.py`
   driving `python -m whilly.cli init` as a subprocess against
   testcontainers Postgres + the deterministic Claude stub.
+- Suite-wide: 1530+ tests passing; `mypy --strict whilly/core/` clean;
+  `ruff check`, `ruff format --check`, and `lint-imports` all green.
+  CI parity enforced by `pip install -e '.[dev]'` at session start.
 
 ## [4.0.0] - 2026-04-29
 

--- a/PYPI_RELEASE_NOTES.md
+++ b/PYPI_RELEASE_NOTES.md
@@ -1,97 +1,134 @@
-# Whilly Orchestrator v3.1.0 - Self-Healing Release 🛡️
+# Whilly Orchestrator v4.1.0 — v4.1 Cleanup Release 🧹
 
 ## What's New
 
-**Self-Healing System** - The major new feature that makes your AI agent pipelines virtually crash-proof:
+**v4.1 builds on the v4.0 distributed orchestrator** (Postgres-backed task
+queue + FastAPI control plane + remote workers) with seven targeted
+cleanups, plus the legacy v3 CLI removal:
 
-### 🔍 Smart Error Detection
-- Automatic crash detection via traceback pattern analysis
-- Support for `NameError`, `ImportError`, `TypeError`, `AttributeError`
-- Learning from historical error patterns in logs
-- Intelligent error categorization and prioritization
+### 🧠 Pure Decision Gate (TASK-104c)
+- New `whilly/core/gates.py` — gate logic stays in the pure domain layer.
+- New `whilly plan apply --strict` rejects plans that contain skip-flagged
+  tasks; non-strict mode warns and continues.
+- `repo.skip_task` emits `task.skipped` events scoped to the current
+  `plan_id` so audit trails stay plan-local.
 
-### 🔧 Automated Fixes
-- **NameError**: Auto-detection and fixing of missing function parameters
-- **ImportError**: Automatic `pip install` for missing modules
-- **TypeError**: Diagnosis and suggestions for parameter mismatches
-- **AttributeError**: Analysis and recommendations for object issues
+### 🔬 Per-task TRIZ analyzer (TASK-104b)
+- New `whilly/core/triz.py` runs a TRIZ contradiction pass per task.
+- New `events.detail jsonb` column carries the analyzer payload.
+- Gated by `WHILLY_TRIZ_ENABLED`; subprocess timeout 25 s; fail-open on
+  missing/timeout/malformed JSON (a `triz.error` event with
+  `detail.reason="timeout"` is still emitted on timeout).
 
-### 🔄 Resilient Restart Logic  
-- Auto-restart with exponential backoff (max 3 retries)
-- Intelligent retry decision making (skip non-recoverable errors)
-- State preservation across restarts
-- Recovery suggestions for complex issues
+### 🔑 Per-worker bearer auth (TASK-101)
+- Migration `004_per_worker_bearer` — `workers.token_hash` nullable +
+  partial UNIQUE on non-NULL.
+- Global `WHILLY_WORKER_TOKEN` deprecated (one-shot warning, suppress
+  with `WHILLY_SUPPRESS_WORKER_TOKEN_WARNING=1`).
+- New `whilly worker register` CLI mints per-worker tokens.
+- Bearer-token identity now bound to the request `worker_id`
+  (cross-worker mismatch → 403). `POST /workers/register` stays
+  bootstrap-gated by `WHILLY_WORKER_BOOTSTRAP_TOKEN`.
 
-### 🛠️ New Tools & Scripts
-- `scripts/whilly_with_healing.py` - Self-healing wrapper with crash protection
-- `scripts/sync_task_status.py` - Task status synchronization utility  
-- `scripts/check_status_sync.py` - Status consistency monitoring
-- `whilly/self_healing.py` - Core healing engine
-- `whilly/recovery.py` - Status recovery and validation
+### 💸 Plan budget guard (TASK-102)
+- Migration `005_plan_budget` — `plans.budget_usd`, `plans.spent_usd`;
+  `events.plan_id NOT NULL`; `events.task_id` made nullable.
+- New `whilly plan create --budget USD` flag.
+- Atomic spend accumulator via `_INCREMENT_SPEND_SQL` with
+  `FOR UPDATE OF t SKIP LOCKED`.
+- `plan.budget_exceeded` sentinel emitted exactly once per crossing with
+  payload `{plan_id, budget_usd, spent_usd, crossing_task_id, reason:
+  "budget_threshold", threshold_pct: 100}`.
 
-### 📚 Enhanced Documentation
-- Complete Self-Healing Guide with examples
-- Architecture documentation and troubleshooting
-- Best practices and extension patterns
-- Updated README with self-healing overview
+### 🚰 Lifespan-managed event flusher (TASK-106)
+- New `whilly/api/event_flusher.py` runs as a FastAPI lifespan task.
+- Bounded `asyncio.Queue`; flushes on (100 ms timer OR 500-row threshold)
+  whichever-first via an `asyncio.Event` wake.
+- Tempfile + `os.replace` checkpoint persistence; SIGTERM/SIGINT trigger
+  a graceful drain.
 
-## Quick Start with Self-Healing
+### 🔥 Forge intake (TASK-108a)
+- Migrations `006_plan_github_ref` (`plans.github_issue_ref text NULL` +
+  partial UNIQUE) and `007_plan_prd_file` (`plans.prd_file text NULL`).
+- New `whilly forge intake owner/repo/N` shells out to `gh` via
+  `gh_subprocess_env()`.
+- Idempotent re-run via the partial UNIQUE; concurrent intake at-most-once
+  `gh issue edit` via creator-vs-loser flag.
+- `plan.created` event with payload `{github_issue_ref, name, tasks_count,
+  prd_file}`.
+- Label transition `whilly-pending` → `whilly-in-progress`.
+- `GET /api/v1/plans/{id}` exposes `github_issue_ref` + `prd_file`.
+
+### 🪝 `whilly init` PRD pipeline (TASK-104a)
+- New `whilly init "<idea>"` combines the v3 PRD-wizard flow with v4
+  Postgres-backed plan storage. Produces `docs/PRD-<slug>.md` via Claude
+  (interactive in TTY, single-shot outside) and imports the resulting
+  task plan straight into Postgres — no `tasks.json` materialised on disk.
+- Flags: `--slug`, `--interactive` / `--headless`, `--no-import`,
+  `--force`, `--model`, `--output-dir`.
+
+### 🌐 Claude HTTPS_PROXY support (TASK-109)
+- New `WHILLY_CLAUDE_PROXY_URL` env var injects `HTTPS_PROXY` + `NO_PROXY`
+  into the **spawned** Claude env only, never into Whilly's own process
+  env. New `--claude-proxy URL` and `--no-claude-proxy` flags on
+  `whilly init`. Pre-flight TCP probe surfaces "tunnel not up" sub-second
+  with an actionable hint.
+
+### 🧹 Removed (TASK-107)
+- `whilly/cli_legacy.py` removed (one release after v4.0 deprecation).
+- `WHILLY_WORKTREE` / `WHILLY_USE_WORKSPACE` env vars are silent no-ops.
+
+### 🧱 Cross-area events
+- `task.created` event per inserted task row.
+- `plan.applied` event per `whilly plan apply` invocation with payload
+  `{tasks_count, skipped_count, warned_count, strict}`.
+
+### 🗄️ Migration chain (final state)
+`001 → 002 → 003_events_detail → 004_per_worker_bearer →
+005_plan_budget → 006_plan_github_ref → 007_plan_prd_file`
+
+## Quick Start
 
 ```bash
-# Install/upgrade
-pip install --upgrade whilly-orchestrator
+# Install / upgrade (pick your shape)
+pip install --upgrade whilly-orchestrator              # base + CLI
+pip install --upgrade 'whilly-orchestrator[server]'    # control plane
+pip install --upgrade 'whilly-orchestrator[worker]'    # remote worker
+pip install --upgrade 'whilly-orchestrator[all]'       # both shapes
 
-# Standard whilly (no crash protection)  
-whilly tasks.json
+# Bootstrap + apply a plan
+whilly plan apply --strict path/to/tasks.json
 
-# Self-healing whilly (recommended)
-python -m whilly.scripts.whilly_with_healing tasks.json
+# GitHub-issue intake
+whilly forge intake owner/repo/123
+
+# PRD pipeline (TTY-aware Claude wizard)
+whilly init "your idea here"
 ```
 
-## Bug Fixes
+## Internal Quality
 
-- Fixed `NameError: name 'config' is not defined` in subprocess handling
-- Improved task status synchronization after orchestrator crashes  
-- Enhanced external task integration error handling
-- Better workspace cleanup and management
+- 1530+ tests passing.
+- `mypy --strict whilly/core/` clean.
+- `ruff check whilly tests` + `ruff format --check whilly tests` clean.
+- `lint-imports` green (`whilly.core` purity contract enforced).
+- CI parity enforced via `pip install -e '.[dev]'` at session start.
 
-## Technical Improvements
+## Migration from 4.0.x
 
-- Added comprehensive error pattern matching
-- Implemented AST-based code analysis for fixes
-- Enhanced recovery mechanisms for task status inconsistencies
-- Improved exponential backoff with intelligent categorization
+No runtime migration required beyond running `alembic upgrade head` to apply
+migrations 003 → 007. Existing v4.0 plans, workers, and events keep working.
 
-## Use Cases
+If you set `WHILLY_WORKER_TOKEN` globally, you'll see a one-shot deprecation
+warning — switch to per-worker tokens via `whilly worker register`, or
+suppress the warning with `WHILLY_SUPPRESS_WORKER_TOKEN_WARNING=1` while
+you migrate.
 
-Perfect for:
-- **Production deployments** where reliability is critical
-- **Long-running pipelines** that can't afford to fail on simple errors
-- **Unattended automation** that needs to self-recover
-- **Development workflows** where interruptions are costly
-
-## Migration from 3.0.x
-
-No breaking changes! All existing `whilly` commands work as before.
-
-To enable self-healing protection, simply wrap your calls:
-```bash
-# Before
-whilly my-tasks.json
-
-# After (with crash protection)  
-python scripts/whilly_with_healing.py my-tasks.json
-```
-
-## What's Next
-
-- SyntaxError detection and fixing (v3.2)
-- Machine learning for error prediction (v3.2)
-- Integration with monitoring systems (v3.2)
-- Semantic code analysis via LLM (v3.3+)
-
-**Make your AI agent pipelines unbreakable! 🚀**
+If you set `WHILLY_WORKTREE` or `WHILLY_USE_WORKSPACE`, those vars are now
+silent no-ops — leaving them set is harmless.
 
 ---
 
-*Whilly Orchestrator - Ralph Wiggum's smarter brother with TRIZ analysis, Decision Gates, PRD wizardry, and now self-healing superpowers!*
+*Whilly Orchestrator — Ralph Wiggum's smarter brother, now with a pure
+decision gate, TRIZ contradiction analysis, per-worker bearer auth, plan
+budget guard, lifespan-managed event flusher, and GitHub-issue Forge intake.*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "whilly-orchestrator"
-version = "4.0.0"
+version = "4.1.0"
 description = "Whilly v4.0 — distributed orchestrator with Postgres-backed task queue, FastAPI control plane, and remote workers"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/whilly/__init__.py
+++ b/whilly/__init__.py
@@ -1,3 +1,3 @@
 """Whilly v4.0 — distributed task orchestrator (Postgres + FastAPI + remote workers)."""
 
-__version__ = "4.0.0"
+__version__ = "4.1.0"

--- a/whilly_worker/pyproject.toml
+++ b/whilly_worker/pyproject.toml
@@ -29,7 +29,7 @@ build-backend = "setuptools.build_meta"
 # which install route is used.
 [project]
 name = "whilly-worker"
-version = "4.0.0"
+version = "4.1.0"
 description = "Whilly v4.0 remote-worker — meta-package that installs the minimal worker dep closure (httpx + pydantic + whilly.core + whilly.adapters.transport.client). Provides the `whilly-worker` console script via whilly-orchestrator[worker]."
 readme = "README.md"
 requires-python = ">=3.12"
@@ -49,7 +49,7 @@ classifiers = [
 # train, so a worker deploy must always match its control plane's minor
 # version. Bumped together with `whilly/__init__.py` and the parent
 # pyproject.toml in TASK-033a (v4.0.0 release).
-dependencies = ["whilly-orchestrator[worker]==4.0.0"]
+dependencies = ["whilly-orchestrator[worker]==4.1.0"]
 
 [project.urls]
 Homepage = "https://mshegolev.github.io/whilly-orchestrator/"


### PR DESCRIPTION
## chore(release): v4.1.0

Cuts the **v4.1 cleanup release** for Whilly Orchestrator. The v4.1 mission
has fully landed on `main`; this PR bumps the version, refreshes
`CHANGELOG.md` / `PYPI_RELEASE_NOTES.md`, and prepares the artifacts for the
PyPI + GitHub release.

### What's in v4.1.0

- **TASK-104c — pure Decision Gate.** New `whilly/core/gates.py`,
  `whilly plan apply --strict`, plan-scoped `task.skipped` events.
- **TASK-104b — per-task TRIZ analyzer.** New `whilly/core/triz.py`,
  `events.detail jsonb`, `WHILLY_TRIZ_ENABLED` env gate, 25 s subprocess
  timeout, fail-open on missing/timeout/malformed JSON.
- **TASK-101 — per-worker bearer auth.** Migration `004_per_worker_bearer`
  (nullable `workers.token_hash` + partial UNIQUE), `WHILLY_WORKER_TOKEN`
  deprecated, new `whilly worker register` CLI, identity bound to request
  `worker_id` (403 on cross-worker mismatch).
- **TASK-102 — plan budget guard.** Migration `005_plan_budget`
  (`plans.budget_usd` / `plans.spent_usd`; `events.plan_id NOT NULL`;
  `events.task_id` nullable), `whilly plan create --budget USD`, atomic
  spend accumulator, exactly-once `plan.budget_exceeded` sentinel.
- **TASK-106 — lifespan-managed event flusher.** New
  `whilly/api/event_flusher.py`, bounded `asyncio.Queue`, 100 ms / 500-row
  flush whichever-first, tempfile + `os.replace` checkpoint, graceful drain
  on SIGTERM/SIGINT.
- **TASK-108a — Forge intake.** Migrations `006_plan_github_ref` +
  `007_plan_prd_file`, `whilly forge intake owner/repo/N`, idempotent re-run
  via partial UNIQUE, at-most-once `gh issue edit`, `plan.created` event,
  `whilly-pending` → `whilly-in-progress` label transition.
- **TASK-107 — v3 legacy CLI removed.** `whilly/cli_legacy.py` deleted;
  `WHILLY_WORKTREE` / `WHILLY_USE_WORKSPACE` are silent no-ops.
- **Cross-area events.** `task.created` per inserted task row;
  `plan.applied` per `whilly plan apply` invocation.

### Migration chain (final)

`001 → 002 → 003_events_detail → 004_per_worker_bearer → 005_plan_budget →
006_plan_github_ref → 007_plan_prd_file`

### Files changed

- `pyproject.toml` — version `4.0.0` → `4.1.0`.
- `whilly/__init__.py` — `__version__ = "4.1.0"`.
- `whilly_worker/pyproject.toml` — version + `whilly-orchestrator[worker]==4.1.0`
  pin (kept in sync per `tests/unit/test_version_consistency.py`).
- `CHANGELOG.md` — new `## [4.1.0] - 2026-04-30` section consolidating the
  TASK-104a + TASK-109 work that previously lived under `[Unreleased]`,
  plus the seven new task summaries.
- `PYPI_RELEASE_NOTES.md` — refreshed for v4.1.0 (was v3.1.0).

### Validation

Run locally on `chore/release-v4.1.0` (Python 3.12.1):

- `pip install -e '.[dev]'` ✅
- `pytest -q` → **1544 passed, 1 skipped** ✅
- `mypy --strict whilly/core/` → no issues ✅
- `ruff check whilly tests` → all checks passed ✅
- `ruff format --check whilly tests` → 233 files already formatted ✅
- `lint-imports` → 1 contract kept, 0 broken ✅

### Post-merge plan

After this PR merges:

1. Tag `v4.1.0` on the merge commit on `main`.
2. `python3 -m build` → `dist/whilly_orchestrator-4.1.0-py3-none-any.whl`
   + `dist/whilly_orchestrator-4.1.0.tar.gz`.
3. `twine check dist/*` → `twine upload dist/*` to PyPI.
4. `gh release create v4.1.0` with the changelog `## [4.1.0]` body and the
   built artifacts attached.
