### PR TITLE
fix(ci): restore green CI on main — version drift + env contract + WUI artifacts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "whilly-orchestrator"
-version = "4.7.0+37fc1f5"
+version = "4.7.0"
 description = "Whilly v4.0 — distributed orchestrator with Postgres-backed task queue, FastAPI control plane, and remote workers"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/unit/test_runner_env.py
+++ b/tests/unit/test_runner_env.py
@@ -28,6 +28,8 @@ def test_base_runner_env_allowlist_contract_is_exact() -> None:
     assert BASE_RUNNER_ENV_ALLOWLIST == (
         "PATH",
         "HOME",
+        "USER",
+        "LOGNAME",
         "LANG",
         "LC_ALL",
         "LC_CTYPE",

--- a/whilly/__init__.py
+++ b/whilly/__init__.py
@@ -1,3 +1,3 @@
 """Whilly v4.0 — distributed task orchestrator (Postgres + FastAPI + remote workers)."""
 
-__version__ = "4.7.0-37fc1f5"
+__version__ = "4.7.0"

--- a/whilly/operator_views.py
+++ b/whilly/operator_views.py
@@ -188,6 +188,11 @@ OPERATOR_WUI_ARTIFACTS: Final[tuple[OperatorUiArtifact, ...]] = (
     OperatorUiArtifact("whilly/api/templates/index.html.j2", OperatorUiArtifactStatus.ACTIVE),
     OperatorUiArtifact("whilly/api/templates/_tasks_table.html", OperatorUiArtifactStatus.ACTIVE),
     OperatorUiArtifact("whilly/api/templates/_workers_table.html", OperatorUiArtifactStatus.ACTIVE),
+    OperatorUiArtifact("whilly/api/templates/login.html.j2", OperatorUiArtifactStatus.ACTIVE),
+    OperatorUiArtifact("whilly/api/templates/login_magic.html.j2", OperatorUiArtifactStatus.ACTIVE),
+    OperatorUiArtifact("whilly/api/templates/login_check_inbox.html.j2", OperatorUiArtifactStatus.ACTIVE),
+    OperatorUiArtifact("whilly/api/templates/login_consumed.html.j2", OperatorUiArtifactStatus.ACTIVE),
+    OperatorUiArtifact("whilly/api/templates/password_change.html.j2", OperatorUiArtifactStatus.ACTIVE),
     OperatorUiArtifact(
         "whilly/api/templates/_logs.html",
         OperatorUiArtifactStatus.ROUTEABLE_NONCANONICAL,


### PR DESCRIPTION
## Summary

Four `tests/unit/*` tests have been failing on `main` since the
[`auth-hardening-p1` merge](https://github.com/mshegolev/whilly-orchestrator/commit/de9d25b).
Diagnosed under PRD `docs/PRD-post-auth-hardening.md` §Epic A, Item 1 (task A1a).

The PRD's original A1a hypothesis — *"FastAPI RuntimeError in `build_auth_router`
that crashes `test_health_*`"* — does **not** reproduce locally
(`pytest tests/unit/test_transport_server.py` → 22 passed). The real CI
breakage is four unrelated drifts between source and contract tests.

## What broke (CI run [#26018392204](https://github.com/mshegolev/whilly-orchestrator/actions/runs/26018392204) against `4ea1957`)

| Test | Root cause | Fix |
|---|---|---|
| `test_version_consistency::test_runtime_version_is_pep440_parseable` | `whilly/__init__.py` had `__version__ = "4.7.0-37fc1f5"` (illegal `-` in PEP 440). Even with the `+37fc1f5` from [`6b83fb2`](https://github.com/mshegolev/whilly-orchestrator/commit/6b83fb2), the test splits on `.` and requires `.isdigit()` on every segment — so any local-version identifier still fails. | Drop the local segment in both `whilly/__init__.py` and `pyproject.toml`. `whilly_worker/pyproject.toml` already had clean `4.7.0`. |
| `test_version_consistency::test_version_is_synchronised_across_release_train_files` | Same drift — three files reported three different version strings. | Falls out of the above. |
| `test_runner_env::test_base_runner_env_allowlist_contract_is_exact` | `BASE_RUNNER_ENV_ALLOWLIST` in [`whilly/adapters/runner/env.py:7`](whilly/adapters/runner/env.py#L7) gained `USER` and `LOGNAME` (intentional, for git-aware coding agents) but the tripwire test was not updated. | Add `USER` + `LOGNAME` to the expected tuple in [`tests/unit/test_runner_env.py:28`](tests/unit/test_runner_env.py#L28). |
| `test_wui_contract_static::test_wui_artifacts_are_classified` | Five auth templates from Phase 1 (`login.html.j2`, `login_magic.html.j2`, `login_check_inbox.html.j2`, `login_consumed.html.j2`, `password_change.html.j2`) were not classified in [`OPERATOR_WUI_ARTIFACTS`](whilly/operator_views.py#L187). | Classify all five as `ACTIVE`. They are served by `whilly/api/auth_routes.py` and contain no `BANNED_ACTIVE_WUI_PATTERNS`. |

## Test plan

- [x] `.venv/bin/pytest tests/unit/test_version_consistency.py tests/unit/test_runner_env.py tests/unit/test_wui_contract_static.py -q` → 25 passed
- [x] `python -m ruff check whilly/ tests/` → clean
- [x] `python -m ruff format --check whilly/ tests/` → 539 files already formatted
- [ ] CI green on this branch (wait for GitHub Actions)

## Follow-up (not in this PR)

- PRD-post-auth-hardening §Epic A `A1a` / `A1b` are now stale and should
  be closed as `skipped` (defect did not reproduce; real CI breakage was
  unrelated). Recommend updating
  `.planning/post-auth-hardening-tasks.json` to add an `A0` epic for the
  four issues above (they were blockers for everything else in the plan).
- The `+37fc1f5` git-SHA build stamp pattern should probably be a
  `setuptools-scm` build hook rather than a manual edit to
  `pyproject.toml`. Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)