### PR TITLE
feat(auth): E17 num_trusted_hops for chained proxies (implements ADR-001 §P1.8)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -266,6 +266,15 @@ WHILLY_DATABASE_URL=postgresql://whilly:whilly@localhost:5432/whilly
 # WHILLY_TRUST_PROXY_AUTH=0             # default; header ignored entirely
 # WHILLY_TRUST_PROXY_AUTH=1             # opt in (requires the allowlist below)
 # WHILLY_TRUSTED_PROXY_IPS=10.0.0.0/24,127.0.0.1/32
+#
+# WHILLY_TRUSTED_PROXY_HOP_COUNT (default 1) — how many trusted proxies sit in
+# front of Whilly. 1 = trust the direct peer only (X-Forwarded-For ignored).
+# Set to N>1 ONLY for a chain like client → LB → auth-proxy → Whilly: the N
+# hops nearest Whilly (direct peer + X-Forwarded-For walked right-to-left) must
+# ALL be in WHILLY_TRUSTED_PROXY_IPS, so a forged X-Forwarded-For cannot widen
+# trust. A too-short X-Forwarded-For fails closed. See ADR-001 §P1.8.
+# WHILLY_TRUSTED_PROXY_HOP_COUNT=1      # default
+# WHILLY_TRUSTED_PROXY_HOP_COUNT=2      # e.g. one L4 LB in front of the auth proxy
 
 # ─── WebAuthn / passkeys as a second factor (PRD §Item 15 — E15) ─────────────
 # Admin-only hardware-passkey second factor, layered on top of the password

--- a/docs/adr/ADR-001-auth-hardening-p1.md
+++ b/docs/adr/ADR-001-auth-hardening-p1.md
@@ -273,11 +273,10 @@ an existing lock and is IP-rate-limited.
 
 ---
 
-## P1.8 — E17 chained-proxy trust (`num_trusted_hops`) — DEFERRED, scoped here
+## P1.8 — E17 chained-proxy trust (`num_trusted_hops`) — IMPLEMENTED
 
-**Status:** Open / deferred (no code). Scoped so the open question from §P1.6
-("single proxy assumed; chained proxies would need a documented
-`num_trusted_hops`") is recorded rather than lost.
+**Status:** Implemented. Closes the open question from §P1.6 ("single proxy
+assumed; chained proxies would need a documented `num_trusted_hops`").
 
 **Problem.** E17 (`whilly/api/oidc_header_auth.py`) trusts the `X-Forwarded-User`
 header only when the **direct TCP peer** (`request.client.host`) is in
@@ -297,26 +296,26 @@ is exactly correct for the **single-hop** topology it was designed for
 case behind an unanticipated LB is *no* proxy auth (401 → cookie login), never a
 bypass. So this is a capability gap, not an open vulnerability.
 
-**Proposed design (only if a multi-hop deployment actually needs it).** Add
-`WHILLY_TRUSTED_PROXY_HOP_COUNT` (default `1` = today's behaviour). When `> 1`,
-walk `X-Forwarded-For` **from the right** (nearest hop first), validating each of
-the N nearest entries against `WHILLY_TRUSTED_PROXY_IPS`; accept the header only
-if **all N nearest hops are trusted** and stop at the first untrusted hop.
-`X-Forwarded-For` is still never trusted blindly — only entries that match the
-allowlist count, and the count bounds how far the walk goes.
+**Design (as built).** `WHILLY_TRUSTED_PROXY_HOP_COUNT` (default `1` = the
+peer-IP-only behaviour). When `> 1`, `ProxyHeaderAuthConfig.chain_is_trusted`
+builds the nearest-first chain `[direct peer, *reversed(X-Forwarded-For)]` and
+requires the first `N` entries to **all** be in `WHILLY_TRUSTED_PROXY_IPS`.
+`X-Forwarded-For` is never trusted blindly — only allowlisted entries count, and
+`N` bounds how far the walk goes. `from_env` fail-closes on a non-integer or
+out-of-range (`1..16`) hop count.
 
-**Acceptance criteria for the future task.**
-- Default `1` is byte-equivalent to the current peer-IP-only path.
-- With `N` configured, a request is trusted iff the `N` nearest XFF hops are all
-  in the allowlist; any untrusted hop within the first `N` → reject (fail-closed).
-- A short/empty/malformed `X-Forwarded-For` under `N>1` → reject, never trust.
-- Spoofing the *(N+1)*th entry (the purported client) must not grant trust.
-- Tests mirror `test_oidc_header_auth.py` (trusted/untrusted peer, missing user)
-  plus hop-walk and spoof cases.
+**Guarantees (verified by `test_oidc_header_auth.py`).**
+- Default `1` is byte-equivalent to the peer-IP-only path (XFF ignored), so a
+  forged XFF cannot widen trust.
+- With `N`, a request is trusted iff the `N` nearest hops are all allowlisted;
+  any untrusted hop within the first `N` → reject (fail-closed).
+- A short/empty/missing `X-Forwarded-For` under `N>1` → reject.
+- The `(N+1)`-th entry (the purported client) is never required to be trusted, so
+  spoofing it changes nothing.
 
-**Not doing now because:** no chained-proxy deployment exists; building
-multi-hop XFF trust speculatively adds the highest-risk kind of auth code (the
-one that parses a client-controlled header) for no current consumer.
+**Operational note.** Set `N` to the exact number of trusted proxies in front of
+Whilly, and put every one of them in `WHILLY_TRUSTED_PROXY_IPS`. An off-by-one
+(too low) fails closed (no auth); too high also fails closed (XFF too short).
 
 ---
 

--- a/tests/unit/test_oidc_header_auth.py
+++ b/tests/unit/test_oidc_header_auth.py
@@ -25,6 +25,7 @@ from starlette.routing import Route
 from whilly.api import auth_audit_repo, users_repo
 from whilly.api.oidc_header_auth import (
     TRUST_PROXY_AUTH_ENV,
+    TRUSTED_PROXY_HOP_COUNT_ENV,
     TRUSTED_PROXY_IPS_ENV,
     ProxyHeaderAuthConfig,
     ProxyHeaderAuthMiddleware,
@@ -208,3 +209,92 @@ async def test_authenticate_session_honours_proxy_principal() -> None:
     # before touching the cookie. Passing sentinels proves that.
     result = await _authenticate_session(request, pool=object(), secret=b"x", cookie_name="whilly_session")
     assert result == principal
+
+
+# ─── P1.8: trusted-proxy hop count (chained proxies) ─────────────────────────
+
+_2HOP_CFG = ProxyHeaderAuthConfig(enabled=True, networks=(ipaddress.ip_network("10.0.0.0/24"),), trusted_hops=2)
+
+
+def test_config_default_hop_count_is_one(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(TRUST_PROXY_AUTH_ENV, "1")
+    monkeypatch.setenv(TRUSTED_PROXY_IPS_ENV, "10.0.0.0/24")
+    monkeypatch.delenv(TRUSTED_PROXY_HOP_COUNT_ENV, raising=False)
+    assert ProxyHeaderAuthConfig.from_env().trusted_hops == 1
+
+
+def test_config_parses_hop_count(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(TRUST_PROXY_AUTH_ENV, "1")
+    monkeypatch.setenv(TRUSTED_PROXY_IPS_ENV, "10.0.0.0/24")
+    monkeypatch.setenv(TRUSTED_PROXY_HOP_COUNT_ENV, "2")
+    assert ProxyHeaderAuthConfig.from_env().trusted_hops == 2
+
+
+def test_config_fail_closed_on_non_integer_hop_count(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(TRUST_PROXY_AUTH_ENV, "1")
+    monkeypatch.setenv(TRUSTED_PROXY_IPS_ENV, "10.0.0.0/24")
+    monkeypatch.setenv(TRUSTED_PROXY_HOP_COUNT_ENV, "two")
+    with pytest.raises(RuntimeError, match="integer"):
+        ProxyHeaderAuthConfig.from_env()
+
+
+def test_config_fail_closed_on_zero_hop_count(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(TRUST_PROXY_AUTH_ENV, "1")
+    monkeypatch.setenv(TRUSTED_PROXY_IPS_ENV, "10.0.0.0/24")
+    monkeypatch.setenv(TRUSTED_PROXY_HOP_COUNT_ENV, "0")
+    with pytest.raises(RuntimeError, match="range"):
+        ProxyHeaderAuthConfig.from_env()
+
+
+def test_chain_hop1_ignores_forwarded_for() -> None:
+    # Default single hop: a forged XFF naming a trusted IP must not widen trust.
+    cfg = _TRUSTED_CFG
+    assert cfg.chain_is_trusted(peer_ip="10.0.0.7", forwarded_for="9.9.9.9") is True
+    assert cfg.chain_is_trusted(peer_ip="203.0.113.9", forwarded_for="10.0.0.7") is False
+
+
+def test_chain_hop2_requires_both_nearest_hops_trusted() -> None:
+    # client → P2(10.0.0.8) → P1(peer 10.0.0.7) → Whilly. XFF = "client, P2".
+    assert _2HOP_CFG.chain_is_trusted(peer_ip="10.0.0.7", forwarded_for="203.0.113.5, 10.0.0.8") is True
+    # Second-nearest hop (XFF[-1]) untrusted → reject.
+    assert _2HOP_CFG.chain_is_trusted(peer_ip="10.0.0.7", forwarded_for="203.0.113.5, 192.168.1.9") is False
+    # Direct peer untrusted → reject regardless of XFF.
+    assert _2HOP_CFG.chain_is_trusted(peer_ip="203.0.113.9", forwarded_for="10.0.0.8, 10.0.0.9") is False
+
+
+def test_chain_hop2_short_or_missing_xff_fails_closed() -> None:
+    # Need 2 hops but only the direct peer is available → reject.
+    assert _2HOP_CFG.chain_is_trusted(peer_ip="10.0.0.7", forwarded_for=None) is False
+    assert _2HOP_CFG.chain_is_trusted(peer_ip="10.0.0.7", forwarded_for="") is False
+
+
+def test_chain_hop2_client_spoof_in_xff_is_ignored() -> None:
+    # The (N+1)-th entry is the purported client; spoofing it to a trusted-looking
+    # IP changes nothing — trust is decided by the 2 nearest hops only.
+    assert _2HOP_CFG.chain_is_trusted(peer_ip="10.0.0.7", forwarded_for="10.0.0.250, 10.0.0.8") is True
+    # And an attacker on an untrusted peer can't fake a 2-hop chain.
+    assert _2HOP_CFG.chain_is_trusted(peer_ip="203.0.113.9", forwarded_for="10.0.0.7, 10.0.0.8") is False
+
+
+async def test_middleware_hop2_trusts_chain(monkeypatch: pytest.MonkeyPatch) -> None:
+    user = SimpleNamespace(username="alice", email="alice@example.test", role="admin")
+    recorded = _patch_user(monkeypatch, user)
+    resp = await _get(
+        _build_app(_2HOP_CFG),
+        peer="10.0.0.7",
+        headers={"X-Forwarded-User": "alice", "X-Forwarded-For": "203.0.113.5, 10.0.0.8"},
+    )
+    assert resp.json()["principal"] is not None
+    assert recorded and recorded[-1]["outcome"] == "ok"
+
+
+async def test_middleware_hop2_rejects_untrusted_second_hop(monkeypatch: pytest.MonkeyPatch) -> None:
+    user = SimpleNamespace(username="alice", email="alice@example.test", role="admin")
+    recorded = _patch_user(monkeypatch, user)
+    resp = await _get(
+        _build_app(_2HOP_CFG),
+        peer="10.0.0.7",
+        headers={"X-Forwarded-User": "alice", "X-Forwarded-For": "203.0.113.5, 192.168.1.9"},
+    )
+    assert resp.json()["principal"] is None
+    assert recorded == []

--- a/whilly/api/oidc_header_auth.py
+++ b/whilly/api/oidc_header_auth.py
@@ -15,9 +15,12 @@ Security invariants — enforced here, verified by ``tests/unit/test_oidc_header
 * **Fail-closed.** Enabling the feature with an empty or unparseable allowlist
   raises at startup (``create_app`` time). An empty allowlist would trust the
   header from *any* peer — a full authentication bypass — so we refuse to boot.
-* **Peer IP only.** The allowlist is checked against ``request.client.host`` (the
-  direct TCP peer), **never** ``X-Forwarded-For`` — that header is itself
-  client-controlled and trusting it would defeat the allowlist.
+* **Peer IP by default; allowlisted hops only.** With the default
+  ``WHILLY_TRUSTED_PROXY_HOP_COUNT=1`` the allowlist is checked against
+  ``request.client.host`` (the direct TCP peer) and ``X-Forwarded-For`` is
+  ignored entirely. With ``N > 1`` the N proxies nearest Whilly (direct peer +
+  XFF walked right-to-left) must *all* be in the allowlist — only allowlisted
+  hops count, so a forged XFF can never widen trust (ADR-001 §P1.8).
 * **Transient.** No row is written to ``sessions``; the identity lives only on
   ``request.state.proxy_principal`` and is honoured by
   :func:`whilly.api.auth_routes._authenticate_session` before the cookie path.
@@ -55,8 +58,18 @@ TRUST_PROXY_AUTH_ENV: Final[str] = "WHILLY_TRUST_PROXY_AUTH"
 #: Comma-separated CIDR / IP allowlist of *direct peers* permitted to assert
 #: the identity header. Required (non-empty, parseable) when the feature is on.
 TRUSTED_PROXY_IPS_ENV: Final[str] = "WHILLY_TRUSTED_PROXY_IPS"
+#: Number of trusted proxy hops in front of Whilly. Default 1 (the direct peer
+#: only — X-Forwarded-For ignored). When > 1, the N proxies closest to Whilly
+#: (direct peer + X-Forwarded-For walked right-to-left) must ALL be in the
+#: allowlist. See ADR-001 §P1.8.
+TRUSTED_PROXY_HOP_COUNT_ENV: Final[str] = "WHILLY_TRUSTED_PROXY_HOP_COUNT"
+#: Defensive upper bound on the hop count — a realistic chain is 1–3 hops.
+_MAX_TRUSTED_HOPS: Final[int] = 16
 #: The trusted identity header set by the reverse proxy.
 FORWARDED_USER_HEADER: Final[str] = "X-Forwarded-User"
+#: Standard hop-recording header. Only consulted when ``trusted_hops > 1``, and
+#: even then only entries matching the allowlist count toward trust.
+FORWARDED_FOR_HEADER: Final[str] = "X-Forwarded-For"
 
 #: Nominal TTL stamped onto the transient principal. The session is not
 #: persisted, so this only bounds how long downstream code treats the principal
@@ -72,6 +85,26 @@ def _truthy(raw: str | None) -> bool:
     return (raw or "").strip().lower() in _TruthyTokens
 
 
+def _resolve_hop_count(raw: str | None) -> int:
+    """Parse the hop count, defaulting to 1 and failing closed on a bad value."""
+    text = (raw or "").strip()
+    if not text:
+        return 1
+    try:
+        hops = int(text)
+    except ValueError as exc:
+        raise RuntimeError(
+            f"{TRUSTED_PROXY_HOP_COUNT_ENV}={text!r} is not an integer. Refusing to start "
+            f"rather than guessing how many proxy hops to trust."
+        ) from exc
+    if hops < 1 or hops > _MAX_TRUSTED_HOPS:
+        raise RuntimeError(
+            f"{TRUSTED_PROXY_HOP_COUNT_ENV}={hops} is out of range — must be 1..{_MAX_TRUSTED_HOPS}. "
+            f"1 = trust the direct peer only; higher = that many trusted proxies in front of Whilly."
+        )
+    return hops
+
+
 @dataclass(frozen=True)
 class ProxyHeaderAuthConfig:
     """Resolved configuration for header-trust auth.
@@ -83,6 +116,7 @@ class ProxyHeaderAuthConfig:
 
     enabled: bool
     networks: tuple[_IPNetwork, ...] = ()
+    trusted_hops: int = 1
 
     @classmethod
     def from_env(cls) -> ProxyHeaderAuthConfig:
@@ -93,6 +127,10 @@ class ProxyHeaderAuthConfig:
         non-empty, fully-parseable CIDR/IP list — otherwise this raises
         :class:`RuntimeError` so the app refuses to start rather than trusting
         the identity header from an unbounded set of peers.
+
+        ``WHILLY_TRUSTED_PROXY_HOP_COUNT`` defaults to 1 (direct-peer trust). A
+        value that is not an integer in ``[1, _MAX_TRUSTED_HOPS]`` raises (fail-
+        closed — a broken hop count must not silently widen or disable trust).
         """
         if not _truthy(os.environ.get(TRUST_PROXY_AUTH_ENV)):
             return cls(enabled=False)
@@ -117,10 +155,12 @@ class ProxyHeaderAuthConfig:
                     f"{TRUSTED_PROXY_IPS_ENV} contains an invalid CIDR/IP {entry!r}: {exc}. "
                     f"Refusing to start rather than silently trusting a broken allowlist."
                 ) from exc
-        return cls(enabled=True, networks=tuple(networks))
+
+        trusted_hops = _resolve_hop_count(os.environ.get(TRUSTED_PROXY_HOP_COUNT_ENV))
+        return cls(enabled=True, networks=tuple(networks), trusted_hops=trusted_hops)
 
     def peer_is_trusted(self, peer_ip: str | None) -> bool:
-        """True iff ``peer_ip`` (the direct TCP peer) is inside the allowlist."""
+        """True iff ``peer_ip`` (a single hop) is inside the allowlist."""
         if not peer_ip:
             return False
         try:
@@ -128,6 +168,28 @@ class ProxyHeaderAuthConfig:
         except ValueError:
             return False
         return any(addr in network for network in self.networks)
+
+    def chain_is_trusted(self, *, peer_ip: str | None, forwarded_for: str | None) -> bool:
+        """True iff the ``trusted_hops`` nearest hops are ALL allowlisted.
+
+        For the default ``trusted_hops == 1`` this is exactly
+        :meth:`peer_is_trusted` on the direct peer — ``X-Forwarded-For`` is
+        ignored, so a forged XFF cannot widen trust (the single-hop invariant).
+
+        For ``N > 1`` the nearest-first chain is ``[direct peer, *reversed(XFF)]``:
+        ``X-Forwarded-For`` is appended oldest→newest, so its rightmost entry is
+        the proxy one hop further out, etc. We require the first ``N`` of that
+        chain to all be allowlisted. The ``(N+1)``-th entry is the purported
+        client and is never required to be trusted; a missing/short XFF (fewer
+        than ``N`` hops available) fails closed.
+        """
+        if self.trusted_hops <= 1:
+            return self.peer_is_trusted(peer_ip)
+        xff = [chunk.strip() for chunk in (forwarded_for or "").split(",") if chunk.strip()]
+        chain = [peer_ip, *reversed(xff)]
+        if len(chain) < self.trusted_hops:
+            return False
+        return all(self.peer_is_trusted(hop) for hop in chain[: self.trusted_hops])
 
 
 class ProxyHeaderAuthMiddleware(BaseHTTPMiddleware):
@@ -153,11 +215,14 @@ class ProxyHeaderAuthMiddleware(BaseHTTPMiddleware):
 
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
         forwarded_user = request.headers.get(FORWARDED_USER_HEADER)
-        # Resolve identity from the DIRECT peer IP only. We deliberately do not
-        # consult X-Forwarded-For: it is client-controlled, so trusting it would
-        # let any client spoof a "trusted" source address.
+        # Trust is gated on the direct peer (and, only when trusted_hops > 1, the
+        # additional nearest hops from X-Forwarded-For — but only allowlisted
+        # entries count, so a forged XFF can never widen trust). With the default
+        # single hop, X-Forwarded-For is ignored entirely.
         peer_ip = request.client.host if request.client else None
-        if forwarded_user and self._config.peer_is_trusted(peer_ip):
+        if forwarded_user and self._config.chain_is_trusted(
+            peer_ip=peer_ip, forwarded_for=request.headers.get(FORWARDED_FOR_HEADER)
+        ):
             await self._resolve_proxy_identity(request, forwarded_user=forwarded_user, peer_ip=peer_ip)
         return await call_next(request)
 
@@ -193,9 +258,11 @@ class ProxyHeaderAuthMiddleware(BaseHTTPMiddleware):
 
 
 __all__ = [
+    "FORWARDED_FOR_HEADER",
     "FORWARDED_USER_HEADER",
     "ProxyHeaderAuthConfig",
     "ProxyHeaderAuthMiddleware",
-    "TRUST_PROXY_AUTH_ENV",
+    "TRUSTED_PROXY_HOP_COUNT_ENV",
     "TRUSTED_PROXY_IPS_ENV",
+    "TRUST_PROXY_AUTH_ENV",
 ]


### PR DESCRIPTION
Implements the §P1.8 follow-up that was scoped+deferred in #311 — multi-hop reverse-proxy support for E17 header-trust, without ever trusting `X-Forwarded-For` blindly.

## Change
- **`WHILLY_TRUSTED_PROXY_HOP_COUNT`** (default `1` = today's peer-IP-only behaviour; XFF ignored). `from_env` fail-closes on a non-integer / out-of-range (`1..16`) value.
- **`ProxyHeaderAuthConfig.chain_is_trusted`** builds the nearest-first chain `[direct peer, *reversed(X-Forwarded-For)]` and requires the first **N** entries to **all** be in `WHILLY_TRUSTED_PROXY_IPS`. Only allowlisted hops count → a forged XFF can't widen trust; a too-short XFF fails closed; the `(N+1)`-th entry (the purported client) is never required to be trusted.
- Middleware gates on `chain_is_trusted`.

**Safe by default:** behaviour is byte-identical at `N=1`, and the feature only activates when an operator both sets `WHILLY_TRUST_PROXY_AUTH=1` **and** a hop count > 1.

## Tests (+10)
default/parse/fail-closed hop count; chain trust at `N=1` (XFF ignored) and `N=2`; short-XFF fail-closed; client-spoof ignored; two middleware-level cases. The existing 15 E17 tests stay green (default unchanged).

Local: `2363 passed, 3 skipped`; ruff + import-linter (2/2) + mypy core green. `.env.example` documented; ADR-001 §P1.8 flipped DEFERRED → IMPLEMENTED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)