### PR TITLE
feat(auth): E16 — /me/sessions list + revoke routes

### DIFF
--- a/.planning/post-auth-hardening-tasks.json
+++ b/.planning/post-auth-hardening-tasks.json
@@ -415,16 +415,20 @@
     },
     {
       "id": "E16-active-sessions-ui",
-      "status": "pending",
+      "status": "done",
       "priority": "low",
       "dependencies": [
         "A0-ci-restoration",
         "D9-self-service-password-change"
       ],
       "key_files": [
-        "whilly/api/auth_routes.py"
+        "whilly/api/auth_routes.py",
+        "whilly/api/sessions.py",
+        "whilly/api/templates/me_sessions.html.j2",
+        "whilly/operator_views.py",
+        "tests/unit/test_me_sessions_routes.py"
       ],
-      "description": "PRD §Epic E, Item 16 — add GET /me/sessions (list rows from sessions table filtered by user) and POST /me/sessions/{session_id}/revoke (delete the row). Template whilly/templates/me_sessions.html shows device user-agent, IP, last-seen timestamp, and a Revoke button. Revoking the current session redirects to /login.",
+      "description": "DONE 2026-05-18: GET /me/sessions + POST /me/sessions/{id}/revoke added to auth_routes.build_auth_router. sessions.list_active_sessions_for_email new helper queries the table filtered by principal email + non-revoked + non-expired. Template me_sessions.html.j2 renders session_id prefix + created/last_seen/expires (sessions schema has no ip/user_agent columns — PRD prose mentioned them but they're not present; gap noted in code). Defence-in-depth: revoke checks target session.email == principal email so an authenticated user cannot revoke another user's session by guessing the session_id. Revoking the CURRENT session clears the cookie and 303s to /login (matches /auth/logout pattern); revoking another device keeps user signed in with a flash. 6 unit tests cover unauth-redirect, list-renders-with-current-tag, other-revoke-keeps-signed-in, current-revoke-clears-cookie-303-to-login, foreign-session-404 (privilege escalation guard), nonexistent-session-404. Template registered in OPERATOR_WUI_ARTIFACTS. Original: PRD §Epic E, Item 16 — add GET /me/sessions (list rows from sessions table filtered by user) and POST /me/sessions/{session_id}/revoke (delete the row). Template whilly/templates/me_sessions.html shows device user-agent, IP, last-seen timestamp, and a Revoke button. Revoking the current session redirects to /login.",
       "acceptance_criteria": [
         "Revoking a session ID makes the corresponding cookie return 401 on next use",
         "GET /me/sessions returns 200 with a list of sessions for the authenticated user",

--- a/tests/unit/test_me_sessions_routes.py
+++ b/tests/unit/test_me_sessions_routes.py
@@ -1,0 +1,149 @@
+"""Unit tests for the active-sessions UI (PRD §Epic E Item 16)."""
+
+from __future__ import annotations
+
+import datetime
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from whilly.api import auth_tokens, sessions
+from whilly.api.auth_routes import build_auth_router
+from whilly.api.csrf import COOKIE_NAME
+
+_TEST_SECRET: bytes = b"e16-test-secret-32-bytes-paddxxx"
+_TEST_SESSION_ID: str = "e16-session-id-current"
+_OTHER_SESSION_ID: str = "e16-session-id-other"
+_FOREIGN_SESSION_ID: str = "e16-session-id-foreign"
+_EMAIL: str = "alice@local"
+_FOREIGN_EMAIL: str = "bob@local"
+
+
+def _session(session_id: str = _TEST_SESSION_ID, email: str = _EMAIL) -> Any:
+    class _S:
+        def __init__(self) -> None:
+            self.session_id = session_id
+            self.email = email
+            self.created_at = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(hours=1)
+            self.last_seen_at = datetime.datetime.now(datetime.timezone.utc)
+            self.expires_at = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(hours=24)
+            self.revoked_at = None
+
+    return _S()
+
+
+def _mint(session_id: str = _TEST_SESSION_ID, email: str = _EMAIL) -> str:
+    return auth_tokens.mint_session_cookie_value(_TEST_SECRET, session_id=session_id, email=email, ttl_seconds=3600)
+
+
+@pytest.fixture
+async def client(monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[AsyncClient]:
+    # By default, verify_session returns the principal session
+    monkeypatch.setattr(sessions, "verify_session", AsyncMock(return_value=_session()))
+    monkeypatch.setattr(
+        sessions,
+        "list_active_sessions_for_email",
+        AsyncMock(return_value=[_session(), _session(_OTHER_SESSION_ID)]),
+    )
+    monkeypatch.setattr(sessions, "revoke_session", AsyncMock(return_value=True))
+    app = FastAPI()
+    app.include_router(build_auth_router(pool=None, secret=_TEST_SECRET))  # type: ignore[arg-type]
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://127.0.0.1:8000") as ac:
+        yield ac
+
+
+@pytest.mark.asyncio
+async def test_get_me_sessions_unauthenticated_redirects_to_login(
+    client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(sessions, "verify_session", AsyncMock(return_value=None))
+    resp = await client.get("/me/sessions", follow_redirects=False)
+    assert resp.status_code == 303
+    assert resp.headers["location"] == "/login"
+
+
+@pytest.mark.asyncio
+async def test_get_me_sessions_lists_user_sessions(client: AsyncClient) -> None:
+    resp = await client.get("/me/sessions", cookies={COOKIE_NAME: _mint()})
+    assert resp.status_code == 200
+    assert _TEST_SESSION_ID[:12] in resp.text
+    assert _OTHER_SESSION_ID[:12] in resp.text
+    assert "this device" in resp.text  # current-session tag
+
+
+@pytest.mark.asyncio
+async def test_revoke_other_session_keeps_user_signed_in(client: AsyncClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Revoking a non-current session re-renders the page with a flash;
+    the user is NOT logged out.
+    """
+    # verify_session is called TWICE: once for principal auth, once for target lookup.
+    # Make both return successfully (principal current, target = the other session).
+    seq = [_session(_TEST_SESSION_ID), _session(_OTHER_SESSION_ID)]
+    monkeypatch.setattr(sessions, "verify_session", AsyncMock(side_effect=seq))
+    monkeypatch.setattr(
+        sessions, "list_active_sessions_for_email", AsyncMock(return_value=[_session(_TEST_SESSION_ID)])
+    )
+    resp = await client.post(
+        f"/me/sessions/{_OTHER_SESSION_ID}/revoke",
+        cookies={COOKIE_NAME: _mint()},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 200
+    assert "revoked" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_revoke_current_session_clears_cookie_and_redirects_to_login(
+    client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Revoking the CURRENT session → 303 to /login + cookie deletion."""
+    # principal auth + target lookup both return the same session_id.
+    seq = [_session(_TEST_SESSION_ID), _session(_TEST_SESSION_ID)]
+    monkeypatch.setattr(sessions, "verify_session", AsyncMock(side_effect=seq))
+    resp = await client.post(
+        f"/me/sessions/{_TEST_SESSION_ID}/revoke",
+        cookies={COOKIE_NAME: _mint()},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+    assert resp.headers["location"] == "/login"
+    # Cookie deletion: Set-Cookie with Max-Age=0 or expires=epoch.
+    set_cookie = resp.headers.get("set-cookie", "")
+    assert "whilly_session=" in set_cookie
+    assert "Max-Age=0" in set_cookie or "expires=Thu, 01 Jan 1970" in set_cookie
+
+
+@pytest.mark.asyncio
+async def test_revoke_foreign_session_returns_404(client: AsyncClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Authenticated as alice, attempting to revoke bob's session → 404.
+
+    Defends against session-id-guessing privilege escalation.
+    """
+    seq = [_session(_TEST_SESSION_ID, _EMAIL), _session(_FOREIGN_SESSION_ID, _FOREIGN_EMAIL)]
+    monkeypatch.setattr(sessions, "verify_session", AsyncMock(side_effect=seq))
+    revoke_mock = AsyncMock(return_value=True)
+    monkeypatch.setattr(sessions, "revoke_session", revoke_mock)
+    resp = await client.post(
+        f"/me/sessions/{_FOREIGN_SESSION_ID}/revoke",
+        cookies={COOKIE_NAME: _mint()},
+    )
+    assert resp.status_code == 404
+    # Critical: revoke_session must NOT have been called.
+    assert revoke_mock.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_revoke_nonexistent_session_returns_404(client: AsyncClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Target session_id doesn't exist (verify_session returns None) → 404."""
+    seq = [_session(_TEST_SESSION_ID), None]
+    monkeypatch.setattr(sessions, "verify_session", AsyncMock(side_effect=seq))
+    resp = await client.post(
+        "/me/sessions/nope-not-a-real-session/revoke",
+        cookies={COOKIE_NAME: _mint()},
+    )
+    assert resp.status_code == 404

--- a/whilly/api/auth_routes.py
+++ b/whilly/api/auth_routes.py
@@ -62,6 +62,7 @@ _HOST_PREFIX_COOKIE_NAME: Final[str] = "__Host-whilly_session"
 
 CHANGE_PASSWORD_TEMPLATE: Final[str] = "password_change.html.j2"
 ME_PASSWORD_TEMPLATE: Final[str] = "me_password.html.j2"
+ME_SESSIONS_TEMPLATE: Final[str] = "me_sessions.html.j2"
 _MIN_PASSWORD_LENGTH: Final[int] = 12
 """__Host- prefixed name used in prod+secure mode for strongest browser binding."""
 
@@ -639,6 +640,84 @@ def build_auth_router(
         logger.info("me.password: password changed for username=%r (self-service)", username)
         return RedirectResponse(url="/", status_code=status.HTTP_303_SEE_OTHER)
 
+    # PRD-post-auth-hardening §Epic E, Item 16 — active-sessions UI ──────────
+    #
+    # GET /me/sessions  → list non-revoked sessions for the principal's email
+    # POST /me/sessions/{session_id}/revoke → drop the row; if it was the
+    #   current session, also clear the cookie and 303 to /login.
+    #
+    # The sessions schema (migration 018) does NOT carry user_agent or IP
+    # columns — PRD prose mentions them but they don't exist. The template
+    # shows session_id prefix + created_at + last_seen_at + expires_at,
+    # which is what is actually queryable today. Adding ip/user_agent is
+    # a future migration.
+
+    @router.get("/me/sessions", response_class=HTMLResponse, include_in_schema=False)
+    async def list_me_sessions(request: Request) -> Response:
+        try:
+            principal = await _authenticate_session(request, pool=pool, secret=secret, cookie_name=cookie_name)
+        except HTTPException:
+            return RedirectResponse(url="/login", status_code=status.HTTP_303_SEE_OTHER)
+        principal_email = str(principal.get("email", ""))
+        active = await sessions.list_active_sessions_for_email(pool, email=principal_email)
+        return templates.TemplateResponse(
+            request,
+            ME_SESSIONS_TEMPLATE,
+            {
+                "sessions": active,
+                "current_session_id": principal.get("session_id"),
+                "principal_email": principal_email,
+                "flash": None,
+            },
+        )
+
+    @router.post(
+        "/me/sessions/{session_id}/revoke",
+        response_class=HTMLResponse,
+        include_in_schema=True,
+        summary="Revoke a session (logs out the device); revoking the current session redirects to /login",
+    )
+    async def revoke_me_session(request: Request, session_id: str) -> Response:
+        try:
+            principal = await _authenticate_session(request, pool=pool, secret=secret, cookie_name=cookie_name)
+        except HTTPException:
+            return RedirectResponse(url="/login", status_code=status.HTTP_303_SEE_OTHER)
+        principal_email = str(principal.get("email", ""))
+        # Guard: the target session must belong to the principal — otherwise
+        # an authenticated user could revoke someone else's session by
+        # guessing the session_id. Look it up via verify_session (which
+        # returns None for expired/revoked/missing) and check the email.
+        target = await sessions.verify_session(pool, session_id=session_id)
+        if target is None or target.email != principal_email:
+            logger.warning(
+                "me.sessions.revoke: %r tried to revoke session %r they don't own",
+                principal_email,
+                session_id[:8] if session_id else "?",
+            )
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="session not found")
+        await sessions.revoke_session(pool, session_id=session_id)
+        is_self_revoke = session_id == principal.get("session_id")
+        if is_self_revoke:
+            # Revoking the current session — clear the cookie and bounce
+            # to /login. The cookie clear matches the /auth/logout pattern.
+            response = RedirectResponse(url="/login", status_code=status.HTTP_303_SEE_OTHER)
+            response.delete_cookie(cookie_name, path="/")
+            return response
+        # Other-device revoke — re-render the list with a flash. The
+        # underlying GET handler runs in the same closure, so just call
+        # the list query again here.
+        active = await sessions.list_active_sessions_for_email(pool, email=principal_email)
+        return templates.TemplateResponse(
+            request,
+            ME_SESSIONS_TEMPLATE,
+            {
+                "sessions": active,
+                "current_session_id": principal.get("session_id"),
+                "principal_email": principal_email,
+                "flash": f"revoked session {session_id[:8]}…",
+            },
+        )
+
     return router
 
 
@@ -790,6 +869,7 @@ __all__ = [
     "DEFAULT_SESSION_COOKIE_NAME",
     "EVENT_LOG_PATH_ENV",
     "ME_PASSWORD_TEMPLATE",
+    "ME_SESSIONS_TEMPLATE",
     "_HOST_PREFIX_COOKIE_NAME",
     "authenticate_session_request",
     "build_auth_router",

--- a/whilly/api/sessions.py
+++ b/whilly/api/sessions.py
@@ -268,6 +268,27 @@ async def verify_session(pool: asyncpg.Pool, *, session_id: str) -> Session | No
         return _row_to_session(row)
 
 
+async def list_active_sessions_for_email(pool: asyncpg.Pool, *, email: str) -> list[Session]:
+    """Return every non-revoked, non-expired session for ``email``.
+
+    Used by the ``/me/sessions`` admin-of-self UI (PRD §Epic E Item 16).
+    Ordered last_seen_at DESC so the active devices appear first.
+    """
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            """
+            SELECT session_id, email, created_at, last_seen_at, expires_at, revoked_at
+            FROM sessions
+            WHERE email = $1
+              AND revoked_at IS NULL
+              AND expires_at > NOW()
+            ORDER BY last_seen_at DESC
+            """,
+            email,
+        )
+    return [_row_to_session(r) for r in rows]
+
+
 async def revoke_session(pool: asyncpg.Pool, *, session_id: str) -> bool:
     """Mark a session revoked. Returns True on the first revoke, False on subsequent calls."""
     if not isinstance(session_id, str) or not session_id:
@@ -333,6 +354,7 @@ __all__ = [
     "consume_magic_link",
     "create_magic_link",
     "create_session",
+    "list_active_sessions_for_email",
     "purge_expired",
     "revoke_session",
     "verify_session",

--- a/whilly/api/templates/me_sessions.html.j2
+++ b/whilly/api/templates/me_sessions.html.j2
@@ -1,0 +1,70 @@
+<!doctype html>
+<html lang="en" data-theme="dark">
+<head>
+  <meta charset="utf-8" />
+  <title>Active sessions — Whilly</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" href="/static/whilly-design.css">
+  <link rel="stylesheet" href="/static/whilly-app.css">
+  <style>
+    body { padding: 24px; max-width: 900px; margin: 0 auto; }
+    .sess-title { color: var(--accent); font: 700 var(--t-body)/var(--lh-tight) var(--font-mono); margin: 0 0 16px; }
+    .sess-table { width: 100%; border-collapse: collapse; font: var(--t-sm)/var(--lh-body) var(--font-mono); }
+    .sess-table th, .sess-table td { padding: 6px 8px; border-bottom: 1px solid var(--line); text-align: left; }
+    .sess-table th { color: var(--muted); }
+    .sess-current { color: var(--accent); font-weight: 700; }
+    .sess-current-tag { background: var(--accent); color: var(--bg); padding: 1px 6px; font-size: 0.85em; margin-left: 6px; }
+    .sess-revoke {
+      background: transparent; border: 1px solid var(--line-strong); color: var(--text);
+      padding: 2px 8px; cursor: pointer; font: inherit;
+    }
+    .sess-revoke:hover { background: var(--danger); color: var(--bg); border-color: var(--danger); }
+    .sess-current .sess-revoke { border-color: var(--danger); color: var(--danger); }
+    .sess-flash { padding: 8px 12px; margin-bottom: 12px; border: 1px solid var(--accent); color: var(--accent); font: var(--t-sm)/var(--lh-body) var(--font-mono); }
+  </style>
+</head>
+<body>
+  <h1 class="sess-title">Active sessions</h1>
+  <p style="color: var(--muted); font: var(--t-sm)/var(--lh-body) var(--font-mono);">
+    Signed in as <strong>{{ principal_email }}</strong>.
+    <a href="/me/password" style="color: var(--accent);">change password</a> &middot;
+    <a href="/" style="color: var(--accent);">dashboard</a>
+  </p>
+
+  {% if flash %}<div class="sess-flash">{{ flash }}</div>{% endif %}
+
+  <p style="color: var(--muted); font: var(--t-sm)/var(--lh-body) var(--font-mono);">
+    Each row is a device currently signed in to your account. Revoking a session immediately
+    invalidates the cookie on that device — the user there is logged out on their next request.
+  </p>
+
+  <table class="sess-table">
+    <thead>
+      <tr>
+        <th>session_id</th><th>created</th><th>last seen</th><th>expires</th><th>action</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for s in sessions %}
+      <tr class="{% if s.session_id == current_session_id %}sess-current{% endif %}">
+        <td>{{ s.session_id[:12] }}…
+          {% if s.session_id == current_session_id %}<span class="sess-current-tag">this device</span>{% endif %}
+        </td>
+        <td>{{ s.created_at.strftime("%Y-%m-%d %H:%M") if s.created_at else "—" }}</td>
+        <td>{{ s.last_seen_at.strftime("%Y-%m-%d %H:%M") if s.last_seen_at else "—" }}</td>
+        <td>{{ s.expires_at.strftime("%Y-%m-%d %H:%M") if s.expires_at else "—" }}</td>
+        <td>
+          <form method="post" action="/me/sessions/{{ s.session_id }}/revoke" style="display: inline;">
+            <button type="submit" class="sess-revoke">
+              {% if s.session_id == current_session_id %}revoke (log out){% else %}revoke{% endif %}
+            </button>
+          </form>
+        </td>
+      </tr>
+      {% else %}
+      <tr><td colspan="5" style="color: var(--muted); text-align: center; padding: 16px;">no active sessions</td></tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</body>
+</html>

--- a/whilly/operator_views.py
+++ b/whilly/operator_views.py
@@ -194,6 +194,7 @@ OPERATOR_WUI_ARTIFACTS: Final[tuple[OperatorUiArtifact, ...]] = (
     OperatorUiArtifact("whilly/api/templates/login_consumed.html.j2", OperatorUiArtifactStatus.ACTIVE),
     OperatorUiArtifact("whilly/api/templates/password_change.html.j2", OperatorUiArtifactStatus.ACTIVE),
     OperatorUiArtifact("whilly/api/templates/me_password.html.j2", OperatorUiArtifactStatus.ACTIVE),
+    OperatorUiArtifact("whilly/api/templates/me_sessions.html.j2", OperatorUiArtifactStatus.ACTIVE),
     OperatorUiArtifact("whilly/api/templates/admin_users.html.j2", OperatorUiArtifactStatus.ACTIVE),
     OperatorUiArtifact("whilly/api/templates/admin_auth_audit.html.j2", OperatorUiArtifactStatus.ACTIVE),
     OperatorUiArtifact(


### PR DESCRIPTION
Closes PRD §E16. New /me/sessions list + /me/sessions/{id}/revoke routes. Defends against session-id-guessing privilege escalation via email-match check. 6 unit tests. New template + registered in WUI artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)