### PR TITLE
feat(admin): D10 — admin user management UI + auth-audit browse

### DIFF
--- a/.planning/post-auth-hardening-tasks.json
+++ b/.planning/post-auth-hardening-tasks.json
@@ -328,7 +328,7 @@
     },
     {
       "id": "D10-admin-user-management-ui",
-      "status": "pending",
+      "status": "done",
       "priority": "medium",
       "dependencies": [
         "A0-ci-restoration",
@@ -338,10 +338,15 @@
       ],
       "key_files": [
         "whilly/api/admin_users_routes.py",
-        "whilly/api/main.py",
-        "whilly/api/sessions.py"
+        "whilly/api/users_repo.py",
+        "whilly/api/auth_audit_repo.py",
+        "whilly/api/templates/admin_users.html.j2",
+        "whilly/api/templates/admin_auth_audit.html.j2",
+        "whilly/operator_views.py",
+        "whilly/adapters/transport/server.py",
+        "tests/unit/test_admin_users_routes.py"
       ],
-      "description": "PRD §Epic D, Item 10 — create whilly/api/admin_users_routes.py with routes: GET /admin/users (table of all users), POST /admin/users/create (username, email, role, initial password → must_change_password=True), POST /admin/users/{id}/role (set role), POST /admin/users/{id}/reset-password (random password, set must_change_password=True), POST /admin/users/{id}/delete. All routes protected by Depends(require_role('admin')). Create Jinja2 template whilly/templates/admin_users.html. Add require_role to sessions.py if absent. Include router in main.py. Also add GET /admin/auth-audit?page=N&username=X paginated browse route (50 rows/page) and its template, calling auth_audit_repo from D11.",
+      "description": "DONE 2026-05-18: new whilly/api/admin_users_routes.py with build_admin_users_router factory exposing 6 routes (/admin/users GET, POST /admin/users/create, POST /admin/users/{u}/role|reset-password|delete, /admin/auth-audit GET paginated). require_admin_role dependency factory authenticates session then rejects role!=admin with 403. PRD nominated putting require_role in sessions.py but that module is pure-asyncpg (no FastAPI imports); kept guard in admin_users_routes.py co-located with its only call sites. users_repo.py gained 5 new functions (list_users, create_user, set_role, delete_user, reset_password_to_random — last returns the random plaintext for one-time admin display). auth_audit_repo.py gained list_attempts with optional username filter. Two new Jinja templates (admin_users.html.j2, admin_auth_audit.html.j2) registered in OPERATOR_WUI_ARTIFACTS. create_app sets app.state.pool=pool so helper render functions can recover it without leaking the pool reference into route bodies. Self-deletion guard prevents an admin from bricking the last admin row. Delete is idempotent (returns 200 on first, 404 on second). 13 unit tests cover 403/401, all 5 user CRUD paths, invalid-role 400, idempotent-delete 404, audit pagination (?username filter + page offset arithmetic). Original: PRD §Epic D, Item 10 — create whilly/api/admin_users_routes.py with routes: GET /admin/users (table of all users), POST /admin/users/create (username, email, role, initial password → must_change_password=True), POST /admin/users/{id}/role (set role), POST /admin/users/{id}/reset-password (random password, set must_change_password=True), POST /admin/users/{id}/delete. All routes protected by Depends(require_role('admin')). Create Jinja2 template whilly/templates/admin_users.html. Add require_role to sessions.py if absent. Include router in main.py. Also add GET /admin/auth-audit?page=N&username=X paginated browse route (50 rows/page) and its template, calling auth_audit_repo from D11.",
       "acceptance_criteria": [
         "Non-admin access to any /admin/* route returns HTTP 403",
         "Admin can create, list, role-change, password-reset, and delete a user",

--- a/tests/unit/test_admin_users_routes.py
+++ b/tests/unit/test_admin_users_routes.py
@@ -1,0 +1,280 @@
+"""Unit tests for :mod:`whilly.api.admin_users_routes`.
+
+PRD-post-auth-hardening §Epic D, Item 10. Verifies the 403/200 role
+gate and the CRUD surface contract (create / set_role / reset_password /
+delete) plus the auth-audit browse pagination.
+
+asyncpg is faked end-to-end — sessions.verify_session and the entire
+users_repo + auth_audit_repo surface are monkeypatched with
+:class:`AsyncMock`s. The pool argument is ``None`` because no DB call
+site is reached; tests assert on mock call args.
+"""
+
+from __future__ import annotations
+
+import datetime
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from whilly.api import auth_audit_repo, auth_tokens, sessions, users_repo
+from whilly.api.admin_users_routes import build_admin_users_router
+from whilly.api.csrf import COOKIE_NAME
+
+_TEST_SECRET: bytes = b"d10-test-secret-32-bytes-paddxxx"
+_TEST_SESSION_ID: str = "d10-session-id"
+_ADMIN_USERNAME: str = "alice"
+_ADMIN_EMAIL: str = f"{_ADMIN_USERNAME}@local"
+_OPERATOR_USERNAME: str = "bob"
+_OPERATOR_EMAIL: str = f"{_OPERATOR_USERNAME}@local"
+
+
+def _session(email: str) -> Any:
+    class _S:
+        session_id = _TEST_SESSION_ID
+        email_ = email
+
+        def __init__(self) -> None:
+            self.email = email
+
+        expires_at = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(hours=1)
+
+    return _S()
+
+
+def _user(username: str, role: str) -> users_repo.User:
+    return users_repo.User(
+        username=username,
+        email=None,
+        role=role,
+        created_at=datetime.datetime.now(datetime.timezone.utc),
+        last_login_at=None,
+        must_change_password=False,
+    )
+
+
+def _mint_cookie(email: str = _ADMIN_EMAIL) -> str:
+    return auth_tokens.mint_session_cookie_value(
+        _TEST_SECRET,
+        session_id=_TEST_SESSION_ID,
+        email=email,
+        ttl_seconds=3600,
+    )
+
+
+@pytest.fixture
+def patch_admin(monkeypatch: pytest.MonkeyPatch) -> dict:
+    """Wire mocks so the admin guard sees an admin user."""
+    monkeypatch.setattr(sessions, "verify_session", AsyncMock(return_value=_session(_ADMIN_EMAIL)))
+    monkeypatch.setattr(users_repo, "get_user_by_username", AsyncMock(return_value=_user(_ADMIN_USERNAME, "admin")))
+    return {
+        "list_users": AsyncMock(return_value=[_user(_ADMIN_USERNAME, "admin"), _user(_OPERATOR_USERNAME, "operator")]),
+        "create_user": AsyncMock(return_value=None),
+        "set_role": AsyncMock(return_value=None),
+        "delete_user": AsyncMock(return_value=True),
+        "reset_password_to_random": AsyncMock(return_value="rand-pw-abc123"),
+        "list_attempts": AsyncMock(return_value=[]),
+    }
+
+
+@pytest.fixture
+async def client(monkeypatch: pytest.MonkeyPatch, patch_admin: dict) -> AsyncIterator[AsyncClient]:
+    # Patch users_repo CRUD functions
+    monkeypatch.setattr(users_repo, "list_users", patch_admin["list_users"])
+    monkeypatch.setattr(users_repo, "create_user", patch_admin["create_user"])
+    monkeypatch.setattr(users_repo, "set_role", patch_admin["set_role"])
+    monkeypatch.setattr(users_repo, "delete_user", patch_admin["delete_user"])
+    monkeypatch.setattr(users_repo, "reset_password_to_random", patch_admin["reset_password_to_random"])
+    monkeypatch.setattr(auth_audit_repo, "list_attempts", patch_admin["list_attempts"])
+    # Patch the binding inside admin_users_routes (since it does `from whilly.api import users_repo`,
+    # accessing users_repo.X is attribute lookup on the module, so the above patches DO reach it)
+    app = FastAPI()
+    app.state.pool = object()  # sentinel — never dereferenced because mocks intercept
+    app.include_router(build_admin_users_router(pool=None, secret=_TEST_SECRET))  # type: ignore[arg-type]
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://127.0.0.1:8000") as ac:
+        yield ac
+
+
+# ─── 403 on non-admin ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_admin_users_returns_403_for_operator_role(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An authenticated session with role!=admin → 403 on any /admin/* route."""
+    monkeypatch.setattr(sessions, "verify_session", AsyncMock(return_value=_session(_OPERATOR_EMAIL)))
+    monkeypatch.setattr(
+        users_repo, "get_user_by_username", AsyncMock(return_value=_user(_OPERATOR_USERNAME, "operator"))
+    )
+    app = FastAPI()
+    app.state.pool = object()
+    app.include_router(build_admin_users_router(pool=None, secret=_TEST_SECRET))  # type: ignore[arg-type]
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://127.0.0.1:8000") as ac:
+        resp = await ac.get("/admin/users", cookies={COOKIE_NAME: _mint_cookie(_OPERATOR_EMAIL)})
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_admin_users_returns_401_without_session(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No session at all → 401 (from _authenticate_session)."""
+    monkeypatch.setattr(sessions, "verify_session", AsyncMock(return_value=None))
+    app = FastAPI()
+    app.state.pool = object()
+    app.include_router(build_admin_users_router(pool=None, secret=_TEST_SECRET))  # type: ignore[arg-type]
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://127.0.0.1:8000") as ac:
+        resp = await ac.get("/admin/users")
+    assert resp.status_code == 401
+
+
+# ─── 200 admin paths ────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_admin_can_list_users(client: AsyncClient, patch_admin: dict) -> None:
+    resp = await client.get("/admin/users", cookies={COOKIE_NAME: _mint_cookie()})
+    assert resp.status_code == 200
+    assert _ADMIN_USERNAME in resp.text
+    assert _OPERATOR_USERNAME in resp.text
+    assert patch_admin["list_users"].await_count >= 1
+
+
+@pytest.mark.asyncio
+async def test_admin_can_create_user(client: AsyncClient, patch_admin: dict) -> None:
+    resp = await client.post(
+        "/admin/users/create",
+        cookies={COOKIE_NAME: _mint_cookie()},
+        data={
+            "username": "newguy",
+            "email": "new@example.com",
+            "role": "operator",
+            "initial_password": "tempPW-12chars",
+        },
+    )
+    assert resp.status_code == 200
+    assert patch_admin["create_user"].await_count == 1
+    kwargs = patch_admin["create_user"].await_args.kwargs
+    assert kwargs["username"] == "newguy"
+    assert kwargs["role"] == "operator"
+
+
+@pytest.mark.asyncio
+async def test_admin_create_with_invalid_role_returns_400(client: AsyncClient, patch_admin: dict) -> None:
+    resp = await client.post(
+        "/admin/users/create",
+        cookies={COOKIE_NAME: _mint_cookie()},
+        data={
+            "username": "x",
+            "email": "",
+            "role": "superuser",  # invalid
+            "initial_password": "pw",
+        },
+    )
+    assert resp.status_code == 400
+    assert "invalid role" in resp.text
+    assert patch_admin["create_user"].await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_admin_can_set_role(client: AsyncClient, patch_admin: dict) -> None:
+    resp = await client.post(
+        f"/admin/users/{_OPERATOR_USERNAME}/role",
+        cookies={COOKIE_NAME: _mint_cookie()},
+        data={"role": "admin"},
+    )
+    assert resp.status_code == 200
+    assert patch_admin["set_role"].await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_admin_can_reset_password_and_flash_shows_new_value(client: AsyncClient, patch_admin: dict) -> None:
+    resp = await client.post(
+        f"/admin/users/{_OPERATOR_USERNAME}/reset-password",
+        cookies={COOKIE_NAME: _mint_cookie()},
+    )
+    assert resp.status_code == 200
+    # The flash message exposes the random password ONCE to the admin.
+    assert "rand-pw-abc123" in resp.text
+    assert patch_admin["reset_password_to_random"].await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_admin_can_delete_user(client: AsyncClient, patch_admin: dict) -> None:
+    resp = await client.post(
+        f"/admin/users/{_OPERATOR_USERNAME}/delete",
+        cookies={COOKIE_NAME: _mint_cookie()},
+    )
+    assert resp.status_code == 200
+    assert patch_admin["delete_user"].await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_admin_cannot_delete_self(client: AsyncClient, patch_admin: dict) -> None:
+    """Self-delete is blocked at 400 — no admin can brick the last admin row."""
+    resp = await client.post(
+        f"/admin/users/{_ADMIN_USERNAME}/delete",
+        cookies={COOKIE_NAME: _mint_cookie()},
+    )
+    assert resp.status_code == 400
+    assert "currently signed-in" in resp.text
+    assert patch_admin["delete_user"].await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_admin_delete_second_attempt_returns_404(
+    client: AsyncClient, monkeypatch: pytest.MonkeyPatch, patch_admin: dict
+) -> None:
+    """AC: idempotent — second delete (row gone) → 404 page."""
+    patch_admin["delete_user"].return_value = False
+    monkeypatch.setattr(users_repo, "delete_user", patch_admin["delete_user"])
+    resp = await client.post(
+        f"/admin/users/{_OPERATOR_USERNAME}/delete",
+        cookies={COOKIE_NAME: _mint_cookie()},
+    )
+    assert resp.status_code == 404
+    assert "not found" in resp.text
+
+
+# ─── auth-audit browse ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_admin_auth_audit_renders_empty(client: AsyncClient, patch_admin: dict) -> None:
+    resp = await client.get("/admin/auth-audit", cookies={COOKIE_NAME: _mint_cookie()})
+    assert resp.status_code == 200
+    assert "no audit rows" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_admin_auth_audit_renders_with_filter(client: AsyncClient, patch_admin: dict) -> None:
+    patch_admin["list_attempts"].return_value = [
+        {
+            "id": 1,
+            "ts": datetime.datetime(2026, 5, 18, 12, 0, 0, tzinfo=datetime.timezone.utc),
+            "username": "alice",
+            "ip": "1.2.3.4",
+            "user_agent": "test-agent",
+            "outcome": "ok",
+            "session_id": None,
+        }
+    ]
+    resp = await client.get("/admin/auth-audit?username=alice", cookies={COOKIE_NAME: _mint_cookie()})
+    assert resp.status_code == 200
+    assert "1.2.3.4" in resp.text
+    kwargs = patch_admin["list_attempts"].await_args.kwargs
+    assert kwargs["username_filter"] == "alice"
+    assert kwargs["offset"] == 0  # page=1 → offset=0
+
+
+@pytest.mark.asyncio
+async def test_admin_auth_audit_pagination_passes_offset(client: AsyncClient, patch_admin: dict) -> None:
+    resp = await client.get("/admin/auth-audit?page=3", cookies={COOKIE_NAME: _mint_cookie()})
+    assert resp.status_code == 200
+    kwargs = patch_admin["list_attempts"].await_args.kwargs
+    assert kwargs["offset"] == 100  # page=3 with page_size=50 → offset=100
+    assert kwargs["limit"] == 50

--- a/whilly/adapters/transport/server.py
+++ b/whilly/adapters/transport/server.py
@@ -1351,6 +1351,7 @@ def create_app(
         # operators expect them there, no reason to relocate.
     )
     from whilly.api import rate_limit as _rate_limit
+    from whilly.api.admin_users_routes import build_admin_users_router
     from whilly.api.auth_routes import build_auth_router
     from whilly.api.csrf import WhillySessionCSRFMiddleware
     from whilly.api.dashboard import FileLogStore
@@ -1367,6 +1368,11 @@ def create_app(
 
     mount_static_assets(app)
     app.state.log_store = FileLogStore(Path("whilly_logs"))
+    # PRD-post-auth-hardening §Epic D Item 10 — admin_users_routes reads the
+    # pool from app.state.pool because the routes are factory-bound (cannot
+    # depend on a closure-captured pool when the same instance must also be
+    # accessible to the helper render functions).
+    app.state.pool = pool
     instrument_app(app)
 
     # PRD-post-auth-hardening §Epic C, Item 6: the must-change-password
@@ -1406,6 +1412,12 @@ def create_app(
     # session-only CRUD surface so a single key governs the whole UI.
     app.include_router(
         build_tasks_crud_router(pool=pool, secret=dashboard_token_secret),
+    )
+    # PRD-post-auth-hardening §Epic D Item 10 — admin user management +
+    # auth-audit browse. Role guard (require_admin_role) rejects any
+    # non-admin session with 403 before the route body runs.
+    app.include_router(
+        build_admin_users_router(pool=pool, secret=dashboard_token_secret),
     )
 
     async def _probe_pool() -> tuple[bool, str | None]:

--- a/whilly/api/admin_users_routes.py
+++ b/whilly/api/admin_users_routes.py
@@ -1,0 +1,258 @@
+"""Admin user-management UI (PRD-post-auth-hardening §Epic D, Item 10).
+
+Two surfaces under ``/admin/``:
+
+1. ``/admin/users`` — CRUD on the ``users`` table:
+   * ``GET /admin/users``                          — list + create form
+   * ``POST /admin/users/create``                  — create with must_change_password=TRUE
+   * ``POST /admin/users/{username}/role``         — set role
+   * ``POST /admin/users/{username}/reset-password`` — generate random pw + must_change=TRUE
+   * ``POST /admin/users/{username}/delete``       — drop the row (idempotent → 404 on second)
+
+2. ``/admin/auth-audit`` — paginated browse of the ``auth_audit`` ledger
+   (50 rows/page; supports ``?username=X`` filter).
+
+All routes are gated by :func:`require_admin_role` — a tiny FastAPI
+dependency that calls :func:`whilly.api.auth_routes._authenticate_session`,
+looks up the principal's user row, and returns 403 when the role is
+anything other than ``"admin"``. PRD nominated putting this in
+``sessions.py`` but that module is pure-asyncpg (no FastAPI imports);
+keeping the guard here co-locates it with its only call sites.
+
+Anti-privilege-escalation guard: the create and role-change paths refuse
+to set ``role="admin"`` from anywhere except an existing admin (enforced
+implicitly because every route is gated by :func:`require_admin_role`).
+The delete path refuses to drop the currently-signed-in user — otherwise
+an admin could brick the only admin account.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Final
+
+import asyncpg
+from fastapi import APIRouter, Depends, Form, HTTPException, Query, Request, status
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+
+from whilly.api import auth_audit_repo, users_repo
+from whilly.api.auth_routes import (
+    DEFAULT_SESSION_COOKIE_NAME,
+    TEMPLATES_DIR,
+    _authenticate_session,
+)
+
+logger = logging.getLogger(__name__)
+
+ADMIN_USERS_TEMPLATE: Final[str] = "admin_users.html.j2"
+ADMIN_AUTH_AUDIT_TEMPLATE: Final[str] = "admin_auth_audit.html.j2"
+
+_VALID_ROLES: Final[tuple[str, ...]] = ("operator", "admin", "readonly")
+_PAGE_SIZE: Final[int] = 50
+
+
+def require_admin_role(*, pool: asyncpg.Pool, secret: bytes, cookie_name: str) -> object:
+    """Build a FastAPI dependency that 403s any non-admin.
+
+    Factory pattern matches :func:`whilly.api.auth_routes.build_auth_router`
+    so the closure carries ``pool``/``secret``/``cookie_name`` once and the
+    routes don't need to re-Depend on them. Returns the dependency callable,
+    intended to be wrapped in :class:`fastapi.Depends` at the route level.
+    """
+
+    async def _dep(request: Request) -> dict[str, object]:
+        try:
+            principal = await _authenticate_session(request, pool=pool, secret=secret, cookie_name=cookie_name)
+        except HTTPException as exc:
+            # Re-raise — 401 from the auth helper is correct for missing session.
+            raise exc
+        session_email = str(principal.get("email", ""))
+        username = session_email.removesuffix("@local") if session_email.endswith("@local") else session_email
+        user = await users_repo.get_user_by_username(pool, username=username) if username else None
+        if user is None or user.role != "admin":
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="admin role required",
+            )
+        principal["username"] = user.username
+        principal["role"] = user.role
+        return principal
+
+    return _dep
+
+
+def build_admin_users_router(
+    *,
+    pool: asyncpg.Pool,
+    secret: bytes,
+    cookie_name: str = DEFAULT_SESSION_COOKIE_NAME,
+) -> APIRouter:
+    """Construct the admin router. See module docstring for the surface."""
+    templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
+    router = APIRouter(tags=["admin"])
+    admin_dep = Depends(require_admin_role(pool=pool, secret=secret, cookie_name=cookie_name))
+
+    @router.get("/admin/users", response_class=HTMLResponse, include_in_schema=False)
+    async def list_users_view(request: Request, principal: dict = admin_dep) -> HTMLResponse:
+        users = await users_repo.list_users(pool)
+        return templates.TemplateResponse(
+            request,
+            ADMIN_USERS_TEMPLATE,
+            {"users": users, "current_user": principal.get("username"), "form_error": None, "flash": None},
+        )
+
+    @router.post("/admin/users/create", response_class=HTMLResponse)
+    async def create_user_view(
+        request: Request,
+        username: str = Form(..., min_length=1, max_length=64),
+        email: str = Form(default="", max_length=320),
+        role: str = Form(..., min_length=1, max_length=16),
+        initial_password: str = Form(..., min_length=1, max_length=512),
+        principal: dict = admin_dep,
+    ) -> HTMLResponse:
+        if role not in _VALID_ROLES:
+            return await _render_with_error(request, templates, principal, f"invalid role {role!r}", status_code=400)
+        try:
+            await users_repo.create_user(
+                pool,
+                username=username,
+                initial_password=initial_password,
+                email=email or None,
+                role=role,
+            )
+        except ValueError as exc:
+            return await _render_with_error(request, templates, principal, str(exc), status_code=400)
+        logger.info("admin.users.create: %r by %r", username, principal.get("username"))
+        return await _render_users(request, templates, principal, flash=f"created user {username!r}")
+
+    @router.post("/admin/users/{username}/role", response_class=HTMLResponse)
+    async def set_role_view(
+        request: Request,
+        username: str,
+        role: str = Form(..., min_length=1, max_length=16),
+        principal: dict = admin_dep,
+    ) -> HTMLResponse:
+        if role not in _VALID_ROLES:
+            return await _render_with_error(request, templates, principal, f"invalid role {role!r}", status_code=400)
+        try:
+            await users_repo.set_role(pool, username=username, role=role)
+        except (LookupError, ValueError) as exc:
+            return await _render_with_error(request, templates, principal, str(exc), status_code=400)
+        logger.info("admin.users.set_role: %r→%r by %r", username, role, principal.get("username"))
+        return await _render_users(request, templates, principal, flash=f"role of {username!r} → {role}")
+
+    @router.post("/admin/users/{username}/reset-password", response_class=HTMLResponse)
+    async def reset_password_view(request: Request, username: str, principal: dict = admin_dep) -> HTMLResponse:
+        try:
+            new_password = await users_repo.reset_password_to_random(pool, username=username)
+        except LookupError as exc:
+            return await _render_with_error(request, templates, principal, str(exc), status_code=404)
+        logger.info(
+            "admin.users.reset_password: %r by %r (must_change_password=TRUE)",
+            username,
+            principal.get("username"),
+        )
+        flash = (
+            f"reset password for {username!r}. Communicate this value to the user — "
+            f"it will not be shown again: {new_password}"
+        )
+        return await _render_users(request, templates, principal, flash=flash)
+
+    @router.post("/admin/users/{username}/delete", response_class=HTMLResponse)
+    async def delete_user_view(request: Request, username: str, principal: dict = admin_dep) -> HTMLResponse:
+        # Self-deletion guard — never let an admin brick the only admin row.
+        if username.strip().lower() == str(principal.get("username", "")).strip().lower():
+            return await _render_with_error(
+                request, templates, principal, "cannot delete the currently signed-in user", status_code=400
+            )
+        deleted = await users_repo.delete_user(pool, username=username)
+        if not deleted:
+            # Idempotent contract per AC: second delete returns 404 (rendered as
+            # an HTMLResponse with a 404 status, not raised — the admin UI is a
+            # browser surface, raising would dump a stack-trace page).
+            return await _render_with_error(
+                request, templates, principal, f"user {username!r} not found", status_code=404
+            )
+        logger.info("admin.users.delete: %r by %r", username, principal.get("username"))
+        return await _render_users(request, templates, principal, flash=f"deleted user {username!r}")
+
+    @router.get("/admin/auth-audit", response_class=HTMLResponse, include_in_schema=False)
+    async def auth_audit_view(
+        request: Request,
+        page: int = Query(default=1, ge=1, le=10_000),
+        username: str | None = Query(default=None, max_length=64),
+        principal: dict = admin_dep,
+    ) -> HTMLResponse:
+        offset = (page - 1) * _PAGE_SIZE
+        rows = await auth_audit_repo.list_attempts(pool, limit=_PAGE_SIZE, offset=offset, username_filter=username)
+        return templates.TemplateResponse(
+            request,
+            ADMIN_AUTH_AUDIT_TEMPLATE,
+            {
+                "rows": rows,
+                "page": page,
+                "page_size": _PAGE_SIZE,
+                "username_filter": username,
+                "has_next": len(rows) == _PAGE_SIZE,
+                "current_user": principal.get("username"),
+            },
+        )
+
+    return router
+
+
+async def _render_users(
+    request: Request, templates: Jinja2Templates, principal: dict, *, flash: str | None
+) -> HTMLResponse:
+    users = await users_repo.list_users(_get_pool_from_principal_or_request(principal, request))
+    return templates.TemplateResponse(
+        request,
+        ADMIN_USERS_TEMPLATE,
+        {"users": users, "current_user": principal.get("username"), "form_error": None, "flash": flash},
+    )
+
+
+async def _render_with_error(
+    request: Request,
+    templates: Jinja2Templates,
+    principal: dict,
+    msg: str,
+    *,
+    status_code: int,
+) -> HTMLResponse:
+    users = await users_repo.list_users(_get_pool_from_principal_or_request(principal, request))
+    return templates.TemplateResponse(
+        request,
+        ADMIN_USERS_TEMPLATE,
+        {"users": users, "current_user": principal.get("username"), "form_error": msg, "flash": None},
+        status_code=status_code,
+    )
+
+
+def _get_pool_from_principal_or_request(principal: dict, request: Request) -> asyncpg.Pool:
+    """Recover the asyncpg pool from request.app.state or principal closure.
+
+    The principal dict doesn't carry the pool (it shouldn't — that would leak
+    a DB handle into route bodies), but the FastAPI app's state has it.
+    Falling back to None if neither is wired up would be a bug — fail fast.
+    """
+    pool = getattr(request.app.state, "pool", None)
+    if pool is None:
+        # The principal closure carries the pool reference indirectly via the
+        # require_admin_role factory — in production the app sets app.state.pool
+        # in create_app. If a test omits this, we surface a clear error.
+        raise RuntimeError(
+            "admin_users_routes: request.app.state.pool is not set; "
+            "create_app must call `app.state.pool = pool` before include_router."
+        )
+    return pool
+
+
+# Re-exports — tests / wiring code grab these by name.
+__all__ = [
+    "ADMIN_AUTH_AUDIT_TEMPLATE",
+    "ADMIN_USERS_TEMPLATE",
+    "build_admin_users_router",
+    "require_admin_role",
+]

--- a/whilly/api/auth_audit_repo.py
+++ b/whilly/api/auth_audit_repo.py
@@ -111,8 +111,49 @@ async def insert_attempt(
         return
 
 
+async def list_attempts(
+    pool: asyncpg.Pool,
+    *,
+    limit: int = 50,
+    offset: int = 0,
+    username_filter: str | None = None,
+) -> list[dict[str, object]]:
+    """Read paginated audit rows for the admin browse page.
+
+    Uses the indexes created in migration 025: ``ix_auth_audit_ts`` for the
+    default recent-first order, ``ix_auth_audit_username_ts`` (partial on
+    ``username IS NOT NULL``) when ``username_filter`` is supplied.
+
+    Returns a list of dicts (one per row) rather than a typed dataclass to
+    keep the Jinja2 render straightforward.
+    """
+    limit = max(1, min(int(limit), 500))
+    offset = max(0, int(offset))
+    if username_filter:
+        sql = """
+            SELECT id, ts, username, ip, user_agent, outcome, session_id
+            FROM auth_audit
+            WHERE username = $1
+            ORDER BY ts DESC
+            LIMIT $2 OFFSET $3
+        """
+        args: tuple[object, ...] = (username_filter.strip().lower(), limit, offset)
+    else:
+        sql = """
+            SELECT id, ts, username, ip, user_agent, outcome, session_id
+            FROM auth_audit
+            ORDER BY ts DESC
+            LIMIT $1 OFFSET $2
+        """
+        args = (limit, offset)
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(sql, *args)
+    return [dict(r) for r in rows]
+
+
 __all__ = [
     "AUTH_AUDIT_OUTCOMES",
     "AuthAuditOutcome",
     "insert_attempt",
+    "list_attempts",
 ]

--- a/whilly/api/templates/admin_auth_audit.html.j2
+++ b/whilly/api/templates/admin_auth_audit.html.j2
@@ -1,0 +1,66 @@
+<!doctype html>
+<html lang="en" data-theme="dark">
+<head>
+  <meta charset="utf-8" />
+  <title>Auth audit log — Whilly admin</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" href="/static/whilly-design.css">
+  <link rel="stylesheet" href="/static/whilly-app.css">
+  <style>
+    body { padding: 24px; max-width: 1200px; margin: 0 auto; }
+    .audit-title { color: var(--accent); font: 700 var(--t-body)/var(--lh-tight) var(--font-mono); margin: 0 0 16px; }
+    .audit-controls { margin-bottom: 16px; font: var(--t-sm)/var(--lh-body) var(--font-mono); }
+    .audit-controls input { background: var(--bg); color: var(--text); border: 1px solid var(--line-strong); padding: 4px 8px; font: inherit; }
+    .audit-controls button { background: transparent; color: var(--accent); border: 1px solid var(--accent); padding: 4px 12px; font: inherit; cursor: pointer; }
+    .audit-table { width: 100%; border-collapse: collapse; font: var(--t-sm)/var(--lh-body) var(--font-mono); }
+    .audit-table th, .audit-table td { padding: 4px 8px; border-bottom: 1px solid var(--line); text-align: left; vertical-align: top; }
+    .audit-table th { color: var(--muted); font-weight: 700; }
+    .outcome-ok { color: var(--accent); }
+    .outcome-bad_password, .outcome-locked, .outcome-rate_limited, .outcome-missing_user { color: var(--danger); }
+    .audit-pager { margin-top: 16px; font: var(--t-sm)/var(--lh-body) var(--font-mono); }
+    .audit-pager a { color: var(--accent); text-decoration: none; padding: 4px 8px; border: 1px solid var(--line-strong); }
+  </style>
+</head>
+<body>
+  <h1 class="audit-title">Auth audit log</h1>
+  <p style="color: var(--muted); font: var(--t-sm)/var(--lh-body) var(--font-mono);">
+    Signed in as <strong>{{ current_user }}</strong>. <a href="/admin/users" style="color: var(--accent);">back to user management</a>
+  </p>
+
+  <form class="audit-controls" method="get" action="/admin/auth-audit">
+    <input type="text" name="username" value="{{ username_filter or '' }}" placeholder="filter by username..." />
+    <button type="submit">filter</button>
+    {% if username_filter %}<a href="/admin/auth-audit" style="margin-left: 8px; color: var(--muted);">clear filter</a>{% endif %}
+  </form>
+
+  <table class="audit-table">
+    <thead>
+      <tr>
+        <th>id</th><th>ts</th><th>username</th><th>ip</th>
+        <th>user_agent</th><th>outcome</th><th>session_id</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for r in rows %}
+      <tr>
+        <td>{{ r.id }}</td>
+        <td>{{ r.ts.strftime("%Y-%m-%d %H:%M:%S") if r.ts else "—" }}</td>
+        <td>{{ r.username or "—" }}</td>
+        <td>{{ r.ip or "—" }}</td>
+        <td>{{ (r.user_agent or "—")[:60] }}</td>
+        <td class="outcome-{{ r.outcome }}">{{ r.outcome }}</td>
+        <td>{{ (r.session_id|string)[:8] if r.session_id else "—" }}</td>
+      </tr>
+      {% else %}
+      <tr><td colspan="7" style="color: var(--muted); text-align: center; padding: 16px;">no audit rows</td></tr>
+      {% endfor %}
+    </tbody>
+  </table>
+
+  <div class="audit-pager">
+    page {{ page }} ({{ rows|length }} rows · {{ page_size }} per page)
+    {% if page > 1 %}<a href="/admin/auth-audit?page={{ page - 1 }}{% if username_filter %}&username={{ username_filter }}{% endif %}">&laquo; prev</a>{% endif %}
+    {% if has_next %}<a href="/admin/auth-audit?page={{ page + 1 }}{% if username_filter %}&username={{ username_filter }}{% endif %}">next &raquo;</a>{% endif %}
+  </div>
+</body>
+</html>

--- a/whilly/api/templates/admin_users.html.j2
+++ b/whilly/api/templates/admin_users.html.j2
@@ -1,0 +1,113 @@
+<!doctype html>
+<html lang="en" data-theme="dark">
+<head>
+  <meta charset="utf-8" />
+  <title>User management — Whilly admin</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" href="/static/whilly-design.css">
+  <link rel="stylesheet" href="/static/whilly-app.css">
+  <style>
+    body { padding: 24px; max-width: 1100px; margin: 0 auto; }
+    .admin-frame { border: 1px solid var(--line-strong); padding: 16px; margin-bottom: 24px; background: var(--surface); }
+    .admin-title { color: var(--accent); margin: 0 0 12px; font: 700 var(--t-body)/var(--lh-tight) var(--font-mono); }
+    .admin-table { width: 100%; border-collapse: collapse; font: var(--t-sm)/var(--lh-body) var(--font-mono); }
+    .admin-table th, .admin-table td { padding: 6px 8px; border-bottom: 1px solid var(--line); text-align: left; }
+    .admin-table th { color: var(--muted); font-weight: 700; }
+    .admin-table .role-admin { color: var(--accent); font-weight: 700; }
+    .admin-row form { display: inline; }
+    .admin-row button {
+      background: transparent; border: 1px solid var(--line-strong); color: var(--text);
+      padding: 2px 8px; cursor: pointer; font: inherit;
+    }
+    .admin-row button:hover { background: var(--accent); color: var(--bg); }
+    .admin-row select, .admin-row input { background: var(--bg); color: var(--text); border: 1px solid var(--line-strong); padding: 2px 4px; font: inherit; }
+    .admin-flash, .admin-error {
+      padding: 8px 12px; margin-bottom: 12px;
+      font: var(--t-sm)/var(--lh-body) var(--font-mono);
+    }
+    .admin-flash { border: 1px solid var(--accent); color: var(--accent); }
+    .admin-error { border: 1px solid var(--danger); color: var(--danger); }
+    .admin-create label { display: block; margin-bottom: 4px; color: var(--muted); }
+    .admin-create input, .admin-create select { display: block; margin-bottom: 8px; padding: 4px 8px; background: var(--bg); color: var(--text); border: 1px solid var(--line-strong); font: var(--t-body)/var(--lh-body) var(--font-mono); }
+    .admin-create button {
+      background: transparent; color: var(--accent); border: 1px solid var(--accent);
+      padding: 4px 16px; font: 700 var(--t-body)/var(--lh-body) var(--font-mono); cursor: pointer;
+    }
+  </style>
+</head>
+<body>
+  <h1 class="admin-title">User management</h1>
+  <p style="color: var(--muted); font: var(--t-sm)/var(--lh-body) var(--font-mono);">
+    Signed in as <strong>{{ current_user }}</strong> (admin). <a href="/me/password" style="color: var(--accent);">change own password</a>
+    &middot; <a href="/admin/auth-audit" style="color: var(--accent);">view auth audit log</a>
+  </p>
+
+  {% if flash %}<div class="admin-flash" role="status">{{ flash }}</div>{% endif %}
+  {% if form_error %}<div class="admin-error" role="alert">{{ form_error }}</div>{% endif %}
+
+  <div class="admin-frame">
+    <h2 class="admin-title">existing users ({{ users|length }})</h2>
+    <table class="admin-table">
+      <thead>
+        <tr>
+          <th>username</th><th>email</th><th>role</th><th>created</th>
+          <th>last login</th><th>must change</th><th>actions</th>
+        </tr>
+      </thead>
+      <tbody>
+      {% for u in users %}
+        <tr class="admin-row">
+          <td>{{ u.username }}</td>
+          <td>{{ u.email or "—" }}</td>
+          <td class="{% if u.role == 'admin' %}role-admin{% endif %}">{{ u.role }}</td>
+          <td>{{ u.created_at.strftime("%Y-%m-%d %H:%M") if u.created_at else "—" }}</td>
+          <td>{{ u.last_login_at.strftime("%Y-%m-%d %H:%M") if u.last_login_at else "—" }}</td>
+          <td>{{ "yes" if u.must_change_password else "no" }}</td>
+          <td>
+            <form method="post" action="/admin/users/{{ u.username }}/role">
+              <select name="role">
+                <option value="operator" {% if u.role == 'operator' %}selected{% endif %}>operator</option>
+                <option value="admin" {% if u.role == 'admin' %}selected{% endif %}>admin</option>
+                <option value="readonly" {% if u.role == 'readonly' %}selected{% endif %}>readonly</option>
+              </select>
+              <button type="submit">set role</button>
+            </form>
+            <form method="post" action="/admin/users/{{ u.username }}/reset-password">
+              <button type="submit">reset pw</button>
+            </form>
+            {% if u.username != current_user %}
+            <form method="post" action="/admin/users/{{ u.username }}/delete">
+              <button type="submit">delete</button>
+            </form>
+            {% endif %}
+          </td>
+        </tr>
+      {% endfor %}
+      </tbody>
+    </table>
+  </div>
+
+  <div class="admin-frame admin-create">
+    <h2 class="admin-title">create new user</h2>
+    <form method="post" action="/admin/users/create">
+      <label>username
+        <input type="text" name="username" required minlength="1" maxlength="64" pattern="[a-z0-9][a-z0-9_-]{0,63}" />
+      </label>
+      <label>email (optional)
+        <input type="email" name="email" maxlength="320" />
+      </label>
+      <label>role
+        <select name="role" required>
+          <option value="operator" selected>operator</option>
+          <option value="admin">admin</option>
+          <option value="readonly">readonly</option>
+        </select>
+      </label>
+      <label>initial password (user will be forced to change on first login)
+        <input type="text" name="initial_password" required minlength="1" maxlength="512" />
+      </label>
+      <button type="submit">[ create user ]</button>
+    </form>
+  </div>
+</body>
+</html>

--- a/whilly/api/users_repo.py
+++ b/whilly/api/users_repo.py
@@ -231,10 +231,133 @@ async def set_password(pool: asyncpg.Pool, *, username: str, new_password: str) 
         raise LookupError(f"set_password: no user found with username={normalised!r}")
 
 
+async def list_users(pool: asyncpg.Pool) -> list[User]:
+    """Return every row from ``users`` ordered by ``username`` (admin UI list)."""
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            "SELECT username, email, role, created_at, last_login_at, must_change_password FROM users ORDER BY username"
+        )
+    return [
+        User(
+            username=r["username"],
+            email=r["email"],
+            role=r["role"],
+            created_at=r["created_at"],
+            last_login_at=r["last_login_at"],
+            must_change_password=bool(r["must_change_password"]),
+        )
+        for r in rows
+    ]
+
+
+async def create_user(
+    pool: asyncpg.Pool,
+    *,
+    username: str,
+    initial_password: str,
+    email: str | None = None,
+    role: str = "operator",
+) -> None:
+    """Insert a new user with ``must_change_password=TRUE``.
+
+    Raises :class:`ValueError` if the username already exists (UniqueViolationError
+    is translated for callers that don't want to depend on asyncpg's exception
+    hierarchy).
+    """
+    if not isinstance(username, str) or not username.strip():
+        raise ValueError("create_user: username must be a non-empty string")
+    if not isinstance(initial_password, str) or not initial_password:
+        raise ValueError("create_user: initial_password must be a non-empty string")
+    if role not in ("operator", "admin", "readonly"):
+        raise ValueError(f"create_user: invalid role {role!r}")
+    normalised = username.strip().lower()
+    salt_hex, hash_hex = hash_password(initial_password)
+    async with pool.acquire() as conn:
+        try:
+            await conn.execute(
+                """
+                INSERT INTO users (username, password_hash, password_salt, email, role, must_change_password)
+                VALUES ($1, $2, $3, $4, $5, TRUE)
+                """,
+                normalised,
+                hash_hex,
+                salt_hex,
+                (email or None),
+                role,
+            )
+        except asyncpg.exceptions.UniqueViolationError as exc:
+            raise ValueError(f"create_user: username {normalised!r} already exists") from exc
+
+
+async def set_role(pool: asyncpg.Pool, *, username: str, role: str) -> None:
+    """Update ``users.role``. Raises :class:`LookupError` when no row matches."""
+    if role not in ("operator", "admin", "readonly"):
+        raise ValueError(f"set_role: invalid role {role!r}")
+    normalised = username.strip().lower()
+    async with pool.acquire() as conn:
+        result = await conn.execute(
+            "UPDATE users SET role = $1, updated_at = NOW() WHERE username = $2",
+            role,
+            normalised,
+        )
+    if int((result or "UPDATE 0").split()[-1]) == 0:
+        raise LookupError(f"set_role: no user found with username={normalised!r}")
+
+
+async def delete_user(pool: asyncpg.Pool, *, username: str) -> bool:
+    """Drop a user row. Returns True if a row was deleted, False if absent.
+
+    Returning a boolean (vs raising) lets the admin route give a clean 404
+    on the second delete attempt without try/except gymnastics.
+    """
+    normalised = username.strip().lower()
+    async with pool.acquire() as conn:
+        result = await conn.execute("DELETE FROM users WHERE username = $1", normalised)
+    return int((result or "DELETE 0").split()[-1]) > 0
+
+
+async def reset_password_to_random(pool: asyncpg.Pool, *, username: str) -> str:
+    """Generate a random URL-safe password, store it, set must_change_password=TRUE.
+
+    Returns the plaintext password so the admin UI can display it ONCE for
+    the operator to communicate to the user out-of-band. The user will be
+    forced to change it on their next login by the must-change gate.
+    """
+    import secrets
+
+    new_password = secrets.token_urlsafe(16)
+    salt_hex, hash_hex = hash_password(new_password)
+    normalised = username.strip().lower()
+    async with pool.acquire() as conn:
+        result = await conn.execute(
+            """
+            UPDATE users
+               SET password_hash        = $1,
+                   password_salt        = $2,
+                   must_change_password = TRUE,
+                   failed_attempts      = 0,
+                   locked_until         = NULL,
+                   updated_at           = NOW()
+             WHERE username = $3
+            """,
+            hash_hex,
+            salt_hex,
+            normalised,
+        )
+    if int((result or "UPDATE 0").split()[-1]) == 0:
+        raise LookupError(f"reset_password_to_random: no user found with username={normalised!r}")
+    return new_password
+
+
 __all__ = [
     "User",
+    "create_user",
+    "delete_user",
     "get_user_by_username",
+    "list_users",
+    "reset_password_to_random",
     "set_password",
+    "set_role",
     "update_last_login",
     "verify_credentials",
 ]

--- a/whilly/operator_views.py
+++ b/whilly/operator_views.py
@@ -194,6 +194,8 @@ OPERATOR_WUI_ARTIFACTS: Final[tuple[OperatorUiArtifact, ...]] = (
     OperatorUiArtifact("whilly/api/templates/login_consumed.html.j2", OperatorUiArtifactStatus.ACTIVE),
     OperatorUiArtifact("whilly/api/templates/password_change.html.j2", OperatorUiArtifactStatus.ACTIVE),
     OperatorUiArtifact("whilly/api/templates/me_password.html.j2", OperatorUiArtifactStatus.ACTIVE),
+    OperatorUiArtifact("whilly/api/templates/admin_users.html.j2", OperatorUiArtifactStatus.ACTIVE),
+    OperatorUiArtifact("whilly/api/templates/admin_auth_audit.html.j2", OperatorUiArtifactStatus.ACTIVE),
     OperatorUiArtifact(
         "whilly/api/templates/_logs.html",
         OperatorUiArtifactStatus.ROUTEABLE_NONCANONICAL,


### PR DESCRIPTION
Closes PRD-post-auth-hardening §Epic D, Item 10. New `whilly/api/admin_users_routes.py` with 6 routes (user CRUD + audit browse), `require_admin_role` guard (403 on non-admin), 5 new `users_repo` functions, `auth_audit_repo.list_attempts` with paginated/filtered query using migration 025 indexes, 2 new Jinja templates registered in WUI artifacts. Self-deletion blocked; delete idempotent; admin browse paginated 50/page with `?username=X` filter. 13 unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)