### PR TITLE
fix(cli): H21 — worker launch --model / --connect override fix

### DIFF
--- a/.planning/post-auth-hardening-tasks.json
+++ b/.planning/post-auth-hardening-tasks.json
@@ -630,15 +630,16 @@
     },
     {
       "id": "H21-fix-worker-launch-model-connect-override",
-      "status": "pending",
+      "status": "done",
       "priority": "medium",
       "dependencies": [
         "B4-unit-tests-worker-launch"
       ],
       "key_files": [
-        "whilly/cli/worker_launch.py"
+        "whilly/cli/worker_launch.py",
+        "tests/unit/test_cli_worker_launch.py"
       ],
-      "description": "PRD §Epic H, Item 21 — in whilly/cli/worker_launch.py, replace dict.setdefault usage with explicit overwrite for keys supplied via CLI flags (--model, --connect). A CLI flag at its default value (not explicitly supplied by the user) must NOT overwrite the saved config value. Use argparse's default sentinel pattern or click's is_eager/standalone_mode pattern to distinguish 'supplied' from 'defaulted'.",
+      "description": "DONE 2026-05-18: replaced setdefault with _persist_default helper that overwrites only when CLI flag was explicitly supplied (argparse default sentinel = None) OR key absent. Reuse-path also updated: --connect / --model on cached creds now update the cached defaults (previously the fresh-register branch was the only writer, so reuse silently ignored CLI overrides). cfg_dirty flag avoids pointless file writes when nothing changed. 3 new H21 tests added to test_cli_worker_launch.py: --model overrides cached default; no --model preserves cached default; --connect overrides default_control_url. Total file now has 25 tests. Original: PRD §Epic H, Item 21 — in whilly/cli/worker_launch.py, replace dict.setdefault usage with explicit overwrite for keys supplied via CLI flags (--model, --connect). A CLI flag at its default value (not explicitly supplied by the user) must NOT overwrite the saved config value. Use argparse's default sentinel pattern or click's is_eager/standalone_mode pattern to distinguish 'supplied' from 'defaulted'.",
       "acceptance_criteria": [
         "whilly worker launch plan.json --model claude-opus-4-6 on existing config updates default_model in ~/.config/whilly/worker.json",
         "whilly worker launch plan.json (no --model) does NOT overwrite the existing default_model",

--- a/tests/unit/test_cli_worker_launch.py
+++ b/tests/unit/test_cli_worker_launch.py
@@ -533,6 +533,131 @@ def test_remove_with_no_workers_in_config_returns_error(cfg_path: Path) -> None:
 #     launch happy path that DOES call run_worker_command) ──────────────────
 
 
+# ─── H21: --model / --connect override on reuse path ───────────────────────
+
+
+def test_launch_model_flag_updates_cached_default_model(monkeypatch: pytest.MonkeyPatch, cfg_path: Path) -> None:
+    """H21 AC: second launch with --model overwrites the cached default_model.
+
+    Pre-populate a config with default_model=X and a cached entry, then
+    re-run launch with --model NEW. After the second call, default_model
+    must be NEW (not X).
+    """
+    monkeypatch.setattr(worker_launch, "_register", _stub_register_factory("w1", "tk1"))
+    cache_key = worker_launch._config_key("http://127.0.0.1:8000", "demo-plan")
+    cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    cfg_path.write_text(
+        json.dumps(
+            {
+                "default_control_url": "http://127.0.0.1:8000",
+                "default_model": "claude-old-model",
+                "last_plan_id": "demo-plan",
+                "workers": {
+                    cache_key: {
+                        "worker_id": "w1",
+                        "token": "tk1",
+                        "plan_id": "demo-plan",
+                        "control_url": "http://127.0.0.1:8000",
+                    }
+                },
+            }
+        )
+    )
+    rc = worker_launch.run_launch_command(
+        [
+            "demo-plan",
+            "--connect",
+            "http://127.0.0.1:8000",
+            "--claude-bin",
+            "/usr/bin/claude",
+            "--model",
+            "claude-new-model",  # explicit override
+            "--register-only",
+            "--config",
+            str(cfg_path),
+        ]
+    )
+    assert rc == worker_launch.EXIT_OK
+    config = json.loads(cfg_path.read_text())
+    assert config["default_model"] == "claude-new-model"
+
+
+def test_launch_without_model_flag_does_not_overwrite_cached_default_model(
+    monkeypatch: pytest.MonkeyPatch, cfg_path: Path
+) -> None:
+    """H21 AC: launch with no --model leaves cached default_model alone."""
+    monkeypatch.setattr(worker_launch, "_register", _stub_register_factory("w1", "tk1"))
+    cache_key = worker_launch._config_key("http://127.0.0.1:8000", "demo-plan")
+    cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    cfg_path.write_text(
+        json.dumps(
+            {
+                "default_control_url": "http://127.0.0.1:8000",
+                "default_model": "claude-preserved",
+                "last_plan_id": "demo-plan",
+                "workers": {
+                    cache_key: {
+                        "worker_id": "w1",
+                        "token": "tk1",
+                        "plan_id": "demo-plan",
+                        "control_url": "http://127.0.0.1:8000",
+                    }
+                },
+            }
+        )
+    )
+    rc = worker_launch.run_launch_command(
+        [
+            "demo-plan",
+            "--connect",
+            "http://127.0.0.1:8000",
+            "--claude-bin",
+            "/usr/bin/claude",
+            "--register-only",
+            "--config",
+            str(cfg_path),
+        ]
+    )
+    assert rc == worker_launch.EXIT_OK
+    config = json.loads(cfg_path.read_text())
+    assert config["default_model"] == "claude-preserved"
+
+
+def test_launch_connect_flag_updates_cached_default_control_url(
+    monkeypatch: pytest.MonkeyPatch, cfg_path: Path
+) -> None:
+    """H21 AC: --connect on reuse path updates the cached default_control_url."""
+    monkeypatch.setattr(worker_launch, "_register", _stub_register_factory("w1", "tk1"))
+    cache_key = worker_launch._config_key("http://NEW", "demo-plan")
+    cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    cfg_path.write_text(
+        json.dumps(
+            {
+                "default_control_url": "http://OLD",
+                "last_plan_id": "demo-plan",
+                "workers": {
+                    cache_key: {"worker_id": "w1", "token": "tk1", "plan_id": "demo-plan", "control_url": "http://NEW"}
+                },
+            }
+        )
+    )
+    rc = worker_launch.run_launch_command(
+        [
+            "demo-plan",
+            "--connect",
+            "http://NEW",
+            "--claude-bin",
+            "/usr/bin/claude",
+            "--register-only",
+            "--config",
+            str(cfg_path),
+        ]
+    )
+    assert rc == worker_launch.EXIT_OK
+    config = json.loads(cfg_path.read_text())
+    assert config["default_control_url"] == "http://NEW"
+
+
 def test_launch_full_path_invokes_worker_loop_after_register(monkeypatch: pytest.MonkeyPatch, cfg_path: Path) -> None:
     """Without --register-only or --print-env, launch should hand off to
     run_worker_command. With the loop stubbed out it returns immediately.

--- a/whilly/cli/worker_launch.py
+++ b/whilly/cli/worker_launch.py
@@ -115,6 +115,21 @@ def _config_key(control_url: str, plan_id: str) -> str:
     return f"{control_url.rstrip('/')}|{plan_id}"
 
 
+def _persist_default(key: str, supplied_arg: str | None, resolved_value: str, config: dict[str, Any]) -> None:
+    """Write ``key`` to ``config`` honouring CLI-supplied-vs-defaulted intent.
+
+    H21 fix: ``dict.setdefault`` silently ignores the new value when the
+    key already exists, so a user passing ``--model X`` on a config that
+    already has ``default_model: Y`` would see Y persist. Replace with
+    "overwrite if the CLI flag was explicitly supplied OR the key is
+    absent". ``supplied_arg is None`` is argparse's signal for "user did
+    not pass this flag" — at that point the previously-stored default
+    (if any) is correct, so we only seed when the key is missing.
+    """
+    if supplied_arg is not None or key not in config:
+        config[key] = resolved_value
+
+
 def _pick_plan_interactive(control_url: str) -> str | None:
     """Last-resort plan picker — only used when neither flag nor config has one.
 
@@ -297,13 +312,31 @@ def run_launch_command(argv: list[str]) -> int:
             "hostname": hostname,
         }
         config["last_plan_id"] = plan_id
-        config.setdefault("default_control_url", control_url)
-        config.setdefault("default_model", model)
+        # PRD-post-auth-hardening §Epic H Item 21 — explicit overwrite on
+        # supplied CLI flags. setdefault would silently ignore the new value
+        # if the key already exists; that defeats the user's intent when
+        # they pass --connect / --model expecting it to stick.
+        _persist_default("default_control_url", args.control_url, control_url, config)
+        _persist_default("default_model", args.model, model, config)
         _write_config(cfg_path, config)
         sys.stderr.write(f"whilly worker launch: saved creds to {cfg_path} (worker_id={worker_id})\n")
 
+    # H21: also honour --connect / --model on the reuse path (cached creds).
+    # Without this, a user who runs `whilly worker launch plan --model X` on
+    # an existing config sees the model NOT updated because the fresh-register
+    # branch never ran. Only update + write when the value actually changes
+    # to avoid pointless file churn on every reuse invocation.
+    cfg_dirty = False
+    if args.control_url is not None and config.get("default_control_url") != control_url:
+        config["default_control_url"] = control_url
+        cfg_dirty = True
+    if args.model is not None and config.get("default_model") != model:
+        config["default_model"] = model
+        cfg_dirty = True
     if config.get("last_plan_id") != plan_id:
         config["last_plan_id"] = plan_id
+        cfg_dirty = True
+    if cfg_dirty:
         _write_config(cfg_path, config)
 
     if args.register_only:


### PR DESCRIPTION
Closes PRD §H21. setdefault replaced with _persist_default that honours argparse's None-as-default sentinel; reuse-path also updates cached defaults. 3 new tests; 25 total in the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)