### PR TITLE
chore(planning): sync STATE.md status_counts after E15 merge (26/3 → 27/2)

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,7 +3,7 @@ gsd_state_version: 1.0
 milestone: v1.1
 milestone_name: UI parity completion
 status: completed
-last_updated: "2026-05-21T00:00:00Z"
+last_updated: "2026-05-21T10:42:33Z"
 last_activity: 2026-05-21
 progress:
   total_phases: 7
@@ -17,8 +17,8 @@ active_out_of_band:
   prd_file: docs/PRD-post-auth-hardening.md
   latest_handoff: .planning/SESSION-HANDOFF-2026-05-21.md
   status_counts:
-    done: 26
-    skipped: 3
+    done: 27
+    skipped: 2
     human_loop: 0
     pending: 0
     total: 29


### PR DESCRIPTION
## What

Fixes a stale counter in `.planning/STATE.md` frontmatter. After PR #308 (E15 WebAuthn) merged, E15 flipped `skipped → done`, but the machine-readable `status_counts` header still read `done:26 / skipped:3` — disagreeing with STATE.md's own body text and the plan JSON (`post-auth-hardening-tasks.json`), both of which already say `done:27 / skipped:2`.

## Change

- `status_counts`: `done 26→27`, `skipped 3→2` (only `A1a`/`A1b` remain skipped — defect never reproduced).
- Bump `last_updated`.

No code change — planning-doc only.

## Verify

```bash
python3 -c "import json; from collections import Counter; \
d=json.load(open('.planning/post-auth-hardening-tasks.json')); \
print(dict(Counter(t['status'] for t in d['tasks'])))"
# -> {'done': 27, 'skipped': 2}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)