### PR TITLE
feat(db): E14a — Alembic 024 user_totp_secrets table + pyotp extras

### DIFF
--- a/.planning/post-auth-hardening-tasks.json
+++ b/.planning/post-auth-hardening-tasks.json
@@ -424,7 +424,7 @@
     },
     {
       "id": "E14a-totp-migration-024",
-      "status": "pending",
+      "status": "done",
       "priority": "low",
       "dependencies": [
         "A0-ci-restoration"
@@ -433,7 +433,7 @@
         "whilly/adapters/db/migrations/versions/024_user_totp_secrets.py",
         "pyproject.toml"
       ],
-      "description": "PRD §Epic E, Item 14 (migration only) — create Alembic migration 024_user_totp_secrets.py: table user_totp_secrets (user_id FK, secret TEXT, enabled BOOL, created_at TIMESTAMPTZ). Add pyotp as an optional dependency in pyproject.toml under [project.optional-dependencies] totp group. Migration must be reversible.",
+      "description": "DONE 2026-05-18: realised as migration 024_user_totp_secrets.py — table user_totp_secrets(username TEXT PRIMARY KEY → users.username ON DELETE CASCADE, secret TEXT NOT NULL, enabled BOOLEAN NOT NULL DEFAULT FALSE, created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()). Column named `username` rather than the PRD's nominal `user_id` to match the actual users PK type (migration 020 made the PK `username TEXT`); FK with CASCADE encodes referential integrity, and PK-on-username encodes the 1:1 invariant in schema. pyotp>=2.9 added under [project.optional-dependencies] totp with explanatory comment block matching the worker/server/llmops style. Reversible (downgrade drops the table). alembic heads → 024_user_totp_secrets. Original: PRD §Epic E, Item 14 (migration only) — create Alembic migration 024_user_totp_secrets.py: table user_totp_secrets (user_id FK, secret TEXT, enabled BOOL, created_at TIMESTAMPTZ). Add pyotp as an optional dependency in pyproject.toml under [project.optional-dependencies] totp group. Migration must be reversible",
       "acceptance_criteria": [
         "Migration 024_user_totp_secrets.py exists and is importable",
         "Downgrade drops the user_totp_secrets table",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,15 @@ llmops = [
     "opentelemetry-exporter-otlp-proto-http>=1.28",
     "traceloop-sdk>=0.41",
 ]
+# Optional TOTP (RFC 6238) second-factor stack. Gated at runtime behind
+# WHILLY_TOTP_ENABLED=1 (see PRD-post-auth-hardening §Epic E, Item 14).
+# The 024 migration adds the user_totp_secrets table unconditionally so
+# the schema is portable, but the routes that import pyotp only load when
+# the flag is set — keeping pyotp optional lets a deployment that doesn't
+# use TOTP avoid the extra dependency entirely.
+totp = [
+    "pyotp>=2.9",
+]
 # Convenience: install both deployment shapes in one go (e.g. for an
 # all-in-one demo or for CI that drives both the server and a remote
 # worker through the same venv).

--- a/whilly/adapters/db/migrations/versions/024_user_totp_secrets.py
+++ b/whilly/adapters/db/migrations/versions/024_user_totp_secrets.py
@@ -1,0 +1,74 @@
+"""Add ``user_totp_secrets`` table for second-factor TOTP enrolment.
+
+Implements migration 024 from PRD-post-auth-hardening §Epic E, Item 14a
+(table only — the routes ship in E14b). One TOTP secret per user, gated at
+runtime behind the ``WHILLY_TOTP_ENABLED=1`` feature flag introduced in E14b;
+this migration is pure DDL and reversible so it can land independently of the
+flag.
+
+Schema:
+
+* ``username``    — primary key, foreign key to ``users(username)`` with
+                    ``ON DELETE CASCADE`` so deleting a user removes their
+                    secret atomically. The PRD prose says "user_id FK" but
+                    the ``users`` PK introduced in migration 020 is
+                    ``username TEXT`` — the column is named to match the
+                    actual PK rather than the PRD's nominal label. Using
+                    ``username`` as the PK of this table also encodes the
+                    1:1 invariant ("each user has at most one TOTP secret")
+                    directly in the schema.
+* ``secret``      — base32-encoded TOTP shared secret (RFC 6238). Stored
+                    plaintext in this migration; encryption-at-rest is
+                    deferred to a follow-up (out of E14a scope).
+* ``enabled``     — boolean, default ``FALSE``. A user can enroll (insert
+                    a row) and then confirm by flipping ``enabled`` to TRUE
+                    after they successfully echo back a valid TOTP code in
+                    the setup ceremony from E14b.
+* ``created_at``  — when the secret was minted. Used for "TOTP rotated N
+                    days ago" admin tooling.
+
+Revision ID: 024_user_totp_secrets
+Revises: 023_worker_tags
+Create Date: 2026-05-18
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "024_user_totp_secrets"
+down_revision: str | None = "023_worker_tags"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+USER_TOTP_SECRETS_TABLE: str = "user_totp_secrets"
+
+
+def upgrade() -> None:
+    op.create_table(
+        USER_TOTP_SECRETS_TABLE,
+        sa.Column("username", sa.Text(), primary_key=True),
+        sa.Column("secret", sa.Text(), nullable=False),
+        sa.Column("enabled", sa.Boolean(), nullable=False, server_default=sa.text("FALSE")),
+        sa.Column(
+            "created_at",
+            postgresql.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["username"],
+            ["users.username"],
+            name="fk_user_totp_secrets_username",
+            ondelete="CASCADE",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table(USER_TOTP_SECRETS_TABLE)


### PR DESCRIPTION
## Summary

Closes PRD §Epic E, Item 14a (migration only) — schema + extras groundwork for TOTP enrolment. The actual TOTP routes (`/me/totp/setup`, `/auth/totp`) ship in **E14b** behind `WHILLY_TOTP_ENABLED=1`, so this migration is feature-flag-independent: the table exists in every deployment, but `pyotp` is only imported when the flag is on.

## Changes

- **New** `whilly/adapters/db/migrations/versions/024_user_totp_secrets.py`:
  - `user_totp_secrets(username TEXT PRIMARY KEY → users.username ON DELETE CASCADE, secret TEXT NOT NULL, enabled BOOLEAN NOT NULL DEFAULT FALSE, created_at TIMESTAMPTZ NOT NULL DEFAULT NOW())`
  - Reversible — `downgrade()` drops the table.
- `pyproject.toml`: new `[project.optional-dependencies].totp = ["pyotp>=2.9"]` group with comment block mirroring the existing `worker`/`server`/`llmops` extras style.
- `.planning/post-auth-hardening-tasks.json`: mark `E14a-totp-migration-024` as `done` with realisation note.

## Deviation from PRD prose

PRD §Epic E Item 14 prose says "user_id FK". The actual `users` PK (introduced in migration **020**) is `username TEXT`, so the column on `user_totp_secrets` is named `username` to match the real PK type rather than the PRD's nominal label. The migration docstring records this choice; ACs (which don't pin column names) all pass either way.

Two design decisions worth flagging for review:

1. **`username` as the PK of `user_totp_secrets`** — encodes the 1:1 invariant ("each user has at most one TOTP secret") directly in the schema, so we never have to worry about duplicate-row defence in the routes. If we ever need multi-secret-per-user (e.g., backup TOTPs), we'd add a surrogate PK and a unique index, but that's not in PRD §14.
2. **FK with `ON DELETE CASCADE`** — sessions/magic_links (migration 018) intentionally don't have a FK to `users` because they predate it. New auth-adjacent tables should have one, otherwise a deleted user leaves orphaned secrets that could match a recycled username. Cascade is the safest default for a secret that has no meaning without its owner.

## Test plan

- [x] `python -m ruff check whilly/adapters/db/migrations/versions/024_user_totp_secrets.py` → clean
- [x] `python -m ruff format --check ...` → already formatted
- [x] `alembic heads` → `024_user_totp_secrets (head)` (single head, no branches)
- [x] `alembic history --verbose` → parent is `023_worker_tags`
- [x] Module imports + introspection: `revision`, `down_revision`, `USER_TOTP_SECRETS_TABLE`, `upgrade`/`downgrade` callables all present
- [x] `pyproject.toml` parses with `tomllib`; `optional-dependencies.totp == ["pyotp>=2.9"]`
- [x] Full-repo ruff sweep (`whilly/` + `tests/`) — all 541 files clean
- [ ] CI green (waiting on push)
- [ ] Full upgrade/downgrade roundtrip against a real Postgres — out of scope; will be exercised by E14b's route tests against a testcontainer

## Why this unblocks downstream

`E14b` (TOTP setup/verify routes) requires this schema to exist; `E15` (WebAuthn) shares the session state machine with E14b; `E16` (active-sessions UI with per-device revoke) needs the post-E14b session model to render meaningfully. None of those tasks can start until `024` is the head.

## Numbering note

Migration takes slot **024** — the next free number after `023_worker_tags` (PR #275). PRD assumed this slot, so unlike F18a there's no numbering drift here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)