### PR TITLE
fix(tests): kill .env env-leak flakes + stop m1 baseline test dirtying docs

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -10,10 +10,43 @@ file-to-file.
 
 from __future__ import annotations
 
+import os
 import socket
 from collections.abc import Iterator
 
 import pytest
+
+
+@pytest.fixture(autouse=True)
+def _restore_os_environ() -> Iterator[None]:
+    """Snapshot ``os.environ`` before every unit test and restore it after.
+
+    Several CLI composition tests (``test_cli_run``, ``test_run_slack_hook``,
+    ``test_cli_worker``) exercise the *real* ``run_run_command`` →
+    :func:`whilly.config.load_layered` → :func:`whilly.config.load_dotenv`
+    chain, which writes the developer's local ``.env`` straight into
+    ``os.environ`` — bypassing :class:`pytest.MonkeyPatch`'s bookkeeping.
+    Without this guard a local ``.env`` containing ``JIRA_VERIFY_SSL=false``
+    leaks into later Jira tests (``test_qa_release_collector``,
+    ``test_prompt_sanitizer_wiring``), flipping ``JiraAuth.verify_ssl`` so
+    ``_jira_get`` takes the ``urlopen(..., context=ctx)`` branch and their
+    ``fake_urlopen`` stub — which has no ``context`` parameter — raises
+    ``TypeError``. CI never had a ``.env`` so the breakage only reproduced
+    locally (the "3 pre-existing test-order flakes" in the 2026-05-19 handoff).
+
+    A full snapshot is required rather than a tracked allow-list because
+    ``load_dotenv`` injects whatever keys the operator's ``.env`` holds.
+    This fixture is dependency-free so it initialises before every other
+    autouse/explicit fixture and finalises last — i.e. it is the outermost
+    env guard, restoring true pre-test state regardless of what inner
+    fixtures or production code mutated.
+    """
+    snapshot = dict(os.environ)
+    try:
+        yield
+    finally:
+        os.environ.clear()
+        os.environ.update(snapshot)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/test_m1_readiness_baseline.py
+++ b/tests/unit/test_m1_readiness_baseline.py
@@ -372,22 +372,31 @@ def test_distributed_audit_library_mirror_canonical_source() -> None:
 
 
 def test_m1_baseline_fixtures_script_is_idempotent_on_rerun(tmp_path) -> None:
-    """Re-running ``scripts/m1_baseline_fixtures.py`` on a clean checkout is a no-op.
+    """Re-running ``scripts/m1_baseline_fixtures.py`` is a no-op on the second pass.
+
+    Runs against a *synthetic* repo (via ``WHILLY_M1_BASELINE_ROOT``) rather
+    than the real checkout. This matters: the script mirrors
+    ``library/distributed-audit/`` into ``docs/distributed-audit/`` byte-for-byte,
+    but the real, committed ``docs/`` copy intentionally carries Jekyll
+    ``{% raw %}`` escapes (added by f6071f4 to keep the GitHub Pages build
+    green) that the ``library/`` copy lacks. Running the script against
+    ``REPO_ROOT`` would therefore overwrite the published docs and leave the
+    working tree dirty on every test run — a test-hygiene violation. The
+    synthetic-tree isolation mirrors the sibling regression tests above.
 
     Captures the script's stdout summary table over two consecutive
-    invocations and asserts the second pass reports nothing as
-    ``created`` or ``updated`` — every action line ends with
-    ``unchanged`` instead.
+    invocations and asserts the second pass reports nothing as ``created``
+    or ``updated`` — every action line ends with ``unchanged`` instead.
     """
-    import subprocess
+    repo = _build_synthetic_repo(tmp_path, with_planning=False, with_library=True)
 
-    script = REPO_ROOT / "scripts" / "m1_baseline_fixtures.py"
-    # First run primes any drift; the assertion runs on the second pass
-    # so this test never trips on a fresh clone where the fixtures
-    # legitimately need creating.
-    subprocess.run(["python3", str(script)], cwd=REPO_ROOT, check=True, capture_output=True)
-    second = subprocess.run(["python3", str(script)], cwd=REPO_ROOT, check=True, capture_output=True, text=True)
-    for line in second.stdout.splitlines():
+    # First run primes the synthetic tree (everything is "created"); the
+    # assertion runs on the second pass so a fresh tree never trips it.
+    code, _, stderr = _run_synthetic_script(repo)
+    assert code == 0, f"non-zero exit on priming run; stderr={stderr!r}"
+    code, stdout, stderr = _run_synthetic_script(repo)
+    assert code == 0, f"non-zero exit on second run; stderr={stderr!r}"
+    for line in stdout.splitlines():
         if not line.strip():
             continue
         # Each action line is "  <name>  <status>  <relpath>"; status is


### PR DESCRIPTION
## Summary

Resolves the **"3 pre-existing test-order flakes"** and the **"dirty docs"** mystery both flagged in the [2026-05-19 session handoff](https://github.com/mshegolev/whilly-orchestrator/blob/main/.planning/SESSION-HANDOFF-2026-05-19.md). Both are local-only test-hygiene defects that are invisible on CI (no local `.env`, ephemeral checkout) — the handoff's "langsmith/pydantic_core collision" diagnosis was wrong about the mechanism.

Two root causes, both test-only fixes:

### 1. `.env` leaks into `os.environ`, flipping `JiraAuth.verify_ssl`
Several CLI composition tests (`test_cli_run`, `test_run_slack_hook`, `test_cli_worker`) exercise the **real** `run_run_command` → `config.load_layered` → `load_dotenv` chain, which writes the developer's local `.env` (including `JIRA_VERIFY_SSL=false`) straight into `os.environ` — past `pytest.MonkeyPatch`'s bookkeeping. Later Jira tests then resolve `verify_ssl=False`, take the `urlopen(..., context=ctx)` branch in `whilly/sources/jira.py`, and their `fake_urlopen` stub (no `context` parameter) raises `TypeError`.

`pytest-randomly` is **not** installed → collection order is deterministic → these failed on *every* full sweep and passed in *every* isolation run (textbook deterministic test pollution).

**Fix:** an autouse, dependency-free `os.environ` snapshot/restore in `tests/unit/conftest.py` (outermost guard; full snapshot because `load_dotenv` injects arbitrary keys). Kills the whole class of env leaks and stops a real secret from bleeding across tests.

### 2. `test_m1_baseline_fixtures_script_is_idempotent_on_rerun` corrupts tracked docs
It ran the real `scripts/m1_baseline_fixtures.py` against `REPO_ROOT`. The script byte-mirrors `library/distributed-audit/` (no Jekyll escapes) over `docs/distributed-audit/` (which carries the `{% raw %}` escapes added in f6071f4 to keep the Pages build green), stripping them and dirtying the working tree on **every** run — while the test still passed.

**Fix:** route it through the `WHILLY_M1_BASELINE_ROOT` synthetic-repo isolation that its sibling regression tests already use. Same assertion, sandboxed.

## Verification
- Full unit sweep, run twice, deterministic: **2302 passed, 3 skipped**.
- Working tree confirmed **clean** after a full `pytest tests/unit/` run (no more dirtied `docs/`).
- `ruff check` + `ruff format --check` clean across `whilly/` + `tests/`; pre-commit hook green.

## Follow-up (not in this PR)
`library/distributed-audit/` lacks the `{% raw %}` escapes the committed `docs/` copy needs. The symptom is gone (the suite no longer touches real docs), but a maintainer manually running `python3 scripts/m1_baseline_fixtures.py` would still re-strip them. The durable fix — teaching the sync to Liquid-escape when writing to the Jekyll-published `docs/` mirror — is a design decision left for a dedicated change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)