### PR TITLE
fix(auth): server-side single-use WebAuthn challenge (E15 review Finding 2)

### DIFF
--- a/docs/adr/ADR-001-auth-hardening-p1.md
+++ b/docs/adr/ADR-001-auth-hardening-p1.md
@@ -320,6 +320,28 @@ one that parses a client-controlled header) for no current consumer.
 
 ---
 
+## P1.9 — Server-side single-use WebAuthn challenge (post-E15 review, Finding 2)
+
+The E15 WebAuthn challenge was carried inside the HMAC-signed pending/registration
+cookie. HMAC gives integrity but not **freshness**: single-use rested on the
+cookie being cleared on success plus the sign-count regression check — and that
+check is a no-op for **counter-less synced passkeys** (iCloud/Google), which
+report `sign_count = 0` forever. A captured `(cookie, assertion)` pair could
+therefore be replayed within the 5-minute TTL.
+
+**Decision.** Move the challenge **server-side** (migration `027_webauthn_challenges`,
+`whilly/api/webauthn_challenge_repo.py`). `begin` inserts a row keyed by a random
+`challenge_id`; the cookie now carries only that id. `verify`/`finish` redeem the
+challenge with an atomic `DELETE … RETURNING`, **before** verifying the assertion —
+so even a failed verify burns it and any replay finds nothing. The challenge is
+bound to its ceremony via a `purpose` CHECK (`register` / `authenticate`) so a
+registration challenge can't be redeemed by the auth path. Applies to **both**
+ceremonies for one auditable mechanism. DB-backed (not in-process) is forced by
+correctness: a `begin` on one uvicorn worker must be redeemable by `verify` on
+another.
+
+---
+
 ## References
 
 - PRD: [`docs/PRD-post-auth-hardening.md`](../PRD-post-auth-hardening.md)

--- a/tests/integration/test_webauthn_challenge_repo.py
+++ b/tests/integration/test_webauthn_challenge_repo.py
@@ -1,0 +1,109 @@
+"""Integration coverage for ``whilly.api.webauthn_challenge_repo`` (migration 027).
+
+Real testcontainers Postgres (``db_pool`` applies ``alembic upgrade head``, so
+``webauthn_challenges`` exists). Pins the single-use guarantee that closes
+Finding 2: a challenge is redeemable exactly once, only by the matching
+user+purpose, and never after it expires.
+"""
+
+from __future__ import annotations
+
+import asyncpg
+import pytest
+
+from tests.conftest import DOCKER_REQUIRED
+from whilly.api import users_repo, webauthn_challenge_repo
+
+pytestmark = DOCKER_REQUIRED
+
+_USERNAME = "challuser"
+_CHALLENGE = b"a-32-byte-server-side-challenge!"
+
+
+@pytest.fixture
+async def _seeded_user(db_pool: asyncpg.Pool):
+    async with db_pool.acquire() as conn:
+        await conn.execute("DELETE FROM webauthn_challenges WHERE username = $1", _USERNAME)
+        await conn.execute("DELETE FROM users WHERE username = $1", _USERNAME)
+    await users_repo.create_user(
+        db_pool, username=_USERNAME, initial_password="correct horse battery", email=None, role="admin"
+    )
+    yield _USERNAME
+    async with db_pool.acquire() as conn:
+        await conn.execute("DELETE FROM webauthn_challenges WHERE username = $1", _USERNAME)
+        await conn.execute("DELETE FROM users WHERE username = $1", _USERNAME)
+
+
+@pytest.mark.asyncio
+async def test_create_then_consume_returns_bytes(db_pool: asyncpg.Pool, _seeded_user: str) -> None:
+    cid = await webauthn_challenge_repo.create_challenge(
+        db_pool, username=_USERNAME, purpose="authenticate", challenge=_CHALLENGE, ttl_seconds=300
+    )
+    got = await webauthn_challenge_repo.consume_challenge(
+        db_pool, challenge_id=cid, username=_USERNAME, purpose="authenticate"
+    )
+    assert got == _CHALLENGE
+
+
+@pytest.mark.asyncio
+async def test_consume_is_single_use(db_pool: asyncpg.Pool, _seeded_user: str) -> None:
+    cid = await webauthn_challenge_repo.create_challenge(
+        db_pool, username=_USERNAME, purpose="authenticate", challenge=_CHALLENGE, ttl_seconds=300
+    )
+    first = await webauthn_challenge_repo.consume_challenge(
+        db_pool, challenge_id=cid, username=_USERNAME, purpose="authenticate"
+    )
+    second = await webauthn_challenge_repo.consume_challenge(
+        db_pool, challenge_id=cid, username=_USERNAME, purpose="authenticate"
+    )
+    assert first == _CHALLENGE
+    assert second is None  # replay finds nothing
+
+
+@pytest.mark.asyncio
+async def test_consume_rejects_wrong_purpose_and_user(db_pool: asyncpg.Pool, _seeded_user: str) -> None:
+    cid = await webauthn_challenge_repo.create_challenge(
+        db_pool, username=_USERNAME, purpose="register", challenge=_CHALLENGE, ttl_seconds=300
+    )
+    # Wrong purpose → None (and the row survives for the correct purpose).
+    assert (
+        await webauthn_challenge_repo.consume_challenge(
+            db_pool, challenge_id=cid, username=_USERNAME, purpose="authenticate"
+        )
+        is None
+    )
+    # Wrong user → None.
+    assert (
+        await webauthn_challenge_repo.consume_challenge(
+            db_pool, challenge_id=cid, username="someone-else", purpose="register"
+        )
+        is None
+    )
+    # Correct purpose+user still works.
+    assert (
+        await webauthn_challenge_repo.consume_challenge(
+            db_pool, challenge_id=cid, username=_USERNAME, purpose="register"
+        )
+        == _CHALLENGE
+    )
+
+
+@pytest.mark.asyncio
+async def test_expired_challenge_not_consumable(db_pool: asyncpg.Pool, _seeded_user: str) -> None:
+    cid = await webauthn_challenge_repo.create_challenge(
+        db_pool, username=_USERNAME, purpose="authenticate", challenge=_CHALLENGE, ttl_seconds=-1
+    )
+    got = await webauthn_challenge_repo.consume_challenge(
+        db_pool, challenge_id=cid, username=_USERNAME, purpose="authenticate"
+    )
+    assert got is None
+
+
+@pytest.mark.asyncio
+async def test_malformed_id_returns_none(db_pool: asyncpg.Pool) -> None:
+    assert (
+        await webauthn_challenge_repo.consume_challenge(
+            db_pool, challenge_id="not-a-uuid", username=_USERNAME, purpose="authenticate"
+        )
+        is None
+    )

--- a/tests/unit/test_webauthn_routes.py
+++ b/tests/unit/test_webauthn_routes.py
@@ -25,7 +25,14 @@ from fastapi import FastAPI  # noqa: E402
 from httpx import ASGITransport, AsyncClient  # noqa: E402
 from webauthn.helpers.exceptions import InvalidAuthenticationResponse  # noqa: E402
 
-from whilly.api import auth_tokens, rate_limit, sessions, users_repo, webauthn_repo  # noqa: E402
+from whilly.api import (  # noqa: E402
+    auth_tokens,
+    rate_limit,
+    sessions,
+    users_repo,
+    webauthn_challenge_repo,
+    webauthn_repo,
+)
 from whilly.api.csrf import COOKIE_NAME  # noqa: E402
 from whilly.api.second_factor import PENDING_COOKIE_NAME, PENDING_MAX_ATTEMPTS, _mint_pending_cookie  # noqa: E402
 from whilly.api.webauthn_routes import (  # noqa: E402
@@ -98,6 +105,13 @@ async def client(monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[AsyncClient]:
     # server-side lockout; neutralise both by default (tests override per case).
     monkeypatch.setattr(rate_limit, "allow", lambda key: True)
     monkeypatch.setattr(users_repo, "is_account_locked", AsyncMock(return_value=False))
+    # The challenge now lives server-side (migration 027): begin mints an id,
+    # verify/finish consume the challenge bytes. Default the store so the
+    # ceremony tests stay deterministic; single-use tests override consume.
+    monkeypatch.setattr(
+        webauthn_challenge_repo, "create_challenge", AsyncMock(return_value="11111111-1111-1111-1111-111111111111")
+    )
+    monkeypatch.setattr(webauthn_challenge_repo, "consume_challenge", AsyncMock(return_value=_CHALLENGE))
     app = FastAPI()
     app.include_router(build_webauthn_router(pool=None, secret=_TEST_SECRET, cookie_secure=False))  # type: ignore[arg-type]
     transport = ASGITransport(app=app)
@@ -391,6 +405,68 @@ async def test_choose_factor_renders_both_options(client: AsyncClient) -> None:
     resp = await client.get("/auth/2fa")
     assert resp.status_code == 200
     assert "/auth/webauthn" in resp.text and "/auth/totp" in resp.text
+
+
+# ── server-side single-use challenge (Finding 2) ────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_auth_begin_persists_challenge_server_side(client: AsyncClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    """begin stores the challenge in the DB and the cookie carries only its id —
+    never the challenge bytes."""
+    monkeypatch.setattr(webauthn_repo, "get_credentials_by_username", AsyncMock(return_value=[_stored_cred()]))
+    create = AsyncMock(return_value="abcdef00-0000-4000-8000-000000000000")
+    monkeypatch.setattr(webauthn_challenge_repo, "create_challenge", create)
+    client.cookies.set(PENDING_COOKIE_NAME, _mint_pending_cookie(_TEST_SECRET, username=_USERNAME))
+    resp = await client.post("/auth/webauthn/begin")
+    assert resp.status_code == 200
+    assert create.await_args.kwargs["purpose"] == "authenticate"
+    # The re-minted pending cookie carries the challenge_id, not a challenge.
+    from whilly.api.second_factor import _verify_pending_cookie
+
+    new_pending = next(
+        v.split(f"{PENDING_COOKIE_NAME}=")[1].split(";")[0]
+        for v in resp.headers.get_list("set-cookie")
+        if PENDING_COOKIE_NAME in v
+    )
+    payload = _verify_pending_cookie(_TEST_SECRET, new_pending)
+    assert payload is not None and payload.get("c") == "abcdef00-0000-4000-8000-000000000000"
+
+
+@pytest.mark.asyncio
+async def test_auth_verify_replayed_challenge_rejected(client: AsyncClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The single-use proof: when consume returns None (already redeemed / expired
+    / replayed), verify is rejected before any assertion check or session mint."""
+    monkeypatch.setattr(webauthn_challenge_repo, "consume_challenge", AsyncMock(return_value=None))
+    get_cred = AsyncMock(return_value=_stored_cred())
+    monkeypatch.setattr(webauthn_repo, "get_credential_by_id", get_cred)
+    create_sess = AsyncMock(return_value=_session())
+    monkeypatch.setattr(sessions, "create_session", create_sess)
+    pending = _mint_pending_cookie(_TEST_SECRET, username=_USERNAME, challenge="dead0000-0000-4000-8000-000000000000")
+    client.cookies.set(PENDING_COOKIE_NAME, pending)
+    resp = await client.post("/auth/webauthn/verify", json={"rawId": _b64url_encode(_CRED_ID), "response": {}})
+    assert resp.status_code == 401  # _handle_failed_assertion (attempts < max)
+    # Never looked the credential up, never minted a session.
+    assert get_cred.await_count == 0
+    assert create_sess.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_register_finish_consumed_challenge_400(client: AsyncClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A registration finish whose challenge was already consumed/expired is 400."""
+    monkeypatch.setattr(sessions, "verify_session", AsyncMock(return_value=_session()))
+    monkeypatch.setattr(users_repo, "get_user_by_username", AsyncMock(return_value=_user()))
+    monkeypatch.setattr(webauthn_challenge_repo, "consume_challenge", AsyncMock(return_value=None))
+    insert = AsyncMock(return_value=None)
+    monkeypatch.setattr(webauthn_repo, "insert_credential", insert)
+    client.cookies.set(COOKIE_NAME, _session_cookie())
+    reg_cookie = _mint_pending_cookie(
+        _TEST_SECRET, username=_USERNAME, challenge="beef0000-0000-4000-8000-000000000000"
+    )
+    client.cookies.set(REG_COOKIE_NAME, reg_cookie)
+    resp = await client.post("/me/webauthn/register/finish", json={"id": "x", "response": {}})
+    assert resp.status_code == 400
+    assert insert.await_count == 0
 
 
 # silence unused-import lint for the round-trip decode helper

--- a/whilly/adapters/db/migrations/versions/027_webauthn_challenges.py
+++ b/whilly/adapters/db/migrations/versions/027_webauthn_challenges.py
@@ -1,0 +1,103 @@
+"""Add ``webauthn_challenges`` table — server-side single-use WebAuthn challenges.
+
+Security follow-up to E15 (post-merge review, Finding 2). The WebAuthn challenge
+used to be carried inside the HMAC-signed pending/registration cookie. The cookie
+guarantees integrity, but not *freshness*: a captured ``(cookie, assertion)`` pair
+could be replayed within the cookie's 5-minute TTL, and the sign-count regression
+check does not help counter-less synced passkeys (iCloud/Google), which report
+``sign_count = 0`` forever.
+
+This table makes the challenge **single-use, server-side**: ``begin`` inserts a
+row keyed by a random ``challenge_id`` (the cookie now carries only that id), and
+``verify``/``finish`` atomically ``DELETE … RETURNING`` it — so a second redemption
+finds nothing. The table ships unconditionally (portable schema), but only the
+flag-gated WebAuthn routes touch it.
+
+Schema:
+
+* ``id``            — BIGINT IDENTITY PK (project convention, matches 026).
+* ``challenge_id``  — UUID NOT NULL UNIQUE. Random handle carried in the cookie;
+                      the row is looked up + consumed by this value.
+* ``username``      — TEXT NOT NULL, FK → ``users(username)`` ON DELETE CASCADE.
+                      A challenge is only ever minted for a known user (an admin
+                      session for register, a password-verified pending cookie
+                      for authenticate), so the FK is safe and keeps the table
+                      tidy when a user is deleted.
+* ``purpose``       — TEXT NOT NULL CHECK IN ('register','authenticate'). Binds a
+                      challenge to its ceremony so a registration challenge can't
+                      be redeemed by the authentication path or vice-versa.
+* ``challenge``     — BYTEA NOT NULL. The raw server-generated challenge bytes.
+* ``created_at``    — TIMESTAMPTZ NOT NULL DEFAULT NOW().
+* ``expires_at``    — TIMESTAMPTZ NOT NULL. Consume rejects expired rows; the repo
+                      also opportunistically sweeps expired rows on insert.
+
+Indexes:
+
+* ``ix_webauthn_challenges_expires`` — (expires_at) for the cheap expiry sweep.
+
+Revision ID: 027_webauthn_challenges
+Revises: 026_webauthn_credentials
+Create Date: 2026-05-21
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "027_webauthn_challenges"
+down_revision: str | None = "026_webauthn_credentials"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+WEBAUTHN_CHALLENGES_TABLE: str = "webauthn_challenges"
+WEBAUTHN_CHALLENGES_EXPIRES_INDEX: str = "ix_webauthn_challenges_expires"
+WEBAUTHN_CHALLENGES_PURPOSE_CHECK: str = "ck_webauthn_challenges_purpose_valid"
+
+
+def upgrade() -> None:
+    op.create_table(
+        WEBAUTHN_CHALLENGES_TABLE,
+        sa.Column(
+            "id",
+            sa.BigInteger(),
+            sa.Identity(always=False, start=1),
+            primary_key=True,
+        ),
+        sa.Column("challenge_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("username", sa.Text(), nullable=False),
+        sa.Column("purpose", sa.Text(), nullable=False),
+        sa.Column("challenge", sa.LargeBinary(), nullable=False),
+        sa.Column(
+            "created_at",
+            postgresql.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+        sa.Column("expires_at", postgresql.TIMESTAMP(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["username"],
+            ["users.username"],
+            name="fk_webauthn_challenges_username",
+            ondelete="CASCADE",
+        ),
+        sa.UniqueConstraint("challenge_id", name="uq_webauthn_challenges_challenge_id"),
+        sa.CheckConstraint(
+            "purpose IN ('register', 'authenticate')",
+            name=WEBAUTHN_CHALLENGES_PURPOSE_CHECK,
+        ),
+    )
+    op.create_index(
+        WEBAUTHN_CHALLENGES_EXPIRES_INDEX,
+        WEBAUTHN_CHALLENGES_TABLE,
+        ["expires_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(WEBAUTHN_CHALLENGES_EXPIRES_INDEX, table_name=WEBAUTHN_CHALLENGES_TABLE)
+    op.drop_table(WEBAUTHN_CHALLENGES_TABLE)

--- a/whilly/api/second_factor.py
+++ b/whilly/api/second_factor.py
@@ -25,8 +25,10 @@ is centralised here:
 
 The pending cookie is factor-agnostic — it only states "password verified for
 user X, awaiting a second factor" — so every verify route (TOTP or WebAuthn)
-redeems the same cookie. The WebAuthn ceremony additionally re-mints it with a
-single-use ``challenge`` embedded (security gate #1); TOTP omits that field.
+redeems the same cookie. The WebAuthn ceremony additionally re-mints it carrying
+a server-side ``challenge_id`` (the random handle for the single-use challenge
+row in ``webauthn_challenges`` — migration 027); TOTP omits that field. The
+challenge itself is never in the cookie.
 
 The pending-cookie helpers used to live in :mod:`whilly.api.totp_routes`;
 they were moved here unchanged (apart from the rename below) so there is a
@@ -73,10 +75,11 @@ def _mint_pending_cookie(
 ) -> str:
     """Sign ``{username, exp, attempts[, challenge]}`` with HMAC-SHA256.
 
-    Returns ``payload.sig``. ``challenge`` (a base64url string) is only present
-    for the WebAuthn assertion ceremony, where the server-generated challenge
-    must survive the begin→verify round-trip bound to this cookie and expire
-    with it (security gate #1). TOTP never sets it.
+    Returns ``payload.sig``. ``challenge`` here is the WebAuthn ceremony's
+    server-side ``challenge_id`` (the random handle for the single-use row in
+    ``webauthn_challenges``), carried so it survives the begin→verify round-trip
+    bound to this cookie; the challenge bytes themselves stay server-side. TOTP
+    never sets it.
     """
     payload: dict[str, object] = {
         "u": username,

--- a/whilly/api/webauthn_challenge_repo.py
+++ b/whilly/api/webauthn_challenge_repo.py
@@ -1,0 +1,109 @@
+"""Async DB repository for ``webauthn_challenges`` (migration 027 / E15 Finding 2).
+
+Server-side single-use WebAuthn challenges. The ceremony routes
+(:mod:`whilly.api.webauthn_routes`) mint a challenge on ``begin`` and redeem it on
+``verify``/``finish``; the cookie carries only the random ``challenge_id``, never
+the challenge itself.
+
+The single-use guarantee is the atomic ``DELETE … RETURNING`` in
+:func:`consume_challenge`: the first redemption returns the challenge and removes
+the row, so any replay (same cookie + same assertion within the TTL) finds
+nothing. This closes the gap that the sign-count check leaves open for
+counter-less synced passkeys.
+
+Pattern matches the other ``whilly/api`` repos — pure asyncpg, no FastAPI and no
+``webauthn`` import (it only stores opaque bytes + metadata).
+"""
+
+from __future__ import annotations
+
+import datetime
+import uuid
+
+import asyncpg
+
+
+async def create_challenge(
+    pool: asyncpg.Pool,
+    *,
+    username: str,
+    purpose: str,
+    challenge: bytes,
+    ttl_seconds: int,
+) -> str:
+    """Persist a fresh challenge and return its ``challenge_id`` (UUID string).
+
+    The id — not the challenge — is what the cookie carries. Expired rows are
+    swept opportunistically on each insert so the table stays bounded without a
+    separate cron. ``purpose`` must be ``'register'`` or ``'authenticate'`` (the
+    CHECK constraint enforces it; binding the challenge to its ceremony stops a
+    register challenge being redeemed by the auth path).
+    """
+    if not isinstance(username, str) or not username.strip():
+        raise ValueError("create_challenge: username must be a non-empty string")
+    if purpose not in ("register", "authenticate"):
+        raise ValueError(f"create_challenge: purpose must be 'register' or 'authenticate', got {purpose!r}")
+    if not challenge:
+        raise ValueError("create_challenge: challenge must be non-empty bytes")
+    challenge_id = uuid.uuid4()
+    expires_at = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(seconds=int(ttl_seconds))
+    normalised = username.strip().lower()
+    async with pool.acquire() as conn:
+        # Opportunistic sweep — keeps the table tiny; best-effort, ignore errors.
+        try:
+            await conn.execute("DELETE FROM webauthn_challenges WHERE expires_at < NOW()")
+        except Exception:  # noqa: BLE001 — sweep is non-critical
+            pass
+        await conn.execute(
+            """
+            INSERT INTO webauthn_challenges (challenge_id, username, purpose, challenge, expires_at)
+            VALUES ($1, $2, $3, $4, $5)
+            """,
+            challenge_id,
+            normalised,
+            purpose,
+            challenge,
+            expires_at,
+        )
+    return str(challenge_id)
+
+
+async def consume_challenge(
+    pool: asyncpg.Pool,
+    *,
+    challenge_id: str,
+    username: str,
+    purpose: str,
+) -> bytes | None:
+    """Atomically redeem a challenge: return its bytes and delete the row.
+
+    Returns ``None`` when the id is malformed, the row is missing (already
+    consumed / never existed), expired, or bound to a different user/purpose —
+    the caller treats every ``None`` identically as "challenge invalid, start
+    over". The ``DELETE … RETURNING`` makes redemption single-use.
+    """
+    if not isinstance(challenge_id, str) or not isinstance(username, str):
+        return None
+    try:
+        cid = uuid.UUID(challenge_id)
+    except (ValueError, AttributeError, TypeError):
+        return None
+    normalised = username.strip().lower()
+    async with pool.acquire() as conn:
+        row = await conn.fetchval(
+            """
+            DELETE FROM webauthn_challenges
+             WHERE challenge_id = $1 AND username = $2 AND purpose = $3 AND expires_at > NOW()
+            RETURNING challenge
+            """,
+            cid,
+            normalised,
+            purpose,
+        )
+    return bytes(row) if row is not None else None
+
+
+__all__ = [
+    "consume_challenge",
+    "create_challenge",
+]

--- a/whilly/api/webauthn_routes.py
+++ b/whilly/api/webauthn_routes.py
@@ -31,8 +31,11 @@ Chooser:
 
 Security posture (see .planning/E15-E17-auth-security-design.md §2):
 
-* The challenge is server-generated (``os.urandom(32)``), single-use, carried
-  inside the HMAC-signed pending/registration cookie, and expires with it.
+* The challenge is server-generated (``os.urandom(32)``) and stored **server-side**
+  in ``webauthn_challenges`` (migration 027); the cookie carries only its random
+  ``challenge_id``. ``verify``/``finish`` consume it atomically (``DELETE …
+  RETURNING``) so it is truly single-use — a replayed ``(cookie, assertion)`` pair
+  finds nothing even for counter-less synced passkeys (Finding 2).
 * ``expected_origin`` / ``rp_id`` come from :class:`WebAuthnConfig` (resolved
   from ``WHILLY_PUBLIC_ORIGIN`` at router build time) — **never** from a request
   header. Building the router with the flag on but no origin raises (fail-closed).
@@ -61,7 +64,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 
-from whilly.api import rate_limit, sessions, users_repo, webauthn_repo
+from whilly.api import rate_limit, sessions, users_repo, webauthn_challenge_repo, webauthn_repo
 from whilly.api.admin_users_routes import require_admin_role
 from whilly.api.auth_routes import (
     DEFAULT_SESSION_COOKIE_NAME,
@@ -74,6 +77,7 @@ from whilly.api.auth_tokens import DEFAULT_SESSION_TTL_SECONDS, mint_session_coo
 from whilly.api.prod_mode import cookie_secure_default
 from whilly.api.second_factor import (
     PENDING_COOKIE_NAME,
+    PENDING_COOKIE_TTL_SECONDS,
     PENDING_MAX_ATTEMPTS,
     _clear_pending_cookie,
     _mint_pending_cookie,
@@ -219,7 +223,12 @@ def build_webauthn_router(
             exclude_credentials=exclude,
         )
         response = Response(content=options_to_json(options), media_type="application/json")
-        reg_cookie = _mint_pending_cookie(secret, username=username, challenge=_b64url_encode(challenge))
+        # Store the challenge server-side (single-use); the cookie carries only
+        # its id, never the challenge itself (Finding 2).
+        challenge_id = await webauthn_challenge_repo.create_challenge(
+            pool, username=username, purpose="register", challenge=challenge, ttl_seconds=PENDING_COOKIE_TTL_SECONDS
+        )
+        reg_cookie = _mint_pending_cookie(secret, username=username, challenge=challenge_id)
         _set_pending_cookie(response, value=reg_cookie, secure=cookie_secure, name=REG_COOKIE_NAME)
         return response
 
@@ -230,16 +239,22 @@ def build_webauthn_router(
 
         username = str(principal["username"])
         reg = _verify_pending_cookie(secret, request.cookies.get(REG_COOKIE_NAME, ""))
-        challenge_b64 = reg.get("c") if reg else None
-        if not reg or not isinstance(challenge_b64, str) or str(reg.get("u")) != username:
+        challenge_id = reg.get("c") if reg else None
+        if not reg or not isinstance(challenge_id, str) or str(reg.get("u")) != username:
             # Cookie missing/expired/forged, or bound to a different user than
             # the authenticated admin — refuse (cannot enroll a key for someone else).
+            raise HTTPException(status_code=400, detail="registration session expired — start over")
+        # Redeem the single-use challenge from the server-side store (Finding 2).
+        challenge = await webauthn_challenge_repo.consume_challenge(
+            pool, challenge_id=challenge_id, username=username, purpose="register"
+        )
+        if challenge is None:
             raise HTTPException(status_code=400, detail="registration session expired — start over")
         body = await request.json()
         try:
             verified = verify_registration_response(
                 credential=body,
-                expected_challenge=_b64url_decode(challenge_b64),
+                expected_challenge=challenge,
                 expected_rp_id=config.rp_id,
                 expected_origin=config.expected_origin,
                 require_user_verification=False,
@@ -310,12 +325,13 @@ def build_webauthn_router(
             user_verification=UserVerificationRequirement.PREFERRED,
         )
         response = Response(content=options_to_json(options), media_type="application/json")
-        # Re-mint the pending cookie with the fresh challenge bound to it
-        # (single-use, expires with the cookie — security gate #1), preserving
-        # the failed-attempt counter across the begin→verify round-trip.
-        new_pending = _mint_pending_cookie(
-            secret, username=username, attempts=attempts, challenge=_b64url_encode(challenge)
+        # Store the challenge server-side (single-use, consumed at verify) and
+        # carry only its id in the re-minted pending cookie, preserving the
+        # failed-attempt counter across the begin→verify round-trip (Finding 2).
+        challenge_id = await webauthn_challenge_repo.create_challenge(
+            pool, username=username, purpose="authenticate", challenge=challenge, ttl_seconds=PENDING_COOKIE_TTL_SECONDS
         )
+        new_pending = _mint_pending_cookie(secret, username=username, attempts=attempts, challenge=challenge_id)
         _set_pending_cookie(response, value=new_pending, secure=cookie_secure)
         return response
 
@@ -328,8 +344,8 @@ def build_webauthn_router(
         if not rate_limit.allow(client_ip):
             raise HTTPException(status_code=429, detail="too many requests")
         pending = _verify_pending_cookie(secret, request.cookies.get(PENDING_COOKIE_NAME, ""))
-        challenge_b64 = pending.get("c") if pending else None
-        if not pending or not isinstance(challenge_b64, str):
+        challenge_id = pending.get("c") if pending else None
+        if not pending or not isinstance(challenge_id, str):
             raise HTTPException(status_code=401, detail="login session expired — start over")
         username = str(pending.get("u", ""))
         attempts = int(pending.get("a", 0))
@@ -344,6 +360,15 @@ def build_webauthn_router(
                 status_code=status.HTTP_429_TOO_MANY_REQUESTS,
             )
 
+        # Redeem the single-use challenge UP FRONT: even a failed verify burns it,
+        # so a replayed (cookie, assertion) within the TTL finds nothing — the
+        # replay defense that does not depend on the (counter-less) sign count.
+        challenge = await webauthn_challenge_repo.consume_challenge(
+            pool, challenge_id=challenge_id, username=username, purpose="authenticate"
+        )
+        if challenge is None:
+            return _handle_failed_assertion(secret, username=username, attempts=attempts, cookie_secure=cookie_secure)
+
         body = await request.json()
         raw_id = body.get("rawId") or body.get("id") if isinstance(body, dict) else None
         stored = None
@@ -357,7 +382,7 @@ def build_webauthn_router(
             try:
                 verified = verify_authentication_response(
                     credential=body,
-                    expected_challenge=_b64url_decode(challenge_b64),
+                    expected_challenge=challenge,
                     expected_rp_id=config.rp_id,
                     expected_origin=config.expected_origin,
                     credential_public_key=stored.public_key,


### PR DESCRIPTION
## Finding 2 (Low → fixed)

The WebAuthn challenge was carried inside the HMAC-signed pending/registration cookie. HMAC gives **integrity, not freshness** — single-use rested on cookie-clear-on-success + the sign-count regression check, and that check is a **no-op for counter-less synced passkeys** (iCloud/Google report `sign_count=0` forever). A captured `(cookie, assertion)` pair could be replayed within the 5-min TTL.

## Fix — move the challenge server-side

- **Migration `027_webauthn_challenges`** — `challenge_id` UUID, `username` FK→users (CASCADE), `purpose` CHECK (`register`/`authenticate`), `challenge` bytea, `expires_at` + expiry index.
- **`webauthn_challenge_repo.py`** — `create_challenge` (+ opportunistic expiry sweep) and `consume_challenge` (atomic `DELETE … RETURNING` = single-use).
- **`webauthn_routes`** — `begin` stores the challenge and the cookie carries only its **id**; `verify`/`finish` consume it **before** verifying, so even a failed verify burns it and a replay finds nothing. `purpose` binds a challenge to its ceremony.

**Why DB-backed, not in-process:** forced by correctness — a `begin` on one uvicorn worker must be redeemable by `verify` on another. (An in-process dict would silently break multi-worker auth.)

## Tests
- **Unit (CI-gated):** begin persists the id (not the challenge) in the cookie; **a replayed/consumed challenge is rejected before any assertion check or session mint**; register-finish 400 on a consumed challenge.
- **Integration (real pool, migration 027):** single-use, purpose/user binding, expiry, malformed id.

Local: `2352 passed, 3 skipped`; ruff + import-linter (2/2) + mypy core green. Decision in ADR-001 §P1.9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)