### PR TITLE
feat(scripts): Liquid-escape docs/ mirror in m1_baseline_fixtures (Jekyll-safe)

### DIFF
--- a/scripts/m1_baseline_fixtures.py
+++ b/scripts/m1_baseline_fixtures.py
@@ -53,8 +53,10 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shutil
 import sys
+from collections.abc import Callable
 from pathlib import Path
 
 # REPO_ROOT defaults to the repository this script lives in (two parents up).
@@ -465,19 +467,77 @@ def _resolve_audit_source() -> Path | None:
     return None
 
 
-def _mirror_file_idempotent(src: Path, dst: Path) -> str:
+# Liquid-trigger tokens that break a Jekyll/GitHub-Pages build if rendered
+# literally. ``_RAW_SPAN`` matches an existing ``{% raw %}…{% endraw %}`` block
+# (kept verbatim so escaping is idempotent); ``_LIQUID_TOKEN`` matches a single
+# ``{{ … }}`` output or ``{% … %}`` tag.
+_RAW_SPAN = re.compile(r"\{%\s*raw\s*%\}.*?\{%\s*endraw\s*%\}", re.DOTALL)
+_LIQUID_TOKEN = re.compile(r"\{\{.*?\}\}|\{%.*?%\}", re.DOTALL)
+
+
+def escape_liquid_for_jekyll(text: str) -> str:
+    """Wrap bare Liquid-trigger tokens in ``{% raw %}…{% endraw %}`` for Jekyll.
+
+    ``docs/distributed-audit/`` is published via GitHub Pages, which renders
+    every ``.md`` through Jekyll's Liquid engine *before* markdown. Literal
+    ``{{ … }}`` / ``{% … %}`` snippets in the audit reports (Go templates,
+    Jinja examples) would otherwise be interpreted and stripped, breaking the
+    Pages build — the exact regression f6071f4 hand-patched. This reproduces
+    that patch mechanically so the canonical source (``.planning/`` /
+    ``library/``) can stay clean and readable.
+
+    Idempotent: tokens already inside a ``{% raw %}`` span — and the
+    ``raw``/``endraw`` tags themselves — are left untouched, so re-escaping
+    already-escaped text returns it unchanged.
+    """
+
+    def _wrap_token(match: re.Match[str]) -> str:
+        token = match.group(0)
+        inner = token[2:-2].strip()
+        if inner in ("raw", "endraw"):  # never escape the raw/endraw tags themselves
+            return token
+        return "{% raw %}" + token + "{% endraw %}"
+
+    out: list[str] = []
+    pos = 0
+    for raw_span in _RAW_SPAN.finditer(text):
+        out.append(_LIQUID_TOKEN.sub(_wrap_token, text[pos : raw_span.start()]))
+        out.append(raw_span.group(0))  # preserve an existing raw block verbatim
+        pos = raw_span.end()
+    out.append(_LIQUID_TOKEN.sub(_wrap_token, text[pos:]))
+    return "".join(out)
+
+
+def _jekyll_escape_bytes(src_bytes: bytes) -> bytes:
+    """``escape_liquid_for_jekyll`` over UTF-8 bytes (mirror transform)."""
+    return escape_liquid_for_jekyll(src_bytes.decode("utf-8")).encode("utf-8")
+
+
+def _mirror_file_idempotent(
+    src: Path,
+    dst: Path,
+    *,
+    transform: Callable[[bytes], bytes] | None = None,
+) -> str:
     """Copy ``src`` → ``dst`` only if missing or drifted (byte-equality).
 
-    Returns one of ``"created"``, ``"updated"``, ``"unchanged"``.
+    When ``transform`` is given the *transformed* source bytes are what gets
+    compared and written — used to Liquid-escape markdown into the
+    Pages-published ``docs/`` mirror while leaving the ``library/`` mirror
+    verbatim. Returns one of ``"created"``, ``"updated"``, ``"unchanged"``.
     """
     src_bytes = src.read_bytes()
+    payload = transform(src_bytes) if transform is not None else src_bytes
     if dst.exists():
-        if dst.read_bytes() == src_bytes:
+        if dst.read_bytes() == payload:
             return "unchanged"
-        dst.write_bytes(src_bytes)
+        dst.write_bytes(payload)
         return "updated"
     dst.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copy2(src, dst)
+    if transform is None:
+        shutil.copy2(src, dst)
+    else:
+        dst.write_bytes(payload)
     return "created"
 
 
@@ -556,6 +616,7 @@ def main() -> int:
             REPO_ROOT / "library" / "distributed-audit",
         )
         src_resolved = src_dir.resolve()
+        docs_mirror = (REPO_ROOT / "docs" / "distributed-audit").resolve()
         for dst_dir in mirror_destinations:
             # If the destination IS the resolved source (e.g. ``library/`` is
             # the fallback source), skip — copying onto self is a guaranteed
@@ -564,16 +625,22 @@ def main() -> int:
             if dst_dir.resolve() == src_resolved:
                 continue
             dst_dir.mkdir(parents=True, exist_ok=True)
+            # The docs/ mirror is published via GitHub Pages (Jekyll/Liquid):
+            # escape literal {{…}}/{%…%} snippets in markdown so the build
+            # stays green. The library/ mirror is a plain tracked copy —
+            # mirror it verbatim.
+            is_docs_mirror = dst_dir.resolve() == docs_mirror
             for src_file in sorted(src_dir.iterdir()):
                 if not src_file.is_file():
                     continue
                 dst_file = dst_dir / src_file.name
+                transform = _jekyll_escape_bytes if (is_docs_mirror and src_file.suffix == ".md") else None
                 mirror_label = dst_dir.relative_to(REPO_ROOT).as_posix()
                 actions.append(
                     (
                         f"{mirror_label}/{src_file.name}",
                         dst_file,
-                        _mirror_file_idempotent(src_file, dst_file),
+                        _mirror_file_idempotent(src_file, dst_file, transform=transform),
                     )
                 )
 

--- a/tests/unit/test_m1_readiness_baseline.py
+++ b/tests/unit/test_m1_readiness_baseline.py
@@ -26,6 +26,37 @@ from tests.conftest import FIXTURES_DIR, load_fixture
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
+def _load_baseline_script_module():
+    """Import ``scripts/m1_baseline_fixtures.py`` as a module (no ``main()`` run).
+
+    Lets tests reuse the script's own ``escape_liquid_for_jekyll`` so the
+    expected docs-mirror bytes are derived from the same transform the script
+    applies, rather than hard-coding the escaping.
+    """
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "m1_baseline_fixtures", REPO_ROOT / "scripts" / "m1_baseline_fixtures.py"
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _expected_docs_bytes(src_file: Path) -> bytes:
+    """Bytes the script should write into the Pages-published ``docs/`` mirror.
+
+    Markdown is Liquid-escaped (so the Jekyll build stays green); every other
+    file type is mirrored verbatim.
+    """
+    src_bytes = src_file.read_bytes()
+    if src_file.suffix != ".md":
+        return src_bytes
+    escape = _load_baseline_script_module().escape_liquid_for_jekyll
+    return escape(src_bytes.decode("utf-8")).encode("utf-8")
+
+
 def _resolve_audit_source(repo_root: Path = REPO_ROOT) -> Path | None:
     """Return the canonical audit-report source for the current checkout.
 
@@ -335,8 +366,9 @@ def test_distributed_audit_docs_mirror_canonical_source() -> None:
     src_names = {p.name for p in src.iterdir() if p.is_file()}
     dst_names = {p.name for p in dst.iterdir() if p.is_file()}
     assert src_names == dst_names, f"only-in-src: {src_names - dst_names}, only-in-dst: {dst_names - src_names}"
+    # docs/ markdown carries the Jekyll Liquid-escapes; non-markdown is verbatim.
     for name in src_names:
-        assert (src / name).read_bytes() == (dst / name).read_bytes(), f"drift: {name}"
+        assert (dst / name).read_bytes() == _expected_docs_bytes(src / name), f"drift: {name}"
 
 
 def test_distributed_audit_library_mirror_canonical_source() -> None:
@@ -375,14 +407,11 @@ def test_m1_baseline_fixtures_script_is_idempotent_on_rerun(tmp_path) -> None:
     """Re-running ``scripts/m1_baseline_fixtures.py`` is a no-op on the second pass.
 
     Runs against a *synthetic* repo (via ``WHILLY_M1_BASELINE_ROOT``) rather
-    than the real checkout. This matters: the script mirrors
-    ``library/distributed-audit/`` into ``docs/distributed-audit/`` byte-for-byte,
-    but the real, committed ``docs/`` copy intentionally carries Jekyll
-    ``{% raw %}`` escapes (added by f6071f4 to keep the GitHub Pages build
-    green) that the ``library/`` copy lacks. Running the script against
-    ``REPO_ROOT`` would therefore overwrite the published docs and leave the
-    working tree dirty on every test run — a test-hygiene violation. The
-    synthetic-tree isolation mirrors the sibling regression tests above.
+    than the real checkout — a test must never mutate tracked working-tree
+    files. (The script now Liquid-escapes markdown on the way into ``docs/``
+    so a real-repo run is idempotent against the committed escaped docs, but
+    sandboxing it is still the correct pattern and matches the sibling
+    regression tests above.)
 
     Captures the script's stdout summary table over two consecutive
     invocations and asserts the second pass reports nothing as ``created``
@@ -404,6 +433,29 @@ def test_m1_baseline_fixtures_script_is_idempotent_on_rerun(tmp_path) -> None:
         assert "created" not in line.split() and "updated" not in line.split(), (
             f"non-idempotent re-run produced action line: {line!r}"
         )
+
+
+def test_escape_liquid_for_jekyll_wraps_bare_tokens_and_is_idempotent() -> None:
+    """The Jekyll escaper wraps bare Liquid tokens once and never double-wraps.
+
+    Pins the transform the docs/ mirror relies on: bare ``{{ … }}`` / ``{% … %}``
+    tokens get a ``{% raw %}`` wrapper, plain text and the ``raw``/``endraw``
+    tags themselves are left alone, and re-escaping is a fixed point.
+    """
+    escape = _load_baseline_script_module().escape_liquid_for_jekyll
+
+    # Bare output + tag tokens get wrapped (matches the two real audit-doc snippets).
+    assert escape("a {{.X}} b") == "a {% raw %}{{.X}}{% endraw %} b"
+    assert escape('{% include "x.html" %}') == '{% raw %}{% include "x.html" %}{% endraw %}'
+
+    # Plain text is untouched.
+    assert escape("no liquid here") == "no liquid here"
+
+    # Idempotent: already-escaped text is a fixed point and raw/endraw tags
+    # are never themselves wrapped.
+    once = escape("docker --format '{{.Names}}'")
+    assert once == "docker --format '{% raw %}{{.Names}}{% endraw %}'"
+    assert escape(once) == once
 
 
 # ─── Regression: clean-clone fallback chain ──────────────────────────────
@@ -494,8 +546,9 @@ def test_m1_baseline_fixtures_script_succeeds_without_planning_dir(tmp_path) -> 
     assert library_names == docs_names, (
         f"only-in-library: {library_names - docs_names}, only-in-docs: {docs_names - library_names}"
     )
+    # docs/ markdown is Liquid-escaped for Jekyll; non-markdown is verbatim.
     for name in library_names:
-        assert (fake_library / name).read_bytes() == (fake_docs / name).read_bytes(), f"drift: {name}"
+        assert (fake_docs / name).read_bytes() == _expected_docs_bytes(fake_library / name), f"drift: {name}"
 
     # The four canonical fixture files must also be present.
     for rel in (


### PR DESCRIPTION
## Summary

Closes the `library/`-vs-`docs/` `{% raw %}` divergence left as a maintainer follow-up in #303.

`docs/distributed-audit/` is published via GitHub Pages → Jekyll renders every `.md` through **Liquid** before markdown. The committed docs carry `{% raw %}…{% endraw %}` wrappers around literal `{{…}}` / `{%…%}` snippets (Go templates, an HTMX `{% include %}` example) added by f6071f4 to keep the Pages build green. The canonical source (`library/distributed-audit/`, and `.planning/` when present) lacks them — and `m1_baseline_fixtures.py` mirrored **byte-for-byte**, so a manual `python3 scripts/m1_baseline_fixtures.py` run stripped the escapes and would re-break the build.

## Fix

The mirror now Liquid-escapes markdown **only** when writing into the Pages-published `docs/` mirror; the `library/` mirror stays verbatim and the canonical source stays clean and readable.

- `escape_liquid_for_jekyll()` wraps each bare Liquid token in `{% raw %}…{% endraw %}`, skips the `raw`/`endraw` tags and any content already inside a raw span (idempotent / fixed point).
- It reproduces f6071f4's hand-patch **exactly**: `escape(library) == the committed docs byte-for-byte`, so a real-repo run is idempotent — every doc reports `unchanged`, working tree stays clean.
- `_mirror_file_idempotent` gained an optional `transform`; the docs mirror passes it for `.md`, `library/` passes `None`.

## Tests
- New unit test pins the escaper (wraps bare tokens, leaves plain text + `raw`/`endraw` alone, idempotent).
- The two docs-vs-source byte-equality assertions now expect `escape(source)` for markdown (verbatim for non-`.md`), via a shared `_expected_docs_bytes` helper that imports the script's own transform.
- Idempotency-test docstring refreshed (the script is now safe against the real repo; synthetic-tree isolation kept as correct practice).

## Verification
- Manual `python3 scripts/m1_baseline_fixtures.py` against the real repo → all six docs `unchanged`, tree clean (previously: stripped escapes, dirty tree).
- Full unit sweep: **2303 passed, 3 skipped**.
- `ruff` clean; `lint-imports` 2/2 contracts kept; os-side-effects guard only scans `whilly/core/` (unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)