### PR TITLE
fix(auth): close 2FA brute-force lockout bypass (server-side + IP rate-limit)

### DIFF
--- a/docs/adr/ADR-001-auth-hardening-p1.md
+++ b/docs/adr/ADR-001-auth-hardening-p1.md
@@ -243,6 +243,36 @@ ignored entirely and the middleware is not mounted.
 
 ---
 
+## P1.7 — Second-factor brute-force lockout (post-E15 security review)
+
+A review of the merged E15 surface surfaced a **pre-existing** weakness (E14b
+code that E15 relocated into `whilly/api/second_factor.py`): the 2FA failed-
+attempt lockout lived **only** in the client-held, HMAC-signed pending cookie.
+HMAC prevents *editing* the counter but not *replaying* an older `a=0` cookie
+before each guess, so the 5-try lockout was bypassable. The password account-
+lockout did not backstop it — once the password is correct, no further password
+failures accrue while the attacker brute-forces the (rotating, but small) TOTP
+code. The verify endpoints also had no IP rate-limit (the password endpoint did).
+
+**Decision — defense in depth, two layers:**
+
+1. **IP rate-limit** (`rate_limit.allow`) on `POST /auth/totp` and the WebAuthn
+   `begin`/`verify` endpoints — the same edge cap `submit_login` already had.
+2. **Server-side per-user lockout** — `users_repo.is_account_locked` /
+   `register_failed_second_factor` reuse the existing `users.failed_attempts` /
+   `locked_until` columns, so a wrong **TOTP** code counts toward the same
+   15-minute account lock the password path uses, and a cookie replay cannot
+   reset it. Cleared on success via `update_last_login`. The per-cookie counter
+   is retained for the "N attempts remaining" UX only.
+
+**Scope decision — WebAuthn does not bump the lockout.** A WebAuthn assertion
+cannot be brute-forced (it needs the private key), so a failed assertion does
+*not* increment the shared counter — that would let a fumbled passkey lock the
+account (including password login) for no security gain. WebAuthn still *respects*
+an existing lock and is IP-rate-limited.
+
+---
+
 ## References
 
 - PRD: [`docs/PRD-post-auth-hardening.md`](../PRD-post-auth-hardening.md)

--- a/tests/integration/test_second_factor_lockout_repo.py
+++ b/tests/integration/test_second_factor_lockout_repo.py
@@ -1,0 +1,72 @@
+"""Integration coverage for the server-side second-factor lockout helpers.
+
+Real testcontainers Postgres (``db_pool`` applies ``alembic upgrade head``).
+These two functions are the fix for the 2FA brute-force finding: the per-cookie
+attempt counter was bypassable (replay an older signed ``a=0`` cookie), so the
+authoritative budget now lives in the ``users`` row.
+
+Pins:
+* a fresh user is not locked;
+* ``register_failed_second_factor`` increments and trips the lock at
+  ``_MAX_FAILED_ATTEMPTS`` (sharing the password-path columns);
+* ``update_last_login`` (the success path) clears the lock.
+"""
+
+from __future__ import annotations
+
+import asyncpg
+import pytest
+
+from tests.conftest import DOCKER_REQUIRED
+from whilly.api import users_repo
+from whilly.api.users_repo import _MAX_FAILED_ATTEMPTS
+
+pytestmark = DOCKER_REQUIRED
+
+_USERNAME = "lockoutuser"
+
+
+@pytest.fixture
+async def _seeded_user(db_pool: asyncpg.Pool):
+    async with db_pool.acquire() as conn:
+        await conn.execute("DELETE FROM users WHERE username = $1", _USERNAME)
+    await users_repo.create_user(
+        db_pool, username=_USERNAME, initial_password="correct horse battery", email=None, role="admin"
+    )
+    yield _USERNAME
+    async with db_pool.acquire() as conn:
+        await conn.execute("DELETE FROM users WHERE username = $1", _USERNAME)
+
+
+@pytest.mark.asyncio
+async def test_fresh_user_is_not_locked(db_pool: asyncpg.Pool, _seeded_user: str) -> None:
+    assert await users_repo.is_account_locked(db_pool, username=_USERNAME) is False
+
+
+@pytest.mark.asyncio
+async def test_register_failures_trip_lock_at_threshold(db_pool: asyncpg.Pool, _seeded_user: str) -> None:
+    # The first N-1 failures must not lock; the Nth must.
+    for _ in range(_MAX_FAILED_ATTEMPTS - 1):
+        locked = await users_repo.register_failed_second_factor(db_pool, username=_USERNAME)
+        assert locked is False
+        assert await users_repo.is_account_locked(db_pool, username=_USERNAME) is False
+    locked = await users_repo.register_failed_second_factor(db_pool, username=_USERNAME)
+    assert locked is True
+    assert await users_repo.is_account_locked(db_pool, username=_USERNAME) is True
+
+
+@pytest.mark.asyncio
+async def test_successful_login_clears_lock(db_pool: asyncpg.Pool, _seeded_user: str) -> None:
+    for _ in range(_MAX_FAILED_ATTEMPTS):
+        await users_repo.register_failed_second_factor(db_pool, username=_USERNAME)
+    assert await users_repo.is_account_locked(db_pool, username=_USERNAME) is True
+    # The 2FA success path calls update_last_login, which clears the budget.
+    await users_repo.update_last_login(db_pool, username=_USERNAME)
+    assert await users_repo.is_account_locked(db_pool, username=_USERNAME) is False
+
+
+@pytest.mark.asyncio
+async def test_unknown_user_never_locks(db_pool: asyncpg.Pool) -> None:
+    # Best-effort + no row → False (no crash, no enumeration signal).
+    assert await users_repo.register_failed_second_factor(db_pool, username="ghost-no-such-user") is False
+    assert await users_repo.is_account_locked(db_pool, username="ghost-no-such-user") is False

--- a/tests/unit/test_totp_routes.py
+++ b/tests/unit/test_totp_routes.py
@@ -235,6 +235,12 @@ async def test_submit_login_unchanged_when_user_totp_disabled_but_enrolled(
 async def totp_client(monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[AsyncClient]:
     monkeypatch.setattr(sessions, "verify_session", AsyncMock(return_value=_session()))
     monkeypatch.setattr(users_repo, "get_user_by_username", AsyncMock(return_value=_user()))
+    # The verify endpoint now IP-rate-limits and consults a server-side lockout
+    # (fix for the cookie-replay brute-force). Neutralise both by default so the
+    # functional verify tests are deterministic; individual tests override them.
+    monkeypatch.setattr(rate_limit, "allow", lambda key: True)
+    monkeypatch.setattr(users_repo, "is_account_locked", AsyncMock(return_value=False))
+    monkeypatch.setattr(users_repo, "register_failed_second_factor", AsyncMock(return_value=False))
     app = FastAPI()
     app.include_router(build_totp_router(pool=None, secret=_TEST_SECRET))  # type: ignore[arg-type]
     transport = ASGITransport(app=app)
@@ -357,6 +363,79 @@ async def test_totp_verify_post_too_many_failures_clears_cookie(
     # Pending cookie cleared.
     set_cookie = resp.headers.get("set-cookie", "")
     assert "whilly_totp_pending=;" in set_cookie or "Max-Age=0" in set_cookie
+
+
+# ─── brute-force hardening (fix: client-cookie counter was bypassable) ──────
+
+
+@pytest.mark.asyncio
+async def test_totp_verify_rate_limited_returns_429(totp_client: AsyncClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Layer 1: the verify endpoint is now IP-rate-limited like the password one."""
+    from whilly.api import auth_audit_repo
+
+    monkeypatch.setattr(rate_limit, "allow", lambda key: False)
+    audit = AsyncMock(return_value=None)
+    monkeypatch.setattr(auth_audit_repo, "insert_attempt", audit)
+    get_totp = AsyncMock(return_value=_totp_row())
+    monkeypatch.setattr(totp_repo, "get_totp_secret", get_totp)
+    pending = _mint_pending_cookie(_TEST_SECRET, username=_USERNAME)
+    resp = await totp_client.post(
+        "/auth/totp",
+        cookies={PENDING_COOKIE_NAME: pending},
+        data=dict(code="000000"),  # noqa: C408
+    )
+    assert resp.status_code == 429
+    # Rate-limited before any TOTP secret lookup, and audited as 'rate_limited'.
+    assert get_totp.await_count == 0
+    assert audit.await_args.kwargs["outcome"] == "rate_limited"
+
+
+@pytest.mark.asyncio
+async def test_totp_verify_server_lock_beats_fresh_cookie(
+    totp_client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Layer 2 / the core fix: a pristine ``a=0`` pending cookie AND a correct
+    code are still rejected when the server-side lockout is set — proving the
+    cookie-replay bypass of the per-cookie counter no longer grants attempts."""
+    monkeypatch.setattr(users_repo, "is_account_locked", AsyncMock(return_value=True))
+    create = AsyncMock(return_value=_session())
+    monkeypatch.setattr(sessions, "create_session", create)
+    get_totp = AsyncMock(return_value=_totp_row())
+    monkeypatch.setattr(totp_repo, "get_totp_secret", get_totp)
+    fresh_cookie = _mint_pending_cookie(_TEST_SECRET, username=_USERNAME, attempts=0)
+    correct_code = pyotp.TOTP(_TEST_TOTP_SECRET).now()
+    resp = await totp_client.post(
+        "/auth/totp",
+        cookies={PENDING_COOKIE_NAME: fresh_cookie},
+        data=dict(code=correct_code),  # noqa: C408
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+    assert resp.headers["location"] == "/login"
+    # No session minted, and we never even reached the TOTP verify.
+    assert create.await_count == 0
+    assert get_totp.await_count == 0
+    set_cookie = resp.headers.get("set-cookie", "")
+    assert "whilly_totp_pending=;" in set_cookie or "Max-Age=0" in set_cookie
+
+
+@pytest.mark.asyncio
+async def test_totp_verify_wrong_code_bumps_server_side_counter(
+    totp_client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A wrong code increments the server-side budget, not just the cookie."""
+    monkeypatch.setattr(totp_repo, "get_totp_secret", AsyncMock(return_value=_totp_row()))
+    bump = AsyncMock(return_value=False)
+    monkeypatch.setattr(users_repo, "register_failed_second_factor", bump)
+    pending = _mint_pending_cookie(_TEST_SECRET, username=_USERNAME)
+    resp = await totp_client.post(
+        "/auth/totp",
+        cookies={PENDING_COOKIE_NAME: pending},
+        data=dict(code="000000"),  # noqa: C408
+    )
+    assert resp.status_code == 422
+    bump.assert_awaited_once()
+    assert bump.await_args.kwargs["username"] == _USERNAME
 
 
 # silence unused-import lint

--- a/tests/unit/test_webauthn_routes.py
+++ b/tests/unit/test_webauthn_routes.py
@@ -25,7 +25,7 @@ from fastapi import FastAPI  # noqa: E402
 from httpx import ASGITransport, AsyncClient  # noqa: E402
 from webauthn.helpers.exceptions import InvalidAuthenticationResponse  # noqa: E402
 
-from whilly.api import auth_tokens, sessions, users_repo, webauthn_repo  # noqa: E402
+from whilly.api import auth_tokens, rate_limit, sessions, users_repo, webauthn_repo  # noqa: E402
 from whilly.api.csrf import COOKIE_NAME  # noqa: E402
 from whilly.api.second_factor import PENDING_COOKIE_NAME, PENDING_MAX_ATTEMPTS, _mint_pending_cookie  # noqa: E402
 from whilly.api.webauthn_routes import (  # noqa: E402
@@ -94,6 +94,10 @@ def _session_cookie() -> str:
 
 @pytest.fixture
 async def client(monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[AsyncClient]:
+    # The auth ceremony now IP-rate-limits begin/verify and honours the shared
+    # server-side lockout; neutralise both by default (tests override per case).
+    monkeypatch.setattr(rate_limit, "allow", lambda key: True)
+    monkeypatch.setattr(users_repo, "is_account_locked", AsyncMock(return_value=False))
     app = FastAPI()
     app.include_router(build_webauthn_router(pool=None, secret=_TEST_SECRET, cookie_secure=False))  # type: ignore[arg-type]
     transport = ASGITransport(app=app)
@@ -304,6 +308,37 @@ async def test_auth_verify_invalid_increments_attempts(client: AsyncClient, monk
     assert resp.status_code == 401
     assert resp.json()["remaining"] == PENDING_MAX_ATTEMPTS - 1
     assert any(PENDING_COOKIE_NAME in v for v in resp.headers.get_list("set-cookie"))
+
+
+@pytest.mark.asyncio
+async def test_auth_begin_rate_limited_429(client: AsyncClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Layer 1: begin is IP-rate-limited (caps a flood before the DB lookup)."""
+    monkeypatch.setattr(rate_limit, "allow", lambda key: False)
+    creds = AsyncMock(return_value=[_stored_cred()])
+    monkeypatch.setattr(webauthn_repo, "get_credentials_by_username", creds)
+    client.cookies.set(PENDING_COOKIE_NAME, _mint_pending_cookie(_TEST_SECRET, username=_USERNAME))
+    resp = await client.post("/auth/webauthn/begin")
+    assert resp.status_code == 429
+    assert creds.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_auth_verify_blocked_when_account_locked(client: AsyncClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify honours the shared server-side lockout (e.g. tripped by failed TOTP)
+    even with a valid pending cookie + challenge — before any assertion check."""
+    monkeypatch.setattr(users_repo, "is_account_locked", AsyncMock(return_value=True))
+    get_cred = AsyncMock(return_value=_stored_cred())
+    monkeypatch.setattr(webauthn_repo, "get_credential_by_id", get_cred)
+    create = AsyncMock(return_value=_session())
+    monkeypatch.setattr(sessions, "create_session", create)
+    pending = _mint_pending_cookie(_TEST_SECRET, username=_USERNAME, challenge=_b64url_encode(_CHALLENGE))
+    client.cookies.set(PENDING_COOKIE_NAME, pending)
+    resp = await client.post("/auth/webauthn/verify", json={"rawId": _b64url_encode(_CRED_ID), "response": {}})
+    assert resp.status_code == 429
+    assert resp.json()["locked"] is True
+    # Never reached the credential lookup or session mint.
+    assert get_cred.await_count == 0
+    assert create.await_count == 0
 
 
 @pytest.mark.asyncio

--- a/whilly/api/totp_routes.py
+++ b/whilly/api/totp_routes.py
@@ -31,12 +31,21 @@ single conditional in ``submit_login``.
 
 Hardening
 ---------
-* Brute-force lock-out: 5 wrong codes invalidate the pending cookie
-  and bounce the user back to ``/login``. The lock is per-cookie not
-  per-user — restarting the login flow gets a fresh budget, but every
-  password verify also drives the existing account-lockout counter
-  from :mod:`whilly.api.users_repo`, so password+TOTP guessing is
-  rate-limited by both.
+* Brute-force lock-out has TWO layers, because the per-cookie attempt
+  counter alone is bypassable: it lives in the client-held signed pending
+  cookie, so an attacker can reset it by replaying an older ``a=0`` cookie
+  before each guess (HMAC stops *editing* the counter, not *reusing* an old
+  signed value). And the password account-lockout does NOT backstop this —
+  once the password is correct no further password failures accrue while the
+  attacker brute-forces the code. So:
+  1. **IP rate-limit** (``rate_limit.allow``) on ``POST /auth/totp`` — the
+     same edge cap the password endpoint has, which the verify path lacked.
+  2. **Server-side per-user lockout** (``users_repo.is_account_locked`` /
+     ``register_failed_second_factor``) — shares the ``failed_attempts`` /
+     ``locked_until`` columns with the password path, so a wrong code counts
+     toward a 15-minute account lock that a cookie replay cannot reset. A
+     successful verify clears it via ``users_repo.update_last_login``.
+  The per-cookie counter is retained only for the "N attempts remaining" UX.
 * ``pyotp`` is a lazy import: when the feature flag is off (default)
   the module never reaches for it, so deployments without the ``totp``
   extras don't crash on import.
@@ -55,7 +64,7 @@ from fastapi import APIRouter, Form, HTTPException, Request, Response, status
 from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 
-from whilly.api import sessions, totp_repo, users_repo
+from whilly.api import auth_audit_repo, rate_limit, sessions, totp_repo, users_repo
 from whilly.api.auth_routes import (
     DEFAULT_SESSION_COOKIE_NAME,
     TEMPLATES_DIR,
@@ -233,6 +242,33 @@ def build_totp_router(
         attempts = int(pending.get("a", 0))
         if not username:
             return RedirectResponse(url="/login", status_code=status.HTTP_303_SEE_OTHER)
+
+        # Layer 1 — IP rate-limit (the password endpoint has this; the verify
+        # endpoint did not). Stop a flood before touching the DB.
+        client_ip = (request.client.host if request.client else None) or "unknown"
+        if not rate_limit.allow(client_ip):
+            await auth_audit_repo.insert_attempt(
+                pool,
+                username=username[:64] or None,
+                ip=client_ip,
+                user_agent=(request.headers.get("user-agent") or "")[:512] or None,
+                outcome="rate_limited",
+            )
+            return templates.TemplateResponse(
+                request,
+                TOTP_VERIFY_TEMPLATE,
+                {"username": username, "form_error": "Too many attempts. Please wait a moment and try again."},
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            )
+
+        # Layer 2 — server-side per-user lockout, which a replayed pending cookie
+        # cannot reset (the cookie-side `a` counter can). See the module docstring.
+        if await users_repo.is_account_locked(pool, username=username):
+            logger.warning("totp.verify: blocked locked account username=%r", username)
+            response = RedirectResponse(url="/login", status_code=status.HTTP_303_SEE_OTHER)
+            _clear_pending_cookie(response)
+            return response
+
         row = await totp_repo.get_totp_secret(pool, username=username)
         if row is None or not row.enabled:
             # User's TOTP was disabled between login and verify — bail.
@@ -243,6 +279,9 @@ def build_totp_router(
 
         totp = pyotp.TOTP(row.secret)
         if not totp.verify(code, valid_window=1):
+            # Server-side budget (authoritative, cookie-replay-proof) + the
+            # per-cookie counter (UX only).
+            await users_repo.register_failed_second_factor(pool, username=username)
             attempts += 1
             if attempts >= PENDING_MAX_ATTEMPTS:
                 logger.warning("totp.verify: %d failed attempts for %r — locking pending cookie", attempts, username)

--- a/whilly/api/users_repo.py
+++ b/whilly/api/users_repo.py
@@ -195,6 +195,78 @@ async def update_last_login(pool: asyncpg.Pool, *, username: str) -> None:
         return
 
 
+async def is_account_locked(pool: asyncpg.Pool, *, username: str) -> bool:
+    """Return True if ``username`` is currently locked out.
+
+    The server-side gate the second-factor verify routes consult *before*
+    honouring a request. The 2FA per-cookie attempt counter lives in the
+    client-held pending cookie and can be reset by replaying an older signed
+    cookie, so it cannot be the only brute-force control. This lockout state
+    lives in the ``users`` row (shared with the password path) and a cookie
+    replay cannot touch it. A successful login clears it via
+    :func:`update_last_login`.
+
+    Best-effort: any error returns ``False`` (fail-open), matching the
+    rate-limiter's posture — a transient DB blip must not hard-brick login.
+    """
+    if not isinstance(username, str) or not username.strip():
+        return False
+    normalised = username.strip().lower()
+    try:
+        async with pool.acquire() as conn:
+            locked = await conn.fetchval(
+                "SELECT locked_until IS NOT NULL AND locked_until > NOW() FROM users WHERE username = $1",
+                normalised,
+            )
+    except Exception:  # noqa: BLE001 — fail-open, never hard-brick the verify path
+        return False
+    return bool(locked)
+
+
+async def register_failed_second_factor(pool: asyncpg.Pool, *, username: str) -> bool:
+    """Count a wrong second factor against the shared ``failed_attempts`` budget.
+
+    Mirrors the password-mismatch branch of :func:`verify_credentials`, but in a
+    single atomic statement (no read-then-write race): at
+    :data:`_MAX_FAILED_ATTEMPTS` it sets ``locked_until = NOW() + 15 min`` and
+    resets the counter, otherwise it increments. Because this is server-side and
+    keyed on the user, an attacker who replays a fresh pending cookie (resetting
+    the cookie-side counter) still hits a per-user wall that only a successful
+    login clears.
+
+    Returns True if the account is now locked. Best-effort: never raises.
+    """
+    if not isinstance(username, str) or not username.strip():
+        return False
+    normalised = username.strip().lower()
+    try:
+        async with pool.acquire() as conn:
+            locked = await conn.fetchval(
+                f"""
+                UPDATE users
+                   SET failed_attempts = CASE WHEN failed_attempts + 1 >= $2 THEN 0
+                                              ELSE failed_attempts + 1 END,
+                       locked_until    = CASE WHEN failed_attempts + 1 >= $2
+                                              THEN NOW() + INTERVAL '{_LOCKOUT_MINUTES} minutes'
+                                              ELSE locked_until END
+                 WHERE username = $1
+                 RETURNING locked_until IS NOT NULL AND locked_until > NOW()
+                """,
+                normalised,
+                _MAX_FAILED_ATTEMPTS,
+            )
+    except Exception:  # noqa: BLE001 — best-effort, must never fail the verify path
+        logger.warning(
+            "users_repo: register_failed_second_factor failed for username=%r — swallowed",
+            normalised,
+            exc_info=True,
+        )
+        return False
+    if locked:
+        logger.warning("users_repo: account locked for username=%r after repeated failed second factors", normalised)
+    return bool(locked)
+
+
 async def set_password(pool: asyncpg.Pool, *, username: str, new_password: str) -> None:
     """Hash ``new_password`` and atomically update the users row.
 
@@ -354,7 +426,9 @@ __all__ = [
     "create_user",
     "delete_user",
     "get_user_by_username",
+    "is_account_locked",
     "list_users",
+    "register_failed_second_factor",
     "reset_password_to_random",
     "set_password",
     "set_role",

--- a/whilly/api/webauthn_routes.py
+++ b/whilly/api/webauthn_routes.py
@@ -61,7 +61,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 
-from whilly.api import sessions, users_repo, webauthn_repo
+from whilly.api import rate_limit, sessions, users_repo, webauthn_repo
 from whilly.api.admin_users_routes import require_admin_role
 from whilly.api.auth_routes import (
     DEFAULT_SESSION_COOKIE_NAME,
@@ -287,6 +287,9 @@ def build_webauthn_router(
         from webauthn import generate_authentication_options, options_to_json
         from webauthn.helpers.structs import PublicKeyCredentialDescriptor, UserVerificationRequirement
 
+        client_ip = (request.client.host if request.client else None) or "unknown"
+        if not rate_limit.allow(client_ip):
+            raise HTTPException(status_code=429, detail="too many requests")
         pending = _verify_pending_cookie(secret, request.cookies.get(PENDING_COOKIE_NAME, ""))
         if pending is None:
             raise HTTPException(status_code=401, detail="login session expired — start over")
@@ -321,12 +324,25 @@ def build_webauthn_router(
         from webauthn import verify_authentication_response
         from webauthn.helpers.exceptions import InvalidAuthenticationResponse
 
+        client_ip = (request.client.host if request.client else None) or "unknown"
+        if not rate_limit.allow(client_ip):
+            raise HTTPException(status_code=429, detail="too many requests")
         pending = _verify_pending_cookie(secret, request.cookies.get(PENDING_COOKIE_NAME, ""))
         challenge_b64 = pending.get("c") if pending else None
         if not pending or not isinstance(challenge_b64, str):
             raise HTTPException(status_code=401, detail="login session expired — start over")
         username = str(pending.get("u", ""))
         attempts = int(pending.get("a", 0))
+
+        # Respect the shared server-side lockout (a failed TOTP factor can set it).
+        # WebAuthn assertions are not brute-forceable, so a failed assertion does
+        # NOT itself bump the counter — that would let a fumbled passkey lock the
+        # account (incl. password login) for no security gain.
+        if await users_repo.is_account_locked(pool, username=username):
+            return JSONResponse(
+                {"verified": False, "error": "Account temporarily locked. Start over from /login.", "locked": True},
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            )
 
         body = await request.json()
         raw_id = body.get("rawId") or body.get("id") if isinstance(body, dict) else None


### PR DESCRIPTION
## Finding (from the post-E15 security review)

The 2FA failed-attempt lockout lived **only** in the client-held HMAC-signed pending cookie. HMAC stops *editing* the `a` counter but not **replaying an older `a=0` cookie** before each guess — so the 5-try lockout was bypassable. The password account-lockout does **not** backstop it: once the password is correct, no further password failures accrue while an attacker brute-forces the rotating-but-small TOTP code. The verify endpoints also had **no IP rate-limit** (the password endpoint did).

Pre-existing (E14b code that E15 relocated into `second_factor.py`), surfaced now and consolidated.

## Fix — defense in depth

1. **IP rate-limit** (`rate_limit.allow`) on `POST /auth/totp` and the WebAuthn `begin`/`verify` endpoints — the same edge cap `submit_login` already had.
2. **Server-side per-user lockout** — `users_repo.is_account_locked` / `register_failed_second_factor` reuse the existing `users.failed_attempts` / `locked_until` columns. A wrong **TOTP** code now counts toward the same 15-minute account lock the password path uses, and a cookie replay cannot reset it. Cleared on success via `update_last_login`. The per-cookie counter is kept for the "N attempts remaining" UX only.

**Scope:** WebAuthn *respects* an existing lock + is IP-rate-limited, but a failed assertion does **not** bump the counter — assertions aren't brute-forceable, and locking on a fumbled passkey would be an availability foot-gun.

## Tests
- **Unit (CI-gated):** `test_totp_routes.py` +3 (rate-limit 429; **fresh `a=0` cookie + correct code still rejected when locked**; wrong code bumps the server counter), `test_webauthn_routes.py` +2 (begin rate-limited; verify blocked when locked).
- **Integration (real pool):** `test_second_factor_lockout_repo.py` (threshold trip, clear-on-success, unknown-user no-op).

Local: `2349 passed, 3 skipped`; ruff + import-linter (2/2) + mypy core all green.

Decision recorded in [ADR-001 §P1.7](../blob/fix/2fa-lockout-bruteforce/docs/adr/ADR-001-auth-hardening-p1.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)