### PR TITLE
feat(auth): C6 — per-request must_change_password gate middleware

### DIFF
--- a/.planning/post-auth-hardening-tasks.json
+++ b/.planning/post-auth-hardening-tasks.json
@@ -220,16 +220,18 @@
     },
     {
       "id": "C6-must-change-gate-middleware",
-      "status": "pending",
+      "status": "done",
       "priority": "high",
       "dependencies": [
         "A0-ci-restoration"
       ],
       "key_files": [
+        "whilly/api/must_change_gate.py",
         "whilly/api/auth_routes.py",
-        "whilly/api/main.py"
+        "whilly/adapters/transport/server.py",
+        "tests/unit/test_must_change_gate.py"
       ],
-      "description": "PRD §Epic C, Item 6 — implement the per-request must_change_password gate as FastAPI middleware (BaseHTTPMiddleware) or a Depends injected into the session dependency. Whitelist: /auth/change-password, /auth/logout, /health, /static/*. Add an in-process TTL cache (30s) keyed on (session_id, password_version) to avoid a DB round-trip on every request. Cache is invalidated on password change. Verify middleware ordering does not break CSRF protection.",
+      "description": "DONE 2026-05-18: realised as new whilly/api/must_change_gate.py (MustChangePasswordGateMiddleware: BaseHTTPMiddleware subclass) + wired into create_app at whilly/adapters/transport/server.py (NOT whilly/api/main.py — that is a re-export shim; real factory lives in transport/server.py) + cache invalidation hook called from the change-password POST handler in whilly/api/auth_routes.py. Middleware ordering: gate registered BEFORE CSRF so CSRF stays outermost (Starlette add_middleware is LIFO) — bad-Origin POSTs are rejected with 403 before the gate queries the DB. Whitelist as PRD plus /auth/login + /auth/magic + /auth/magic-login (entry points). Cache: 30s TTL keyed on session_id alone (NOT (session_id, password_version) as PRD nominates — users table has no password_version column; equivalent guarantee via explicit invalidate_session(session_id) called from change-password POST). Session.email → username conversion via strip-@local suffix (matches existing logic in submit_change_password at auth_routes.py:428). Fail-open on every error mode (DB hiccup, missing session, missing user, malformed cookie) — gate never breaks the request lifecycle. 12 new unit tests in tests/unit/test_must_change_gate.py cover all 4 ACs explicitly (303 redirect, whitelist passthrough, invalidation, 5-rapid-requests-=-1-DB-call) plus CSRF ordering verification, cookie absence, cookie tampering, user-not-found, TTL expiry. All 12 pass; full unit sweep 2155 passed (3 pre-existing test-order flakes confirmed unrelated, pass in isolation). mypy + import-linter + ruff full repo clean. Original: PRD §Epic C, Item 6 — implement the per-request must_change_password gate as FastAPI middleware (BaseHTTPMiddleware) or a Depends injected into the session dependency. Whitelist: /auth/change-password, /auth/logout, /health, /static/*. Add an in-process TTL cache (30s) keyed on (session_id, password_version) to avoid a DB round-trip on every request. Cache is invalidated on password change. Verify middleware ordering does not break CSRF protection.",
       "acceptance_criteria": [
         "Authenticated request to / with must_change_password=True returns HTTP 303 → /auth/change-password",
         "Request to /auth/change-password with the flag set returns 200",

--- a/tests/unit/test_must_change_gate.py
+++ b/tests/unit/test_must_change_gate.py
@@ -1,0 +1,409 @@
+"""Unit tests for :class:`whilly.api.must_change_gate.MustChangePasswordGateMiddleware`.
+
+These pin the contract of PRD-post-auth-hardening §Epic C, Item 6 without
+requiring a real Postgres pool — :func:`whilly.api.sessions.verify_session`
+and :func:`whilly.api.users_repo.get_user_by_username` are monkeypatched
+with :class:`AsyncMock`s so the tests can assert call counts to verify
+caching behaviour (AC: ≤ 1 DB lookup over 5 rapid requests).
+
+Integration coverage against a real DB lives in the auth-matrix tests
+once D9's full change-password round-trip exists; this file is the
+narrow contract pin so a regression in the middleware itself surfaces
+without testcontainers.
+"""
+
+from __future__ import annotations
+
+import datetime
+import time
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from whilly.api import auth_tokens, must_change_gate, sessions, users_repo
+from whilly.api.csrf import COOKIE_NAME, WhillySessionCSRFMiddleware
+from whilly.api.must_change_gate import (
+    CACHE_TTL_SECONDS,
+    CHANGE_PASSWORD_PATH,
+    MustChangePasswordGateMiddleware,
+    _clear_cache,
+    invalidate_session,
+)
+
+# 32-byte secret used to sign session cookies in these tests. Must be a
+# `bytes` long enough for HMAC-SHA256 — any constant string of the right
+# length is fine.
+_TEST_SECRET: bytes = b"gate-test-secret-32-bytes-padxx!"
+_GOOD_ORIGIN: str = "http://127.0.0.1:8000"
+_TEST_SESSION_ID: str = "test-session-id-abc123"
+_TEST_USERNAME: str = "alice"
+_TEST_EMAIL: str = f"{_TEST_USERNAME}@local"
+
+
+@pytest.fixture(autouse=True)
+def _reset_gate_cache() -> Iterator[None]:
+    """Wipe the gate's process-local cache between tests."""
+    _clear_cache()
+    yield
+    _clear_cache()
+
+
+def _make_session_record() -> Any:
+    """Build a session-like object with the attributes the gate reads."""
+
+    class _SessionStub:
+        session_id = _TEST_SESSION_ID
+        email = _TEST_EMAIL
+        # Real :class:`whilly.api.sessions.Session` carries more — the gate
+        # only reads ``email``, so the stub stays narrow.
+        expires_at = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(hours=1)
+
+    return _SessionStub()
+
+
+def _make_user(*, must_change: bool) -> users_repo.User:
+    """Construct a User dataclass instance with the ``must_change`` flag set."""
+    return users_repo.User(
+        username=_TEST_USERNAME,
+        email=None,
+        role="operator",
+        created_at=datetime.datetime.now(datetime.timezone.utc),
+        last_login_at=None,
+        must_change_password=must_change,
+    )
+
+
+def _mint_cookie(*, session_id: str = _TEST_SESSION_ID) -> str:
+    """Mint a session cookie that the gate's signature check will accept."""
+    return auth_tokens.mint_session_cookie_value(
+        _TEST_SECRET,
+        session_id=session_id,
+        email=_TEST_EMAIL,
+        ttl_seconds=3600,
+    )
+
+
+@pytest.fixture
+def patched_sessions(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
+    """Patch ``sessions.verify_session`` to return a fixed session stub."""
+    mock = AsyncMock(return_value=_make_session_record())
+    monkeypatch.setattr(sessions, "verify_session", mock)
+    return mock
+
+
+@pytest.fixture
+def patched_users_must_change(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
+    """Patch ``users_repo.get_user_by_username`` to return a must-change user."""
+    mock = AsyncMock(return_value=_make_user(must_change=True))
+    # The gate imports the function directly into its own namespace, so
+    # patching the module-level binding inside ``must_change_gate`` is
+    # required — patching ``users_repo.get_user_by_username`` alone would
+    # not redirect the call site inside ``_lookup_must_change``.
+    monkeypatch.setattr(must_change_gate, "get_user_by_username", mock)
+    return mock
+
+
+@pytest.fixture
+def patched_users_ok(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
+    """Patch ``users_repo.get_user_by_username`` to return a no-must-change user."""
+    mock = AsyncMock(return_value=_make_user(must_change=False))
+    monkeypatch.setattr(must_change_gate, "get_user_by_username", mock)
+    return mock
+
+
+def _build_app() -> FastAPI:
+    """Minimal app with the gate + CSRF + a couple of routes to drive."""
+    app = FastAPI()
+    # Ordering: gate added FIRST, CSRF added SECOND. Starlette LIFO means
+    # CSRF is the outer layer at runtime (CSRF runs first, then gate).
+    app.add_middleware(
+        MustChangePasswordGateMiddleware,
+        pool=None,  # type: ignore[arg-type] — gate never touches the pool, mocks intercept
+        secret=_TEST_SECRET,
+    )
+    app.add_middleware(WhillySessionCSRFMiddleware, allowlist=[_GOOD_ORIGIN])
+
+    @app.get("/")
+    async def root() -> dict[str, str]:
+        return {"ok": "yes"}
+
+    @app.get(CHANGE_PASSWORD_PATH)
+    async def change_pw_form() -> dict[str, str]:
+        return {"form": "change-password"}
+
+    @app.get("/health")
+    async def health() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @app.get("/static/app.css")
+    async def static_asset() -> dict[str, str]:
+        return {"asset": "css"}
+
+    @app.post("/api/v1/foo")
+    async def post_foo() -> dict[str, str]:
+        return {"posted": "yes"}
+
+    return app
+
+
+@pytest.fixture
+async def client() -> AsyncIterator[AsyncClient]:
+    app = _build_app()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://127.0.0.1:8000") as ac:
+        yield ac
+
+
+# ─── AC1: GET / with must_change=True redirects ─────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_root_with_must_change_redirects_303(
+    client: AsyncClient,
+    patched_sessions: AsyncMock,
+    patched_users_must_change: AsyncMock,
+) -> None:
+    """Authenticated GET / with must_change_password=True → 303 to change-password."""
+    cookie = _mint_cookie()
+    response = await client.get("/", cookies={COOKIE_NAME: cookie}, follow_redirects=False)
+    assert response.status_code == 303
+    assert response.headers["location"] == CHANGE_PASSWORD_PATH
+    # Sanity: the gate actually consulted the DB once.
+    assert patched_sessions.await_count == 1
+    assert patched_users_must_change.await_count == 1
+
+
+# ─── AC2: GET /auth/change-password with the flag set passes through ────────
+
+
+@pytest.mark.asyncio
+async def test_change_password_path_passes_through_when_must_change_true(
+    client: AsyncClient,
+    patched_sessions: AsyncMock,
+    patched_users_must_change: AsyncMock,
+) -> None:
+    """The whitelist must include the change-password path itself."""
+    cookie = _mint_cookie()
+    response = await client.get(CHANGE_PASSWORD_PATH, cookies={COOKIE_NAME: cookie}, follow_redirects=False)
+    assert response.status_code == 200
+    assert response.json() == {"form": "change-password"}
+    # Whitelist short-circuits BEFORE any DB call.
+    assert patched_sessions.await_count == 0
+    assert patched_users_must_change.await_count == 0
+
+
+# ─── AC3: after invalidation, the next request to / returns 200 ─────────────
+
+
+@pytest.mark.asyncio
+async def test_invalidate_session_clears_cache_after_password_change(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    patched_sessions: AsyncMock,
+) -> None:
+    """Simulate the post-password-change flow: first call sees must_change=True
+    and is cached; ``invalidate_session`` drops the entry; the next lookup
+    returns must_change=False and the request to / is served (200).
+    """
+    user_mock = AsyncMock(side_effect=[_make_user(must_change=True), _make_user(must_change=False)])
+    monkeypatch.setattr(must_change_gate, "get_user_by_username", user_mock)
+    cookie = _mint_cookie()
+
+    # First request — cache miss, returns the must_change=True user → 303.
+    r1 = await client.get("/", cookies={COOKIE_NAME: cookie}, follow_redirects=False)
+    assert r1.status_code == 303
+
+    # Simulate the change-password handler's invalidation step.
+    invalidate_session(_TEST_SESSION_ID)
+
+    # Second request — cache miss again because we invalidated; returns the
+    # second side_effect (must_change=False) → 200.
+    r2 = await client.get("/", cookies={COOKIE_NAME: cookie}, follow_redirects=False)
+    assert r2.status_code == 200
+    assert user_mock.await_count == 2
+
+
+# ─── AC4: 5 rapid requests result in ≤ 1 DB lookup (cache hit) ──────────────
+
+
+@pytest.mark.asyncio
+async def test_cache_hit_collapses_five_rapid_requests_to_one_db_lookup(
+    client: AsyncClient,
+    patched_sessions: AsyncMock,
+    patched_users_must_change: AsyncMock,
+) -> None:
+    """The 30-s cache must collapse 5 successive requests into a single DB pair.
+
+    PRD AC: 'Cache hit confirmed by asserting DB query count ≤ 1 for 5
+    rapid successive requests (mock.call_count)'. The gate makes two DB
+    calls on a miss (verify_session + get_user_by_username); the cache
+    is keyed at the verdict level, so both must be called exactly once.
+    """
+    cookie = _mint_cookie()
+    for _ in range(5):
+        response = await client.get("/", cookies={COOKIE_NAME: cookie}, follow_redirects=False)
+        assert response.status_code == 303
+    assert patched_sessions.await_count == 1
+    assert patched_users_must_change.await_count == 1
+
+
+# ─── Whitelist: /health, /static/* bypass without any DB hit ────────────────
+
+
+@pytest.mark.asyncio
+async def test_health_path_bypasses_gate(
+    client: AsyncClient,
+    patched_sessions: AsyncMock,
+    patched_users_must_change: AsyncMock,
+) -> None:
+    cookie = _mint_cookie()
+    response = await client.get("/health", cookies={COOKIE_NAME: cookie})
+    assert response.status_code == 200
+    assert patched_sessions.await_count == 0
+    assert patched_users_must_change.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_static_path_bypasses_gate(
+    client: AsyncClient,
+    patched_sessions: AsyncMock,
+    patched_users_must_change: AsyncMock,
+) -> None:
+    cookie = _mint_cookie()
+    response = await client.get("/static/app.css", cookies={COOKIE_NAME: cookie})
+    assert response.status_code == 200
+    assert patched_sessions.await_count == 0
+    assert patched_users_must_change.await_count == 0
+
+
+# ─── No cookie → no DB hit, passes through ──────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_request_without_cookie_passes_through_no_db_hit(
+    client: AsyncClient,
+    patched_sessions: AsyncMock,
+    patched_users_must_change: AsyncMock,
+) -> None:
+    """Bearer/JWT traffic doesn't carry the session cookie; gate must
+    pass through without any DB call.
+    """
+    response = await client.get("/")
+    assert response.status_code == 200
+    assert patched_sessions.await_count == 0
+    assert patched_users_must_change.await_count == 0
+
+
+# ─── Bad cookie signature → passes through (gate fail-opens) ────────────────
+
+
+@pytest.mark.asyncio
+async def test_malformed_cookie_fails_open_without_db_hit(
+    client: AsyncClient,
+    patched_sessions: AsyncMock,
+    patched_users_must_change: AsyncMock,
+) -> None:
+    response = await client.get("/", cookies={COOKIE_NAME: "not-a-real-cookie"})
+    assert response.status_code == 200
+    assert patched_sessions.await_count == 0
+    assert patched_users_must_change.await_count == 0
+
+
+# ─── user lookup returns None (e.g. magic-link user) → pass through ─────────
+
+
+@pytest.mark.asyncio
+async def test_user_not_found_passes_through(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    patched_sessions: AsyncMock,
+) -> None:
+    monkeypatch.setattr(must_change_gate, "get_user_by_username", AsyncMock(return_value=None))
+    cookie = _mint_cookie()
+    response = await client.get("/", cookies={COOKIE_NAME: cookie}, follow_redirects=False)
+    assert response.status_code == 200
+
+
+# ─── must_change=False user → pass through without redirect ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_user_without_must_change_passes_through(
+    client: AsyncClient,
+    patched_sessions: AsyncMock,
+    patched_users_ok: AsyncMock,
+) -> None:
+    cookie = _mint_cookie()
+    response = await client.get("/", cookies={COOKIE_NAME: cookie}, follow_redirects=False)
+    assert response.status_code == 200
+    assert patched_users_ok.await_count == 1
+
+
+# ─── AC5: CSRF middleware still protects POST routes (ordering check) ───────
+
+
+@pytest.mark.asyncio
+async def test_csrf_still_blocks_bad_origin_post_with_session(
+    client: AsyncClient,
+    patched_sessions: AsyncMock,
+    patched_users_ok: AsyncMock,
+) -> None:
+    """The gate sitting under CSRF must not steal traffic CSRF wants to reject.
+
+    A cookie-authenticated POST from a disallowed Origin should be 403'd
+    by the (outermost) CSRF middleware before the gate runs. If the gate
+    were outermost, this would be a 200 or a redirect — both wrong.
+    """
+    cookie = _mint_cookie()
+    response = await client.post(
+        "/api/v1/foo",
+        cookies={COOKIE_NAME: cookie},
+        headers={"Origin": "http://evil.example.com"},
+    )
+    assert response.status_code == 403
+    assert "csrf_origin_check_failed" in response.text
+    # The gate never ran — CSRF rejected the request before lookups.
+    assert patched_sessions.await_count == 0
+    assert patched_users_ok.await_count == 0
+
+
+# ─── Cache TTL: after expiry, the next request re-hits the DB ───────────────
+
+
+@pytest.mark.asyncio
+async def test_cache_expires_after_ttl_seconds(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    patched_sessions: AsyncMock,
+    patched_users_must_change: AsyncMock,
+) -> None:
+    """After CACHE_TTL_SECONDS, the gate must re-consult the DB.
+
+    Faked by advancing :func:`time.monotonic` past the TTL boundary
+    between two requests. The verdict here happens to stay the same,
+    but the call_count is what matters: 2 lookups, not 1.
+    """
+    cookie = _mint_cookie()
+
+    # First request — cache miss, 1 lookup.
+    r1 = await client.get("/", cookies={COOKIE_NAME: cookie}, follow_redirects=False)
+    assert r1.status_code == 303
+    assert patched_users_must_change.await_count == 1
+
+    # Advance monotonic clock past the TTL.
+    real_monotonic = time.monotonic
+    base = real_monotonic()
+
+    def _shifted() -> float:
+        return base + CACHE_TTL_SECONDS + 1.0
+
+    monkeypatch.setattr(must_change_gate.time, "monotonic", _shifted)
+
+    # Second request — cache expired, 1 fresh lookup.
+    r2 = await client.get("/", cookies={COOKIE_NAME: cookie}, follow_redirects=False)
+    assert r2.status_code == 303
+    assert patched_users_must_change.await_count == 2

--- a/whilly/adapters/transport/server.py
+++ b/whilly/adapters/transport/server.py
@@ -1353,6 +1353,7 @@ def create_app(
     from whilly.api.auth_routes import build_auth_router
     from whilly.api.csrf import WhillySessionCSRFMiddleware
     from whilly.api.dashboard import FileLogStore
+    from whilly.api.must_change_gate import MustChangePasswordGateMiddleware
     from whilly.api.plans_api import build_plans_router
     from whilly.api.static_mount import mount_static_assets
     from whilly.api.tasks_api_crud import build_tasks_crud_router
@@ -1361,6 +1362,17 @@ def create_app(
     app.state.log_store = FileLogStore(Path("whilly_logs"))
     instrument_app(app)
 
+    # PRD-post-auth-hardening §Epic C, Item 6: the must-change-password
+    # gate. Registered BEFORE the CSRF middleware so that CSRF (added next)
+    # becomes the OUTERMOST layer on the request path — Starlette's
+    # ``add_middleware`` is LIFO. The ordering matters: a bad-Origin POST
+    # must be rejected with 403 before the gate ever queries the DB to
+    # decide whether the user needs to change their password.
+    app.add_middleware(
+        MustChangePasswordGateMiddleware,
+        pool=pool,
+        secret=dashboard_token_secret,
+    )
     # PRD-wui-multi-plan v2 Epic A + §6.1: install the CSRF gate BEFORE the
     # auth router and any subsequent CRUD routers. The middleware is a
     # no-op for requests that do not carry the session cookie, so worker

--- a/whilly/api/auth_routes.py
+++ b/whilly/api/auth_routes.py
@@ -436,6 +436,16 @@ def build_auth_router(
             logger.warning("auth.change-password: set_password failed for %r: %s", username, exc)
             return _render_error("Could not update password. Please try again.")
 
+        # PRD-post-auth-hardening §Epic C Item 6: drop the gate's cached
+        # must_change verdict for this session so the very next request
+        # (the 303 redirect to /) is not bounced back to the change-password
+        # form by a stale True verdict.
+        session_id_raw = principal.get("session_id")
+        if isinstance(session_id_raw, str) and session_id_raw:
+            from whilly.api.must_change_gate import invalidate_session
+
+            invalidate_session(session_id_raw)
+
         _append_event(
             {
                 "event_type": "auth.password.changed",

--- a/whilly/api/must_change_gate.py
+++ b/whilly/api/must_change_gate.py
@@ -1,0 +1,270 @@
+"""Per-request ``must_change_password`` gate (PRD §Epic C, Item 6).
+
+When a user signed in with ``must_change_password=True`` makes ANY request
+other than the small whitelist below, the gate returns ``303 → /auth/change-
+password``. This stops the "navigate-away-after-login" bypass: the password-
+change page is rendered once after a successful login, but nothing prevents
+the user from typing ``/`` into the URL bar before completing the change.
+The middleware enforces the redirect on every request, not just the one
+right after login.
+
+Whitelist (request passes through unchanged):
+    * ``/auth/change-password`` — the change-password form + POST itself.
+    * ``/auth/logout``          — never trap a user who wants to leave.
+    * ``/auth/login``, ``/auth/magic``, ``/auth/magic-login`` — entry
+      points needed to *get* a session in the first place.
+    * ``/health``               — liveness probes.
+    * ``/static/*``             — CSS, JS, images.
+
+Cookie-unauthenticated requests (worker bearer, dashboard JWT) carry no
+``whilly_session`` cookie and pass through with no DB round-trip — the gate
+has no opinion on machine-to-machine auth paths.
+
+Caching
+-------
+The gate caches the ``must_change_password`` verdict per ``session_id``
+with a 30 s TTL in a process-local dict. Without caching every authenticated
+request would issue two DB round-trips (``verify_session`` +
+``get_user_by_username``); with the cache the steady state is one in 30 s.
+
+The PRD specifies the cache key as ``(session_id, password_version)``
+to auto-invalidate on password change. The current ``users`` schema has
+no ``password_version`` column, so the cache is keyed on ``session_id``
+alone and invalidation is performed *explicitly* by the change-password
+POST handler calling :func:`invalidate_session` right after a successful
+``set_password``. A future schema migration that adds
+``users.password_version`` could swap to the PRD's two-tuple key without
+changing the public API of this module — :func:`invalidate_session` would
+become a no-op and the cache TTL could grow.
+
+Middleware ordering
+-------------------
+This middleware is registered BEFORE :class:`WhillySessionCSRFMiddleware`
+in :func:`whilly.adapters.transport.server.create_app`. In Starlette,
+``add_middleware`` is LIFO — the *last* middleware added is the
+*outermost* on the request path. So CSRF (added last) runs first; a
+bad-Origin POST is rejected with 403 before the gate ever queries the DB.
+The gate then runs on already-CSRF-validated requests. This ordering is
+verified by ``tests/unit/test_must_change_gate.py``.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Awaitable, Callable
+from typing import Final
+
+import asyncpg
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import RedirectResponse, Response
+from starlette.types import ASGIApp
+
+from whilly.api import auth_tokens, sessions
+from whilly.api.csrf import COOKIE_NAME, _HOST_PREFIX_COOKIE_NAME
+from whilly.api.users_repo import get_user_by_username
+
+logger = logging.getLogger(__name__)
+
+#: Target of the redirect when the gate fires.
+CHANGE_PASSWORD_PATH: Final[str] = "/auth/change-password"
+
+#: Paths exempted from the gate by exact match. ``/auth/login`` etc. are
+#: included so an already-logged-in-but-must-change user can still hit
+#: them without infinite redirect loops on edge cases (e.g. opening
+#: ``/auth/login`` in a second tab while the first tab is sitting on the
+#: change-password form).
+GATE_EXEMPT_EXACT: Final[frozenset[str]] = frozenset(
+    {
+        CHANGE_PASSWORD_PATH,
+        "/auth/logout",
+        "/auth/login",
+        "/auth/magic",
+        "/auth/magic-login",
+        "/health",
+    }
+)
+
+#: Path *prefixes* exempted from the gate. ``/static/`` covers the CSS,
+#: JS and image bundle the login + change-password forms depend on.
+GATE_EXEMPT_PREFIXES: Final[tuple[str, ...]] = ("/static/",)
+
+#: Cache TTL in seconds. PRD specifies 30 s as the maximum staleness
+#: window between a password change and the cached verdict expiring.
+#: Combined with explicit invalidation on password change, this is the
+#: tail-latency bound for stale verdicts during failure scenarios (e.g.
+#: when ``invalidate_session`` is somehow skipped).
+CACHE_TTL_SECONDS: Final[float] = 30.0
+
+#: Process-local cache: ``session_id`` → ``(must_change, expires_at_monotonic)``.
+#: A bare dict is safe under the GIL for the single read + single write
+#: pattern below; no async lock is required and adding one would only slow
+#: down the cache-hit path the gate exists to optimise.
+_cache: dict[str, tuple[bool, float]] = {}
+
+
+def invalidate_session(session_id: str) -> None:
+    """Drop the cached ``must_change_password`` verdict for ``session_id``.
+
+    Called by the change-password POST handler immediately after a
+    successful :func:`whilly.api.users_repo.set_password`. Without this
+    the cached ``True`` verdict would persist for up to
+    :data:`CACHE_TTL_SECONDS` and the user would loop on the change-
+    password form even though the flag is already ``False`` in the DB.
+
+    Idempotent — calling on a session that has no cache entry is a no-op,
+    so the change-password handler does not need to know whether the gate
+    has seen this session yet.
+    """
+    _cache.pop(session_id, None)
+
+
+def _clear_cache() -> None:
+    """Reset the entire cache. Test-only helper, not exported."""
+    _cache.clear()
+
+
+def _is_exempt_path(path: str) -> bool:
+    """Return True iff ``path`` is on the gate's whitelist."""
+    if path in GATE_EXEMPT_EXACT:
+        return True
+    return any(path.startswith(prefix) for prefix in GATE_EXEMPT_PREFIXES)
+
+
+def _extract_session_id(request: Request, *, secret: bytes, cookie_name: str) -> str | None:
+    """Pull and verify the ``session_id`` from the request cookie.
+
+    Returns ``None`` on any failure — missing cookie, bad signature,
+    expired, malformed claims. The gate fail-opens in every failure mode:
+    a request the gate cannot make sense of is left to the route handlers
+    (which run their own authentication and will return 401 if needed).
+    """
+    cookie_raw = request.cookies.get(cookie_name) or request.cookies.get(_HOST_PREFIX_COOKIE_NAME)
+    if not cookie_raw:
+        return None
+    try:
+        claims = auth_tokens.verify_session_cookie_value(cookie_raw, secret)
+    except auth_tokens.AuthTokenError:
+        return None
+    sid = claims.get("sid")
+    if not isinstance(sid, str) or not sid:
+        return None
+    return sid
+
+
+def _session_email_to_username(session_email: str) -> str:
+    """Recover the username from a ``sessions.email`` value.
+
+    The username+password login path synthesises ``<username>@local`` as
+    the ``sessions.email`` value (see
+    :mod:`whilly.api.auth_routes.submit_login`); the magic-link path
+    stores a real email. The username PK CHECK constraint
+    (``^[a-z0-9][a-z0-9_-]{0,63}$``) means a real email never round-trips
+    through :func:`get_user_by_username` — those users have no row in
+    ``users`` at all, so the lookup returns ``None`` and the gate
+    fail-opens. The synthetic case is the one that matters: strip
+    ``@local`` and recover the original username.
+    """
+    if session_email.endswith("@local"):
+        return session_email.removesuffix("@local")
+    return session_email
+
+
+class MustChangePasswordGateMiddleware(BaseHTTPMiddleware):
+    """Redirect every cookie-authenticated request to the change-password
+    form while the signed-in user has ``must_change_password=True``.
+
+    See module docstring for the design rationale, whitelist contents,
+    caching strategy, and middleware ordering requirements.
+    """
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        *,
+        pool: asyncpg.Pool,
+        secret: bytes,
+        cookie_name: str = COOKIE_NAME,
+    ) -> None:
+        super().__init__(app)
+        self._pool = pool
+        self._secret = secret
+        self._cookie_name = cookie_name
+
+    async def dispatch(
+        self,
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        # Fast path 1: whitelisted path. No cookie inspection, no DB.
+        if _is_exempt_path(request.url.path):
+            return await call_next(request)
+
+        # Fast path 2: no session cookie → request relies on bearer/JWT.
+        # The gate has no opinion on machine-to-machine traffic.
+        sid = _extract_session_id(request, secret=self._secret, cookie_name=self._cookie_name)
+        if sid is None:
+            return await call_next(request)
+
+        # Slow path: cached or DB lookup for the must_change verdict.
+        must_change = await self._must_change_for_session(sid)
+        if must_change:
+            return RedirectResponse(url=CHANGE_PASSWORD_PATH, status_code=303)
+        return await call_next(request)
+
+    async def _must_change_for_session(self, session_id: str) -> bool:
+        """Return ``True`` iff the signed-in user has
+        ``must_change_password=True``. 30 s TTL cache.
+        """
+        now = time.monotonic()
+        cached = _cache.get(session_id)
+        if cached is not None and cached[1] > now:
+            return cached[0]
+        verdict = await self._lookup_must_change(session_id)
+        _cache[session_id] = (verdict, now + CACHE_TTL_SECONDS)
+        return verdict
+
+    async def _lookup_must_change(self, session_id: str) -> bool:
+        """One round-trip to ``sessions`` and one to ``users``.
+
+        Fail-open on any exception or missing row — the gate never breaks
+        the request lifecycle when the DB hiccups. The route handlers
+        downstream will return 401 if the session is genuinely invalid.
+        """
+        try:
+            session = await sessions.verify_session(self._pool, session_id=session_id)
+        except Exception:  # noqa: BLE001 — gate must never crash the request
+            logger.warning(
+                "must_change_gate: verify_session raised for sid=%r — fail-open",
+                session_id,
+                exc_info=True,
+            )
+            return False
+        if session is None:
+            return False
+        username = _session_email_to_username(session.email)
+        try:
+            user = await get_user_by_username(self._pool, username=username)
+        except Exception:  # noqa: BLE001 — gate must never crash the request
+            logger.warning(
+                "must_change_gate: get_user_by_username raised for %r — fail-open",
+                username,
+                exc_info=True,
+            )
+            return False
+        if user is None:
+            # Magic-link user with no ``users`` row, or stale session whose
+            # user has been deleted. Pass through; downstream handlers cope.
+            return False
+        return bool(user.must_change_password)
+
+
+__all__ = [
+    "CACHE_TTL_SECONDS",
+    "CHANGE_PASSWORD_PATH",
+    "GATE_EXEMPT_EXACT",
+    "GATE_EXEMPT_PREFIXES",
+    "MustChangePasswordGateMiddleware",
+    "invalidate_session",
+]


### PR DESCRIPTION
## Summary

Closes PRD-post-auth-hardening §Epic C, Item 6. Implements the per-request `must_change_password` gate as a Starlette `BaseHTTPMiddleware`, closing the "navigate-away-after-login" bypass: once a user with `must_change_password=True` is signed in, every request EXCEPT a tight whitelist returns `303 → /auth/change-password` regardless of which URL they typed.

This is the **biggest single dep-graph unblocker** in the post-auth-hardening backlog — D9 → D10 → D10b → D13 → E14b → E15/E16/E17 are all gated on this landing.

## Changes

### New: `whilly/api/must_change_gate.py` (270 lines)
- `MustChangePasswordGateMiddleware(BaseHTTPMiddleware)` — drop-in middleware
- Whitelist (exact): `/auth/change-password`, `/auth/logout`, `/auth/login`, `/auth/magic`, `/auth/magic-login`, `/health`
- Whitelist (prefix): `/static/*`
- Process-local 30s TTL cache keyed on `session_id`
- `invalidate_session(session_id)` helper for explicit cache invalidation on password change
- Fail-open on every error mode (DB hiccup, missing session, missing user, malformed cookie)

### Wiring: `whilly/adapters/transport/server.py` (+12 lines)
Middleware registered BEFORE `WhillySessionCSRFMiddleware`. Starlette's `add_middleware` is LIFO — the last-added middleware is the outermost on the request path. So CSRF (added last) wraps the gate, meaning a bad-Origin POST gets 403 before the gate ever queries the DB. The ordering is critical and is verified by `test_csrf_still_blocks_bad_origin_post_with_session`.

### Patch: `whilly/api/auth_routes.py` (+10 lines)
The change-password POST handler now calls `invalidate_session(session_id)` immediately after a successful `set_password`. Without this hook the cached `must_change=True` verdict would persist for up to 30 s, and the user would loop on the change-password form even though the flag is already `False` in the DB.

### Tests: `tests/unit/test_must_change_gate.py` (409 lines, 12 cases)
Pure unit tests — no Docker. Monkeypatches `sessions.verify_session` and `users_repo.get_user_by_username` with `AsyncMock`s so call counts can be asserted to verify caching.

| Test | AC |
|---|---|
| `test_root_with_must_change_redirects_303` | AC1 |
| `test_change_password_path_passes_through_when_must_change_true` | AC2 |
| `test_invalidate_session_clears_cache_after_password_change` | AC3 |
| `test_cache_hit_collapses_five_rapid_requests_to_one_db_lookup` | AC4 (`≤ 1 DB call for 5 rapid requests`) |
| `test_csrf_still_blocks_bad_origin_post_with_session` | AC5 (ordering) |
| `test_health_path_bypasses_gate` | whitelist exact |
| `test_static_path_bypasses_gate` | whitelist prefix |
| `test_request_without_cookie_passes_through_no_db_hit` | bearer/JWT no-op |
| `test_malformed_cookie_fails_open_without_db_hit` | tampered cookie fail-open |
| `test_user_not_found_passes_through` | magic-link user no-op |
| `test_user_without_must_change_passes_through` | normal user pass |
| `test_cache_expires_after_ttl_seconds` | TTL boundary |

## PRD-prose deviations

1. **Cache key**: PRD nominates `(session_id, password_version)` for auto-invalidation. The `users` table has no `password_version` column, so cache is keyed on `session_id` alone and invalidation is **explicit** via `invalidate_session()` called from the change-password POST handler. A future migration that adds `users.password_version` could swap to the PRD's two-tuple key without changing the public API of this module — `invalidate_session` would become a no-op and the cache TTL could grow.
2. **Wiring location**: PRD lists `whilly/api/main.py` as a key file. That module is a re-export shim — the real `create_app` factory is `whilly/adapters/transport/server.py:774`. Middleware is registered there, where it actually runs.

## Why the whitelist includes `/auth/login`, `/auth/magic`, `/auth/magic-login`

The minimum whitelist from PRD prose is `{change-password, logout, health, static/*}`. I added the three login entry points because of edge cases: an already-signed-in-but-must-change user can open `/auth/login` in a second tab while the first tab sits on the change-password form. Without those on the whitelist, the second tab would be 303-redirected to the change-password form — which the user is already filling out in the first tab. Whitelisting the login routes keeps the behaviour intuitive (login pages remain reachable even mid-flow).

## Why session.email → username strips `@local`

Username+password login synthesises `<username>@local` as the `sessions.email` value (see `submit_login`). Magic-link login stores a real email. The user PK CHECK constraint `^[a-z0-9][a-z0-9_-]{0,63}$` means a real email never round-trips through `get_user_by_username` — those users have no `users` row at all, so the lookup returns `None` and the gate fail-opens. The same `removesuffix('@local')` logic is already used in the change-password handler at `auth_routes.py:428`, so this is consistent.

## Test plan

- [x] `pytest tests/unit/test_must_change_gate.py -v` → **12 passed in 0.33s**
- [x] `pytest tests/unit/test_admin_auth.py tests/unit/test_transport_server.py -q` → **42 passed in 0.87s** (AC test_steps target — no regressions)
- [x] `pytest tests/unit/ -q` → **2155 passed, 3 pre-existing test-order flakes** (`test_prompt_sanitizer_wiring`, `test_qa_release_collector` — handoff doc 2026-05-18 flagged these as `langsmith`/`pydantic_core` `typing_extensions` collisions; pass cleanly in isolation: `pytest tests/unit/test_prompt_sanitizer_wiring.py tests/unit/test_qa_release_collector.py -q` → **45 passed**)
- [x] `mypy whilly/api/must_change_gate.py` → clean
- [x] `import-linter` → 2 contracts kept, 0 broken (new module respects layering)
- [x] Full-repo ruff sweep (545 files) → clean
- [x] Pre-commit hook → all checks passed
- [ ] CI green (waiting on push)
- [ ] Integration verification against real DB — out of scope for unit-test-only PR; will be exercised when D9 ships its full E2E change-password test

## Unblocks

- `D9-self-service-password-change` (only direct blocker)
- Transitively: D10 → D10b → D13 → E14b → E15 / E16 / E17

🤖 Generated with [Claude Code](https://claude.com/claude-code)