### PR TITLE
fix(auth): gate /auth/change-password to must_change_password (Finding 6)

### DIFF
--- a/docs/adr/ADR-001-auth-hardening-p1.md
+++ b/docs/adr/ADR-001-auth-hardening-p1.md
@@ -377,15 +377,17 @@ IDOR-guarded session revoke). Two URL-handling weaknesses were fixed:
   `\` to `/`, so `/\evil.com` becomes protocol-relative `//evil.com`.
   `_sanitise_next_path` now rejects any path containing a backslash.
 
-**Also noted, NOT changed here — Finding 6 (Low).** `POST /auth/change-password`
-(the forced first-login flow) requires an authenticated session but neither the
-current password nor `must_change_password=True`, so a session that was hijacked
-(cookie theft) or left open could rotate the password without the current one —
-the check `POST /me/password` enforces. It is *not* CSRF-exploitable (SameSite=
-Strict cookie + Origin allowlist; the path is not CSRF-exempt). Recommended
-follow-up: gate the forced path to `must_change_password=True`, else redirect to
-`/me/password`. Deferred because it touches the must-change-gate flow and is
-lower-risk than the URL fixes above.
+**Finding 6 (Low) — FIXED.** `POST /auth/change-password` (the forced first-login
+flow) sets a new password WITHOUT the current one. It required an authenticated
+session but neither the current password nor `must_change_password=True`, so a
+session that was hijacked (cookie theft) or left open could rotate the password
+without the current one — the check `POST /me/password` enforces. (Not CSRF-
+exploitable: SameSite=Strict cookie + Origin allowlist; the path is not CSRF-
+exempt.) The handler now reads the user row and proceeds only when
+`must_change_password=True`; any other session (or a missing user row) is
+redirected to `/me/password`, which requires the current password. The forced
+first-login flow is unchanged (bootstrap admin has the flag set). Verified by
+`tests/unit/test_change_password_gate.py`.
 
 ---
 

--- a/tests/unit/test_change_password_gate.py
+++ b/tests/unit/test_change_password_gate.py
@@ -1,0 +1,122 @@
+"""Unit tests for the /auth/change-password must-change gate (Finding 6).
+
+The forced-flow ``POST /auth/change-password`` sets a new password WITHOUT the
+current one. That is only acceptable while the account is genuinely in the
+must-change state; for any other session it must route to ``/me/password``
+(which requires the current password) so a hijacked/idle session cannot rotate
+the password. No Postgres — the DB call sites are monkeypatched (pool=None).
+"""
+
+from __future__ import annotations
+
+import datetime
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from whilly.api import auth_tokens, sessions, users_repo
+from whilly.api.auth_routes import build_auth_router
+from whilly.api.csrf import COOKIE_NAME
+
+_SECRET: bytes = b"f6-test-secret-32-bytes-paddingx"
+_SESSION_ID: str = "f6-session-id-abc123"
+_USERNAME: str = "alice"
+_EMAIL: str = f"{_USERNAME}@local"
+_NEW_PW: str = "new-strong-pw-12+"  # 17 chars, satisfies _MIN_PASSWORD_LENGTH
+
+
+def _session() -> Any:
+    class _S:
+        session_id = _SESSION_ID
+        email = _EMAIL
+        expires_at = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(hours=1)
+
+    return _S()
+
+
+def _user(*, must_change: bool) -> users_repo.User:
+    return users_repo.User(
+        username=_USERNAME,
+        email=None,
+        role="operator",
+        created_at=datetime.datetime.now(datetime.timezone.utc),
+        last_login_at=None,
+        must_change_password=must_change,
+    )
+
+
+def _cookie() -> str:
+    return auth_tokens.mint_session_cookie_value(_SECRET, session_id=_SESSION_ID, email=_EMAIL, ttl_seconds=3600)
+
+
+@pytest.fixture
+async def client() -> AsyncIterator[AsyncClient]:
+    app = FastAPI()
+    app.include_router(build_auth_router(pool=None, secret=_SECRET))  # type: ignore[arg-type]
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://127.0.0.1:8000") as ac:
+        yield ac
+
+
+async def _post(client: AsyncClient, *, with_cookie: bool) -> Any:
+    cookies = {COOKIE_NAME: _cookie()} if with_cookie else {}
+    return await client.post(
+        "/auth/change-password",
+        cookies=cookies,
+        data={"new_password": _NEW_PW, "confirm_new_password": _NEW_PW},
+        follow_redirects=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_proceeds_when_must_change_password_set(client: AsyncClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sessions, "verify_session", AsyncMock(return_value=_session()))
+    monkeypatch.setattr(users_repo, "get_user_by_username", AsyncMock(return_value=_user(must_change=True)))
+    set_pw = AsyncMock(return_value=None)
+    monkeypatch.setattr(users_repo, "set_password", set_pw)
+    resp = await _post(client, with_cookie=True)
+    assert resp.status_code == 303
+    assert resp.headers["location"] == "/"
+    set_pw.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_redirects_to_me_password_when_not_must_change(
+    client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(sessions, "verify_session", AsyncMock(return_value=_session()))
+    monkeypatch.setattr(users_repo, "get_user_by_username", AsyncMock(return_value=_user(must_change=False)))
+    set_pw = AsyncMock(return_value=None)
+    monkeypatch.setattr(users_repo, "set_password", set_pw)
+    resp = await _post(client, with_cookie=True)
+    assert resp.status_code == 303
+    assert resp.headers["location"] == "/me/password"
+    # The password was NOT rotated without the current one.
+    assert set_pw.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_redirects_when_user_row_missing(client: AsyncClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sessions, "verify_session", AsyncMock(return_value=_session()))
+    monkeypatch.setattr(users_repo, "get_user_by_username", AsyncMock(return_value=None))
+    set_pw = AsyncMock(return_value=None)
+    monkeypatch.setattr(users_repo, "set_password", set_pw)
+    resp = await _post(client, with_cookie=True)
+    assert resp.status_code == 303
+    assert resp.headers["location"] == "/me/password"
+    assert set_pw.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_unauthenticated_redirects_to_login(client: AsyncClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sessions, "verify_session", AsyncMock(return_value=None))
+    set_pw = AsyncMock(return_value=None)
+    monkeypatch.setattr(users_repo, "set_password", set_pw)
+    resp = await _post(client, with_cookie=False)
+    assert resp.status_code == 303
+    assert resp.headers["location"] == "/login"
+    assert set_pw.await_count == 0

--- a/whilly/api/auth_routes.py
+++ b/whilly/api/auth_routes.py
@@ -510,6 +510,20 @@ def build_auth_router(
             logger.warning("auth.change-password: could not resolve username from session email %r", session_email)
             return _render_error("Session error — please log out and log in again.")
 
+        # SECURITY (Finding 6): this forced-flow endpoint sets a password WITHOUT
+        # the current one — acceptable only while the account is actually in the
+        # must-change state (first login on a bootstrap/temp password). For any
+        # other session, route to /me/password, which requires the current
+        # password, so a hijacked or idle session cannot silently rotate it.
+        forced_user = await users_repo.get_user_by_username(pool, username=username)
+        if forced_user is None or not forced_user.must_change_password:
+            logger.info(
+                "auth.change-password: POST for username=%r without must_change_password set — "
+                "redirecting to /me/password (current password required there)",
+                username,
+            )
+            return RedirectResponse(url="/me/password", status_code=status.HTTP_303_SEE_OTHER)
+
         try:
             await users_repo.set_password(pool, username=username, new_password=new_password)
         except (ValueError, LookupError) as exc:


### PR DESCRIPTION
Closes the last open finding from the auth-surface review (recorded in ADR-001 §P1.11).

## Finding 6 (Low → fixed)
`POST /auth/change-password` (the forced first-login flow) sets a new password **without** the current one. It required an authenticated session but neither the current password nor `must_change_password=True`, so a **hijacked (cookie-theft) or idle** session could rotate the password without the current one — the check `/me/password` enforces. (Not CSRF-exploitable: SameSite=Strict + Origin allowlist; path not CSRF-exempt.)

## Fix
The handler reads the user row and proceeds **only** when `must_change_password=True`; any other session (or a missing user row) is redirected to `/me/password` (which requires the current password). The forced first-login flow is unchanged — the bootstrap admin has the flag set.

## Tests (+4 unit, CI-gated)
proceeds when `must_change` set; redirects to `/me/password` when not set / when the user row is missing; unauthenticated → `/login`.

Local: `2380 passed, 3 skipped`; ruff + import-linter (2/2) + mypy core green.

⚠️ **Note:** `tests/integration/test_post_auth_smoke.py` fails on this branch **and on clean `main`** (verified by checkout) — a **pre-existing, stateful-test flake** at `GET /` (a step *upstream* of this change), caused by the reused testcontainers DB + must-change-gate in-process cache across repeated local runs. Unrelated to this fix and **not CI-gated** (integration isn't run in CI). Flagged for a separate idempotency fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)