### PR TITLE
docs(auth): C7 — document WHILLY_DASHBOARD_TOKEN_SECRET

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -194,6 +194,20 @@ POSTGRES_PORT=5432
 WHILLY_WORKER_BOOTSTRAP_TOKEN=demo-bootstrap
 WHILLY_METRICS_TOKEN=
 
+# WHILLY_DASHBOARD_TOKEN_SECRET signs operator dashboard session tokens. When
+# unset, the control plane generates a per-process random secret on startup —
+# all issued dashboard tokens are invalidated on every restart and operators
+# get logged out. Set this in production for stable sessions across restarts
+# and for multi-replica deployments (every replica must share the same value
+# or tokens minted by one are rejected by the others). Treat the value like a
+# signing key: never commit it, never share it, rotate it by editing the env
+# and restarting the control plane.
+#
+# Generate a fresh 32-byte URL-safe secret:
+#   python -c "import secrets;print(secrets.token_urlsafe(32))"
+# WHILLY_DASHBOARD_TOKEN_SECRET=
+# WHILLY_DASHBOARD_TOKEN_TTL_SECONDS=86400   # default 24h
+
 # WHILLY_USE_CONNECT_FLOW switches the docker entrypoint's worker role from
 # the legacy bash-awk register path to the new `whilly worker connect`
 # one-shot bootstrap. Default is OFF so pre-v4.4 single-host demos remain

--- a/.planning/post-auth-hardening-tasks.json
+++ b/.planning/post-auth-hardening-tasks.json
@@ -154,14 +154,14 @@
     },
     {
       "id": "C7-document-dashboard-token-secret",
-      "status": "pending",
+      "status": "done",
       "priority": "high",
       "dependencies": [],
       "key_files": [
         ".env.example",
         "docs/Whilly-Usage.md"
       ],
-      "description": "PRD §Epic C, Item 7 — document WHILLY_DASHBOARD_TOKEN_SECRET in .env.example (with inline generator one-liner) and in docs/Whilly-Usage.md under a new 'Authentication Configuration' heading. The heading must cover: what the variable does, when to set it (production), rotation procedure (restart required), and security warning (treat as a signing key). This task has no dependency on CI state and can land in parallel with A1.",
+      "description": "DONE 2026-05-18: realised manually (no Whilly orchestrator). .env.example +12 lines (WHILLY_DASHBOARD_TOKEN_SECRET stub with inline generator, plus WHILLY_DASHBOARD_TOKEN_TTL_SECONDS hint). docs/Whilly-Usage.md +45 lines (new ## Authentication Configuration section, 325 words). Original: PRD §Epic C, Item 7 — document WHILLY_DASHBOARD_TOKEN_SECRET in .env.example (with inline generator one-liner) and in docs/Whilly-Usage.md under a new 'Authentication Configuration' heading. The heading must cover: what the variable does, when to set it (production), rotation procedure (restart required), and security warning (treat as a signing key). This task has no dependency on CI state and can land in parallel with A1.",
       "acceptance_criteria": [
         ".env.example contains WHILLY_DASHBOARD_TOKEN_SECRET with an inline generator comment: python -c \"import secrets;print(secrets.token_urlsafe(32))\"",
         "docs/Whilly-Usage.md has ≥ 150 words on the topic under 'Authentication Configuration'",

--- a/docs/Whilly-Usage.md
+++ b/docs/Whilly-Usage.md
@@ -397,6 +397,52 @@ touching code. Available placeholders match the
 :class:`whilly.core.notifications.RunCompletedEvent` fields plus
 `{completed_at_iso}`.
 
+## Authentication Configuration
+
+The Whilly control plane mints HMAC-signed session tokens for operator
+dashboard requests. The signing key comes from the
+`WHILLY_DASHBOARD_TOKEN_SECRET` environment variable.
+
+**What it does.** Every dashboard token (the bearer the WUI/TUI presents on
+HTTP requests to the control plane) is signed and verified with this secret.
+A token signed by one secret cannot be verified by a different one — so the
+secret directly controls who can log in and stay logged in.
+
+**When to set it.** Always in production, and in any multi-replica deployment.
+When the env var is unset or empty, `create_app` generates a per-process
+random secret on startup and logs a warning. That fallback is fine for local
+development (single process, restarts often) but breaks two things in prod:
+(1) every restart invalidates every active session, kicking all operators
+back to the login screen; (2) a multi-replica control plane mints tokens one
+replica cannot verify, so requests sticky-routed to a different replica
+return 401.
+
+**How to generate a fresh value.** A 32-byte URL-safe random string is
+sufficient:
+
+```bash
+python -c "import secrets;print(secrets.token_urlsafe(32))"
+```
+
+Store the output in your secret manager and inject it into the control-plane
+process environment (Kubernetes Secret, systemd `EnvironmentFile=`, Docker
+Compose `env_file:`, or your secret-of-choice).
+
+**Rotation.** Rotate by overwriting the env value and restarting the control
+plane. The restart is required — secrets are loaded once at `create_app`
+time. All existing dashboard tokens are immediately invalidated by the
+rotation; operators see a single login prompt. Pair the rotation with a
+forced re-login if your incident playbook says session compromise is
+suspected.
+
+**Security posture.** Treat `WHILLY_DASHBOARD_TOKEN_SECRET` exactly like a
+signing key: never commit it, never paste it into chat, never log it. Anyone
+who learns the value can forge dashboard tokens for any operator email
+without going through the login form. Companion knob
+`WHILLY_DASHBOARD_TOKEN_TTL_SECONDS` controls token lifetime (default 24
+hours); lowering it shortens the window of damage from a leaked token at
+the cost of more frequent re-logins.
+
 ## Operator Dashboard Parity
 
 The active browser WUI and browserless TUI expose the same canonical operator


### PR DESCRIPTION
## Summary

Closes [PRD §Epic C, Item 7](docs/PRD-post-auth-hardening.md) — operator-facing documentation for `WHILLY_DASHBOARD_TOKEN_SECRET`, the HMAC signing key for control-plane dashboard tokens.

## Changes

- **`.env.example`** (+14 lines): new `WHILLY_DASHBOARD_TOKEN_SECRET` stub between `WHILLY_METRICS_TOKEN` and the `WHILLY_USE_CONNECT_FLOW` block, with the canonical inline generator `python -c "import secrets;print(secrets.token_urlsafe(32))"` and a hint about the companion `WHILLY_DASHBOARD_TOKEN_TTL_SECONDS` knob.
- **`docs/Whilly-Usage.md`** (+46 lines): new [`## Authentication Configuration`](docs/Whilly-Usage.md) section (325 words) inserted before [`## Operator Dashboard Parity`](docs/Whilly-Usage.md). Covers:
  - What the secret does (HMAC signing for session tokens)
  - When to set it (always in prod; mandatory in multi-replica deployments — replicas without a shared secret reject each other's tokens with 401)
  - Generator one-liner in a `bash` code block
  - Rotation procedure (env edit + restart, immediate token invalidation)
  - Security posture (treat as a signing key — leak = full operator impersonation)
- **`.planning/post-auth-hardening-tasks.json`** (+2/-2): mark `C7-document-dashboard-token-secret` as `status=done`; description prefixed with realisation note.

## Why manual instead of Whilly orchestrator

We attempted to run this task through Whilly itself as a dogfood smoke test. Whilly v4 requires a Postgres-backed control plane (`WHILLY_DATABASE_URL`), so spinning it up for a single ~5-minute documentation task was uneconomic for this session. Follow-up issue tracking this friction will be filed separately.

## Test plan

Acceptance criteria from C7 verified locally:

- [x] `grep -n 'WHILLY_DASHBOARD_TOKEN_SECRET' .env.example` → matches the stub + generator line
- [x] `grep -c 'WHILLY_DASHBOARD_TOKEN_SECRET' docs/Whilly-Usage.md` → 2 (heading description + section body)
- [x] `## Authentication Configuration` section is 325 words (≥ 150 required)
- [x] Generator one-liner present in a `bash` code block in the new section
- [x] `python -m ruff check whilly/ tests/` → All checks passed

## Follow-ups (not in this PR)

- File GitHub issue: Whilly v4 lacks an in-process / no-DB mode for single-task runs, which makes dogfooding small follow-ups uneconomic.
- File GitHub issue: `CLAUDE.md` still describes the v3 in-process orchestrator (`whilly/cli.py::run_plan`); v4 architecture (Postgres + control plane + workers) is not reflected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)