### PR TITLE
fix(auth): pin magic-link origin + harden next-path (auth-surface review)

### DIFF
--- a/docs/adr/ADR-001-auth-hardening-p1.md
+++ b/docs/adr/ADR-001-auth-hardening-p1.md
@@ -358,6 +358,37 @@ the assertion check.
 
 ---
 
+## P1.11 — Auth URL safety (broader auth-surface review)
+
+A review of the rest of the auth surface (login / magic-link / change-password /
+sessions, beyond E15/E17) found the token, session and CSRF primitives sound
+(`hmac.compare_digest`, explicit `alg=HS256`, `typ`-claim separation, 256-bit
+session ids, atomic single-use magic-link consume, email-scoped session list,
+IDOR-guarded session revoke). Two URL-handling weaknesses were fixed:
+
+- **Finding 5 (Medium) — host-header injection in magic links.** `_build_magic_url`
+  built the link from `request.base_url` (the client-controlled `Host`). An
+  attacker could request a link for a *victim's* email while spoofing
+  `Host: attacker.test`; the victim's email would point at the attacker, who
+  harvests the valid single-use token on click → account takeover. Fixed by
+  `_public_base_url`: prefer `WHILLY_PUBLIC_ORIGIN` (already used by E15), falling
+  back to `request.base_url` only when unset (dev/loopback).
+- **Finding 7 (Low) — open-redirect via backslash in `?next=`.** Browsers fold
+  `\` to `/`, so `/\evil.com` becomes protocol-relative `//evil.com`.
+  `_sanitise_next_path` now rejects any path containing a backslash.
+
+**Also noted, NOT changed here — Finding 6 (Low).** `POST /auth/change-password`
+(the forced first-login flow) requires an authenticated session but neither the
+current password nor `must_change_password=True`, so a session that was hijacked
+(cookie theft) or left open could rotate the password without the current one —
+the check `POST /me/password` enforces. It is *not* CSRF-exploitable (SameSite=
+Strict cookie + Origin allowlist; the path is not CSRF-exempt). Recommended
+follow-up: gate the forced path to `must_change_password=True`, else redirect to
+`/me/password`. Deferred because it touches the must-change-gate flow and is
+lower-risk than the URL fixes above.
+
+---
+
 ## References
 
 - PRD: [`docs/PRD-post-auth-hardening.md`](../PRD-post-auth-hardening.md)

--- a/tests/unit/test_auth_url_safety.py
+++ b/tests/unit/test_auth_url_safety.py
@@ -1,0 +1,64 @@
+"""Unit tests for the auth URL-safety helpers (post-E15 review, Findings 5 + 7).
+
+Pure functions from ``whilly.api.auth_routes``:
+
+* ``_build_magic_url`` / ``_public_base_url`` — a magic link must be built from
+  the configured ``WHILLY_PUBLIC_ORIGIN``, not the client-controlled ``Host``
+  header (host-header injection → token harvest → account takeover, Finding 5).
+* ``_sanitise_next_path`` — ``?next=`` must stay a local path; the backslash
+  variants browsers fold to ``//`` must be rejected (open redirect, Finding 7).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from whilly.api.auth_routes import (
+    PUBLIC_ORIGIN_ENV,
+    _build_magic_url,
+    _public_base_url,
+    _sanitise_next_path,
+)
+
+
+def _req(base_url: str) -> object:
+    return SimpleNamespace(base_url=base_url)
+
+
+def test_magic_url_uses_configured_origin_not_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(PUBLIC_ORIGIN_ENV, "https://whilly.example.com")
+    # An attacker-controlled Host must be ignored when the origin is pinned.
+    url = _build_magic_url(_req("https://attacker.test/"), "tok123")
+    assert url.startswith("https://whilly.example.com/auth/magic?token=")
+    assert "attacker.test" not in url
+
+
+def test_magic_url_falls_back_to_host_when_origin_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(PUBLIC_ORIGIN_ENV, raising=False)
+    url = _build_magic_url(_req("http://127.0.0.1:8000/"), "tok123")
+    assert url == "http://127.0.0.1:8000/auth/magic?token=tok123"
+
+
+def test_public_base_url_strips_trailing_slash(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(PUBLIC_ORIGIN_ENV, "https://whilly.example.com/")
+    assert _public_base_url(_req("http://unused/")) == "https://whilly.example.com"
+
+
+@pytest.mark.parametrize("evil", ["//evil.com", "/\\evil.com", "\\/evil.com", "\\\\evil.com", "/path\\to"])
+def test_sanitise_next_rejects_redirect_tricks(evil: str) -> None:
+    assert _sanitise_next_path(evil) == "/"
+
+
+@pytest.mark.parametrize("absolute", ["http://evil.com", "https://evil.com", "javascript:alert(1)"])
+def test_sanitise_next_rejects_absolute_urls(absolute: str) -> None:
+    assert _sanitise_next_path(absolute) == "/"
+
+
+def test_sanitise_next_allows_local_deep_link() -> None:
+    assert _sanitise_next_path("/plans/foo?tab=tasks#x") == "/plans/foo?tab=tasks#x"
+
+
+def test_sanitise_next_defaults_root_on_empty() -> None:
+    assert _sanitise_next_path("") == "/"

--- a/whilly/api/auth_routes.py
+++ b/whilly/api/auth_routes.py
@@ -821,9 +821,31 @@ def _set_session_cookie(
     )
 
 
+#: Configured public origin (shared with E15 WebAuthn). When set, auth URLs are
+#: built from it instead of the request's Host header — see _public_base_url.
+PUBLIC_ORIGIN_ENV: Final[str] = "WHILLY_PUBLIC_ORIGIN"
+
+
+def _public_base_url(request: Request) -> str:
+    """Return the base URL for auth links, preferring the configured origin.
+
+    Building a magic-link URL from ``request.base_url`` trusts the client-
+    controlled ``Host`` header — a host-header-injection vector: an attacker can
+    trigger a link for a *victim's* email while spoofing ``Host: attacker.test``,
+    so the email the victim receives points at the attacker, who harvests the
+    valid single-use token when the victim clicks. ``WHILLY_PUBLIC_ORIGIN`` pins
+    the origin; we fall back to ``request.base_url`` only when it is unset (dev /
+    loopback), where the Host is not attacker-reachable.
+    """
+    configured = (os.environ.get(PUBLIC_ORIGIN_ENV) or "").strip().rstrip("/")
+    if configured:
+        return configured
+    return str(request.base_url).rstrip("/")
+
+
 def _build_magic_url(request: Request, token: str) -> str:
     """Construct the absolute /auth/magic URL emitted to the event log."""
-    base = str(request.base_url).rstrip("/")
+    base = _public_base_url(request)
     return f"{base}/auth/magic?token={urllib.parse.quote(token, safe='')}"
 
 
@@ -831,7 +853,12 @@ def _sanitise_next_path(raw: str) -> str:
     """Constrain ``?next=`` to local paths so /auth/magic cannot be an open redirect."""
     if not raw or not isinstance(raw, str):
         return "/"
-    if raw.startswith("//") or raw.startswith("\\\\"):
+    # Browsers fold backslashes to forward slashes, so "/\\evil.com" and
+    # "\\/evil.com" become protocol-relative "//evil.com" → open redirect.
+    # A legitimate local path never contains a backslash, so reject outright.
+    if "\\" in raw:
+        return "/"
+    if raw.startswith("//"):
         return "/"
     parsed = urllib.parse.urlparse(raw)
     if parsed.scheme or parsed.netloc:


### PR DESCRIPTION
Continuing the auth-hardening thread: a review of the **rest** of the auth surface (login / magic-link / change-password / sessions, beyond E15/E17). The token, session and CSRF primitives are **sound** — `hmac.compare_digest`, explicit `alg=HS256` (no alg-confusion), `typ`-claim separation, 256-bit session ids, atomic single-use magic-link consume, email-scoped session list, IDOR-guarded revoke. Two URL-handling weaknesses fixed:

### 🟠 Finding 5 (Medium) — host-header injection in magic links
`_build_magic_url` built the link from `request.base_url` (the client-controlled `Host`). An attacker requests a link for a **victim's** email while spoofing `Host: attacker.test` → the victim's email points at the attacker, who harvests the valid single-use token on click → **account takeover**. Fixed via `_public_base_url`: prefer `WHILLY_PUBLIC_ORIGIN` (already used by E15), fall back to `request.base_url` only when unset (dev/loopback).

### 🟡 Finding 7 (Low) — open redirect via backslash in `?next=`
Browsers fold `\`→`/`, so `/\evil.com` becomes protocol-relative `//evil.com`. `_sanitise_next_path` now rejects any path containing a backslash.

### Documented, not changed — Finding 6 (Low)
`POST /auth/change-password` rotates the password without the current password or a `must_change_password` gate — reachable only via **cookie theft** (not CSRF: SameSite=Strict + Origin allowlist; path not exempt). Recommended follow-up recorded in ADR-001 §P1.11; deferred because it touches the must-change-gate flow.

## Tests (+13 unit, CI-gated)
origin pinning + Host fallback; backslash / protocol-relative / absolute-url rejection; legit deep-link preserved.

Local: `2376 passed, 3 skipped`; ruff + import-linter (2/2) + mypy core green. Decisions in ADR-001 §P1.11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)