### PR TITLE
chore(planning): session handoff 2026-05-21 + STATE catch-up + E17 done

### DIFF
--- a/.planning/SESSION-HANDOFF-2026-05-21.md
+++ b/.planning/SESSION-HANDOFF-2026-05-21.md
@@ -1,0 +1,109 @@
+# Session Handoff — 2026-05-21
+
+PRD scope: [`docs/PRD-post-auth-hardening.md`](../docs/PRD-post-auth-hardening.md)
+Plan file: [`.planning/post-auth-hardening-tasks.json`](post-auth-hardening-tasks.json)
+ADR: [`docs/adr/ADR-001-auth-hardening-p1.md`](../docs/adr/ADR-001-auth-hardening-p1.md)
+Prev handoff: [`SESSION-HANDOFF-2026-05-19.md`](SESSION-HANDOFF-2026-05-19.md)
+
+## TL;DR
+
+Started from the 2026-05-19 handoff's leftovers (the "3 pre-existing flakes,
+not blocking" + the dirty `docs/` files). Those turned out to be **two real,
+local-only test-hygiene bugs**, both fixed. Then closed the deferred
+`{% raw %}` divergence, and — under explicit security review — implemented
+**E17 (OIDC reverse-proxy header-trust)**. Plan is now `done=26, skipped=3`
+(only A1a/A1b/E15). `main` is clean, no open PRs.
+
+## What shipped this session (5 PRs merged)
+
+| PR | What |
+|---|---|
+| [#303](https://github.com/mshegolev/whilly-orchestrator/pull/303) | Killed the "3 flakes" (a local `.env`→`os.environ` leak flipping `JiraAuth.verify_ssl`) via an autouse env snapshot/restore in `tests/unit/conftest.py`; stopped `test_m1_baseline_fixtures_script_is_idempotent_on_rerun` from corrupting `docs/` by routing it through the `WHILLY_M1_BASELINE_ROOT` synthetic-repo isolation. |
+| [#304](https://github.com/mshegolev/whilly-orchestrator/pull/304) | `m1_baseline_fixtures.py` now Liquid-escapes markdown when mirroring into the Jekyll-published `docs/distributed-audit/` (`escape_liquid_for_jekyll`), so a manual script run no longer strips the `{% raw %}` escapes. Reproduces f6071f4 exactly → `escape(library) == committed docs` byte-for-byte. |
+| [#305](https://github.com/mshegolev/whilly-orchestrator/pull/305) | E15/E17 security-design plan: [`.planning/E15-E17-auth-security-design.md`](E15-E17-auth-security-design.md) (doc-only review artifact). |
+| [#306](https://github.com/mshegolev/whilly-orchestrator/pull/306) | **E17 — OIDC header-trust** (flag-gated, default OFF). New `whilly/api/oidc_header_auth.py`; `_authenticate_session` honours `request.state.proxy_principal`; conditional innermost mount in `create_app`; 15 tests. Reviewer decisions recorded in ADR-001 §P1.6. |
+
+(Plus the ADR §P1.6 addendum + design-doc §3.5 resolution were squashed into #306.)
+
+## E17 — what to know before touching it
+
+- **Default OFF.** When `WHILLY_TRUST_PROXY_AUTH` is unset/`0`, the middleware
+  is **not mounted**, so `request.state.proxy_principal` is never set and the
+  new branch in `_authenticate_session` is a provable no-op.
+- **Real app factory is `whilly/adapters/transport/server.py::create_app`**,
+  not `whilly/api/main.py` (the PRD/plan said `main.py` — stale). Config is
+  resolved there with `ProxyHeaderAuthConfig.from_env()` at construction time
+  (fail-closed: empty/invalid allowlist → app refuses to start).
+- **Trust is on the DIRECT peer IP** (`request.client.host`), never
+  `X-Forwarded-For`. Allowlist is `WHILLY_TRUSTED_PROXY_IPS` (CIDR list).
+- **⚠️ Operational gate (separate from the merge gate):** do NOT set
+  `WHILLY_TRUST_PROXY_AUTH=1` in any deployment until (a) the reverse proxy is
+  confirmed to strip any client-supplied `X-Forwarded-User`, and (b)
+  `WHILLY_TRUSTED_PROXY_IPS` is set to the proxy's CIDR(s). See
+  [ADR-001 §P1.6](../docs/adr/ADR-001-auth-hardening-p1.md) +
+  [`.env.example`](../.env.example).
+- **Resolved review questions** (ADR-001 §P1.6): proxy identity keeps full role
+  from the `users` row (not read-only); `must_change_password` is bypassed by
+  design (SSO password lifecycle is the proxy's); no conflict with
+  `WHILLY_ENABLE_ROUTE_AUDIT=1` (route audit walks routes, header-trust adds
+  none). **Still open:** trusted-hop count (single proxy assumed; chained
+  proxies would need a documented `num_trusted_hops`).
+
+## What's left
+
+- **E15 (WebAuthn / passkeys)** — `skipped`, **held for a dedicated sprint**.
+  Blocker on *this* machine: the `webauthn` PyPI package can't be installed
+  (no network / PyPI access), so the ceremony code can't be run or verified —
+  do it where PyPI + CI are available. Full plan in
+  [`E15-E17-auth-security-design.md`](E15-E17-auth-security-design.md) §2; it
+  reuses the E14b TOTP pending-cookie state machine. New migration would be
+  `026_webauthn_credentials` (head is `025_auth_audit`; the PRD's "025" is
+  stale). Gate tests with `pytest.importorskip("webauthn")`.
+- **A1a / A1b** — `skipped`; original `build_auth_router` defect never
+  reproduced. Nothing to do.
+
+## How to start the next session
+
+```bash
+cd /opt/develop/whilly-orchestrator
+git checkout main && git pull --ff-only origin main
+cat .planning/SESSION-HANDOFF-2026-05-21.md   # this file
+
+# Plan state
+cat .planning/post-auth-hardening-tasks.json | python3 -c "
+import json,sys; from collections import Counter
+d=json.load(sys.stdin); print('STATE:', dict(Counter(t['status'] for t in d['tasks'])))
+print('skipped:', [t['id'] for t in d['tasks'] if t['status']=='skipped'])"
+```
+
+### If picking up E15 (only where webauthn installs)
+```bash
+grep -B2 -A30 "## 2. E15" .planning/E15-E17-auth-security-design.md
+pip install '.[webauthn]'   # add the extra to pyproject first
+```
+
+## Verification commands
+
+```bash
+.venv/bin/python -m pytest tests/unit/ -q          # 2318 passed, 3 skipped (deterministic)
+.venv/bin/python -m pytest tests/unit/test_oidc_header_auth.py -v   # 15 E17 tests
+.venv/bin/python -m ruff check whilly/ tests/
+.venv/bin/python -m ruff format --check whilly/ tests/
+.venv/bin/lint-imports                              # 2 contracts kept
+.venv/bin/alembic -c alembic.ini heads              # 025_auth_audit (head)
+```
+
+## Sharp edges / notes for the next operator
+
+- **`tests/unit/conftest.py` now snapshots/restores `os.environ` per test.**
+  This is the guard that keeps a local `.env` (which `run_run_command` loads
+  via `load_dotenv`) from leaking `JIRA_VERIFY_SSL=false` (and a real Jira
+  token) into later tests. Scoped to `tests/unit/` only — `tests/conftest.py`
+  has session-scoped fixtures that set `DOCKER_HOST`/`WHILLY_DATABASE_URL`, so
+  a per-test restore there would wipe them mid-session. Don't move it up.
+- **Don't run `m1_baseline_fixtures.py` expecting it to be a no-op on an old
+  checkout** — pre-#304 it strips the Jekyll escapes from `docs/`. On `main`
+  it's now idempotent (escapes preserved).
+- **CI is green-but-blind to local-only issues**: both bugs fixed this session
+  were invisible on CI (no `.env`, ephemeral checkout). Run the full
+  `pytest tests/unit/` locally before trusting "CI passed".

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,8 +3,8 @@ gsd_state_version: 1.0
 milestone: v1.1
 milestone_name: UI parity completion
 status: completed
-last_updated: "2026-05-18T13:10:00Z"
-last_activity: 2026-05-18
+last_updated: "2026-05-21T00:00:00Z"
+last_activity: 2026-05-21
 progress:
   total_phases: 7
   completed_phases: 7
@@ -15,12 +15,12 @@ active_out_of_band:
   plan: post-auth-hardening
   plan_file: .planning/post-auth-hardening-tasks.json
   prd_file: docs/PRD-post-auth-hardening.md
-  latest_handoff: .planning/SESSION-HANDOFF-2026-05-18.md
+  latest_handoff: .planning/SESSION-HANDOFF-2026-05-21.md
   status_counts:
-    done: 3
-    skipped: 2
-    human_loop: 1
-    pending: 23
+    done: 26
+    skipped: 3
+    human_loop: 0
+    pending: 0
     total: 29
 ---
 
@@ -40,25 +40,31 @@ firms up.
 ## Current Position
 
 Current Milestone: v1.1 (archived) — no v1.2 declared yet
-Phase: Out-of-band follow-up (`post-auth-hardening`)
+Phase: Out-of-band follow-up (`post-auth-hardening`) — functionally complete
 Plan: `.planning/post-auth-hardening-tasks.json`
-Status: 3 done, 2 skipped, 1 human_loop, 23 pending (of 29 total)
-Last Activity: 2026-05-18
-Last Activity Description: Shipped PRs #271 (CI restoration), #272 (C7 docs), #275 (F18a
-migration 023). Filed issues #273 (Whilly v4 single-task mode) and #274 (CLAUDE.md stale).
-Wrote session handoff at [`SESSION-HANDOFF-2026-05-18.md`](SESSION-HANDOFF-2026-05-18.md).
+Status: 26 done, 3 skipped (A1a, A1b, E15), 0 pending (of 29 total)
+Last Activity: 2026-05-21
+Last Activity Description: Closed the 2026-05-19 handoff leftovers. Shipped PRs #303
+(root-caused the "3 flakes" to a local `.env`→`os.environ` leak; fixed via unit-conftest env
+restore + isolated the m1 baseline test), #304 (Jekyll-safe `docs/` mirror in
+`m1_baseline_fixtures.py`), #305 (E15/E17 security-design doc), #306 (E17 OIDC header-trust,
+flag-gated default OFF, under explicit security review — decisions in ADR-001 §P1.6). E17
+flipped skipped→done. E15 remains deferred to a dedicated sprint (the `webauthn` package is not
+installable in this environment). Wrote [`SESSION-HANDOFF-2026-05-21.md`](SESSION-HANDOFF-2026-05-21.md).
 
 Progress (v1.1 milestone): [##########] 100%
-Progress (post-auth-hardening, by count): 3 done + 2 skipped = 5/29 cleared (~17%)
+Progress (post-auth-hardening, by count): 26 done + 3 skipped = 29/29 resolved (100%)
 
 ## Active Scope
 
 **Out-of-band:** [`post-auth-hardening`](post-auth-hardening-tasks.json) plan, scoped by
-[`docs/PRD-post-auth-hardening.md`](../docs/PRD-post-auth-hardening.md). Latest handoff with
-ready-task list and recommended next step lives at
-[`SESSION-HANDOFF-2026-05-18.md`](SESSION-HANDOFF-2026-05-18.md). Handoff files are
+[`docs/PRD-post-auth-hardening.md`](../docs/PRD-post-auth-hardening.md). Now functionally
+complete (26 done, 3 skipped). Latest handoff lives at
+[`SESSION-HANDOFF-2026-05-21.md`](SESSION-HANDOFF-2026-05-21.md). Handoff files are
 date-stamped so the history accumulates rather than being overwritten — start the next
-session by reading the most recent one.
+session by reading the most recent one. Only remaining deferred work: **E15 (WebAuthn)**, held
+for a dedicated sprint where the `webauthn` package is installable (see the design doc at
+[`E15-E17-auth-security-design.md`](E15-E17-auth-security-design.md)).
 
 **Archived v1.1 evidence:**
 

--- a/.planning/post-auth-hardening-tasks.json
+++ b/.planning/post-auth-hardening-tasks.json
@@ -521,7 +521,7 @@
     },
     {
       "id": "E17-oidc-header-trust",
-      "status": "skipped",
+      "status": "done",
       "priority": "low",
       "dependencies": [
         "A0-ci-restoration",
@@ -532,7 +532,7 @@
         "whilly/api/main.py",
         ".env.example"
       ],
-      "description": "SKIPPED 2026-05-18: PRD §Risk Register R3 flags this as \"Critical impact\" — header injection attack surface when trusting a reverse-proxy identity header. Requires careful WHILLY_TRUSTED_PROXY_IPS allowlist enforcement and mandatory security review per the PRD R3 mitigation. Beyond the safe scope of the autopilot run; should be paired with the security-review process the PRD mandates. Per autopilot risk policy (\"Mark skipped with rationale\"), correct deferral. Original: PRD §Epic E, Item 17 — create whilly/api/oidc_header_auth.py. When WHILLY_TRUST_PROXY_AUTH=1, inspect X-Forwarded-User header on every request; if present and user exists, create a transient session (not persisted to DB). Strict: only accept the header from IPs in WHILLY_TRUSTED_PROXY_IPS (CIDR list). When WHILLY_TRUST_PROXY_AUTH is unset or 0, the header is completely ignored. Add conditional middleware registration in main.py. SECURITY NOTE: requires mandatory security review before merge; incorrect IP allowlisting enables header injection.",
+      "description": "DONE 2026-05-21: shipped in PR #306 (flag-gated, default OFF) under explicit security review. whilly/api/oidc_header_auth.py provides ProxyHeaderAuthConfig.from_env() (fail-closed: raises if WHILLY_TRUST_PROXY_AUTH=1 with empty/invalid WHILLY_TRUSTED_PROXY_IPS) + ProxyHeaderAuthMiddleware which, for a trusted DIRECT peer carrying X-Forwarded-User, sets a transient request.state.proxy_principal (no DB session) and audits. _authenticate_session honours that principal before the cookie path (no-op when the feature is off). Mounted conditionally in whilly/adapters/transport/server.py (NOTE: that is the real app factory, not main.py as the original scope said) as the innermost auth layer; CSRF stays outermost. 15 unit tests pin all five gates. Reviewer decisions (full role from DB; must_change bypass by design; no route-audit conflict) recorded in docs/adr/ADR-001 §P1.6. Operational gate: do NOT enable in prod until the proxy strips client X-Forwarded-User. — Superseded prior SKIPPED 2026-05-18: PRD §Risk Register R3 flags this as \"Critical impact\" — header injection attack surface when trusting a reverse-proxy identity header. Requires careful WHILLY_TRUSTED_PROXY_IPS allowlist enforcement and mandatory security review per the PRD R3 mitigation. Beyond the safe scope of the autopilot run; should be paired with the security-review process the PRD mandates. Per autopilot risk policy (\"Mark skipped with rationale\"), correct deferral. Original: PRD §Epic E, Item 17 — create whilly/api/oidc_header_auth.py. When WHILLY_TRUST_PROXY_AUTH=1, inspect X-Forwarded-User header on every request; if present and user exists, create a transient session (not persisted to DB). Strict: only accept the header from IPs in WHILLY_TRUSTED_PROXY_IPS (CIDR list). When WHILLY_TRUST_PROXY_AUTH is unset or 0, the header is completely ignored. Add conditional middleware registration in main.py. SECURITY NOTE: requires mandatory security review before merge; incorrect IP allowlisting enables header injection.",
       "acceptance_criteria": [
         "WHILLY_TRUST_PROXY_AUTH=1 with a seeded user: request with X-Forwarded-User: alice from trusted IP reaches dashboard",
         "Same request from untrusted IP returns 401",


### PR DESCRIPTION
## Summary

Saves the 2026-05-21 session so the next session can continue from `main`.

- **New `.planning/SESSION-HANDOFF-2026-05-21.md`** — 5 PRs (#303–#306), E17 operational gate, E15 hold rationale (webauthn not installable here), verification commands, and the sharp edges (unit-conftest env guard; don't run the baseline script on an old checkout).
- **`STATE.md`** — frontmatter + Current Position + Active Scope refreshed: plan functionally complete (`done=26, skipped=3`), `latest_handoff` repointed, `last_activity` 2026-05-21.
- **`post-auth-hardening-tasks.json`** — `E17-oidc-header-trust` flipped `skipped`→`done` with a realisation note (shipped in #306; decisions in ADR-001 §P1.6).

Planning docs only — no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)