### PR TITLE
fix(auth): resolve session identity by email, not naive @local-strip (Finding 8)

### DIFF
--- a/docs/adr/ADR-001-auth-hardening-p1.md
+++ b/docs/adr/ADR-001-auth-hardening-p1.md
@@ -391,6 +391,41 @@ first-login flow is unchanged (bootstrap admin has the flag set). Verified by
 
 ---
 
+## P1.12 — Session-identity resolution (`<username>@local` vs real email, Finding 8)
+
+**Severity: Medium — found while making the post-auth smoke test pass.** Several
+auth call sites recovered the username from `sessions.email` by
+`removesuffix("@local")`. That works for password users with no email (the
+synthetic `<username>@local`), but **the seeded admin's email is the real
+`admin@whilly.local`** (migration 020). For it, the strip is a no-op, leaving
+`admin@whilly.local`, which has no `users` row — so:
+
+- the **must-change gate fail-opened** → the default `admin/admin` account was
+  never actually forced to change its password (it could navigate past the
+  one-time login redirect to any page); and
+- **both change-password endpoints broke** for the admin (`set_password` /
+  `verify_credentials` got a non-existent username) — the seeded admin literally
+  could not change its password through either flow.
+
+`submit_login` works because it has the `User` object directly; only the
+email→username *reconstruction* sites were affected.
+
+**Fix.** One canonical resolver, `users_repo.get_user_by_session_email`:
+`<username>@local` → strip + `get_user_by_username`; any other value →
+`get_user_by_email` (defensive `LIMIT 2`, exactly-one-match else `None`; a
+magic-link-only user with no row still → `None` → gate fail-open, which is
+correct). Routed through it: the must-change gate, `POST /auth/change-password`,
+and `POST /me/password`. Verified by the now-passing
+`tests/integration/test_post_auth_smoke.py` plus
+`tests/integration/test_user_email_resolution.py` (against the real seeded admin).
+
+> Note: `tests/integration/test_post_auth_smoke.py` also needed an explicit
+> `Origin` header on its change-password POST — a *test* gap (a browser sends
+> `Origin` on a same-origin form POST; the CSRF middleware is correct), not a
+> product issue.
+
+---
+
 ## References
 
 - PRD: [`docs/PRD-post-auth-hardening.md`](../PRD-post-auth-hardening.md)

--- a/tests/integration/test_post_auth_smoke.py
+++ b/tests/integration/test_post_auth_smoke.py
@@ -140,10 +140,14 @@ def test_post_auth_journey_login_change_password_tasks_audit(
         assert root_resp.status_code == 303
         assert "change-password" in (root_resp.headers.get("location") or "")
 
-        # Step 3 — submit the change-password form.
+        # Step 3 — submit the change-password form. A real browser sends an
+        # Origin header on a same-origin form POST; httpx does not by default,
+        # so set it explicitly or the CSRF middleware (correctly) rejects the
+        # cookie-authenticated POST with 403.
         cp_resp = client.post(
             "/auth/change-password",
             cookies={"whilly_session": cookie},
+            headers={"Origin": base},
             data={"new_password": _NEW_PASSWORD, "confirm_new_password": _NEW_PASSWORD},
         )
         assert cp_resp.status_code == 303, (

--- a/tests/integration/test_user_email_resolution.py
+++ b/tests/integration/test_user_email_resolution.py
@@ -1,0 +1,48 @@
+"""Integration tests for the session-identity resolver (post-E15 review, Finding 8).
+
+The seeded admin (migration 020) has a **real** email ``admin@whilly.local`` — not
+the ``<username>@local`` synthetic form. Several auth call sites used to recover
+the username by ``removesuffix("@local")``, which leaves ``admin@whilly.local``
+(no ``users`` row) — so the must-change gate silently bypassed enforcement for
+the admin and the admin could never change its password. ``get_user_by_session_email``
+is the single resolver that fixes all of them; these pins exercise it against the
+real seeded row.
+"""
+
+from __future__ import annotations
+
+import asyncpg
+import pytest
+
+from tests.conftest import DOCKER_REQUIRED
+from whilly.api import users_repo
+
+pytestmark = DOCKER_REQUIRED
+
+
+@pytest.mark.asyncio
+async def test_seeded_admin_resolves_by_real_email(db_pool: asyncpg.Pool) -> None:
+    # The exact bug: a real email must resolve to the admin row (was None before).
+    user = await users_repo.get_user_by_session_email(db_pool, session_email="admin@whilly.local")
+    assert user is not None
+    assert user.username == "admin"
+
+
+@pytest.mark.asyncio
+async def test_get_user_by_email_exact_match(db_pool: asyncpg.Pool) -> None:
+    user = await users_repo.get_user_by_email(db_pool, email="admin@whilly.local")
+    assert user is not None and user.username == "admin"
+
+
+@pytest.mark.asyncio
+async def test_synthetic_local_email_still_resolves_by_username(db_pool: asyncpg.Pool) -> None:
+    # The <username>@local path (password users with no email set) is unchanged.
+    user = await users_repo.get_user_by_session_email(db_pool, session_email="admin@local")
+    assert user is not None and user.username == "admin"
+
+
+@pytest.mark.asyncio
+async def test_unknown_identity_returns_none(db_pool: asyncpg.Pool) -> None:
+    # Magic-link-only user with no users row → None → gate fail-opens (correct).
+    assert await users_repo.get_user_by_session_email(db_pool, session_email="ghost@nowhere.example") is None
+    assert await users_repo.get_user_by_session_email(db_pool, session_email="ghost@local") is None

--- a/tests/unit/test_change_password_gate.py
+++ b/tests/unit/test_change_password_gate.py
@@ -75,7 +75,7 @@ async def _post(client: AsyncClient, *, with_cookie: bool) -> Any:
 @pytest.mark.asyncio
 async def test_proceeds_when_must_change_password_set(client: AsyncClient, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(sessions, "verify_session", AsyncMock(return_value=_session()))
-    monkeypatch.setattr(users_repo, "get_user_by_username", AsyncMock(return_value=_user(must_change=True)))
+    monkeypatch.setattr(users_repo, "get_user_by_session_email", AsyncMock(return_value=_user(must_change=True)))
     set_pw = AsyncMock(return_value=None)
     monkeypatch.setattr(users_repo, "set_password", set_pw)
     resp = await _post(client, with_cookie=True)
@@ -89,7 +89,7 @@ async def test_redirects_to_me_password_when_not_must_change(
     client: AsyncClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setattr(sessions, "verify_session", AsyncMock(return_value=_session()))
-    monkeypatch.setattr(users_repo, "get_user_by_username", AsyncMock(return_value=_user(must_change=False)))
+    monkeypatch.setattr(users_repo, "get_user_by_session_email", AsyncMock(return_value=_user(must_change=False)))
     set_pw = AsyncMock(return_value=None)
     monkeypatch.setattr(users_repo, "set_password", set_pw)
     resp = await _post(client, with_cookie=True)
@@ -100,14 +100,16 @@ async def test_redirects_to_me_password_when_not_must_change(
 
 
 @pytest.mark.asyncio
-async def test_redirects_when_user_row_missing(client: AsyncClient, monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_session_error_when_user_unresolvable(client: AsyncClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    # The session authenticated, but the identity does not resolve to a users
+    # row (deleted user / magic-link-only). Treat as a session error rather than
+    # bouncing to /me/password (which would also fail to resolve). No write.
     monkeypatch.setattr(sessions, "verify_session", AsyncMock(return_value=_session()))
-    monkeypatch.setattr(users_repo, "get_user_by_username", AsyncMock(return_value=None))
+    monkeypatch.setattr(users_repo, "get_user_by_session_email", AsyncMock(return_value=None))
     set_pw = AsyncMock(return_value=None)
     monkeypatch.setattr(users_repo, "set_password", set_pw)
     resp = await _post(client, with_cookie=True)
-    assert resp.status_code == 303
-    assert resp.headers["location"] == "/me/password"
+    assert resp.status_code == 422
     assert set_pw.await_count == 0
 
 

--- a/tests/unit/test_me_password_routes.py
+++ b/tests/unit/test_me_password_routes.py
@@ -97,6 +97,16 @@ def patched_set_password(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
     return mock
 
 
+@pytest.fixture(autouse=True)
+def _patched_session_user(monkeypatch: pytest.MonkeyPatch) -> None:
+    """submit_me_password resolves the user via ``get_user_by_session_email``
+    before checking the current password (so the seeded admin's real email
+    round-trips — Finding 8). Default it to the test user so the pool=None mock
+    harness never dereferences a real connection; reaching tests then drive the
+    ``verify_credentials`` mock as before."""
+    monkeypatch.setattr(users_repo, "get_user_by_session_email", AsyncMock(return_value=_make_user()))
+
+
 @pytest.fixture
 async def client() -> AsyncIterator[AsyncClient]:
     """A minimal app wired with build_auth_router + no CSRF (POST tests need to

--- a/tests/unit/test_must_change_gate.py
+++ b/tests/unit/test_must_change_gate.py
@@ -97,21 +97,21 @@ def patched_sessions(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
 
 @pytest.fixture
 def patched_users_must_change(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
-    """Patch ``users_repo.get_user_by_username`` to return a must-change user."""
+    """Patch the gate's user resolver to return a must-change user."""
     mock = AsyncMock(return_value=_make_user(must_change=True))
-    # The gate imports the function directly into its own namespace, so
+    # The gate imports the resolver directly into its own namespace, so
     # patching the module-level binding inside ``must_change_gate`` is
-    # required — patching ``users_repo.get_user_by_username`` alone would
+    # required — patching ``users_repo.get_user_by_session_email`` alone would
     # not redirect the call site inside ``_lookup_must_change``.
-    monkeypatch.setattr(must_change_gate, "get_user_by_username", mock)
+    monkeypatch.setattr(must_change_gate, "get_user_by_session_email", mock)
     return mock
 
 
 @pytest.fixture
 def patched_users_ok(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
-    """Patch ``users_repo.get_user_by_username`` to return a no-must-change user."""
+    """Patch the gate's user resolver to return a no-must-change user."""
     mock = AsyncMock(return_value=_make_user(must_change=False))
-    monkeypatch.setattr(must_change_gate, "get_user_by_username", mock)
+    monkeypatch.setattr(must_change_gate, "get_user_by_session_email", mock)
     return mock
 
 
@@ -210,7 +210,7 @@ async def test_invalidate_session_clears_cache_after_password_change(
     returns must_change=False and the request to / is served (200).
     """
     user_mock = AsyncMock(side_effect=[_make_user(must_change=True), _make_user(must_change=False)])
-    monkeypatch.setattr(must_change_gate, "get_user_by_username", user_mock)
+    monkeypatch.setattr(must_change_gate, "get_user_by_session_email", user_mock)
     cookie = _mint_cookie()
 
     # First request — cache miss, returns the must_change=True user → 303.
@@ -322,7 +322,7 @@ async def test_user_not_found_passes_through(
     monkeypatch: pytest.MonkeyPatch,
     patched_sessions: AsyncMock,
 ) -> None:
-    monkeypatch.setattr(must_change_gate, "get_user_by_username", AsyncMock(return_value=None))
+    monkeypatch.setattr(must_change_gate, "get_user_by_session_email", AsyncMock(return_value=None))
     cookie = _mint_cookie()
     response = await client.get("/", cookies={COOKIE_NAME: cookie}, follow_redirects=False)
     assert response.status_code == 200

--- a/whilly/api/auth_routes.py
+++ b/whilly/api/auth_routes.py
@@ -501,22 +501,24 @@ def build_auth_router(
         if len(new_password) < _MIN_PASSWORD_LENGTH:
             return _render_error(f"Password must be at least {_MIN_PASSWORD_LENGTH} characters.")
 
-        # Extract username from the session email.  The email stored in the
-        # sessions table is either the real email or the ``<username>@local``
-        # synthetic address produced by submit_login.
+        # Resolve the user from the session identity via the single canonical
+        # resolver. Critically this handles a real email (e.g. the seeded admin
+        # ``admin@whilly.local``) — a naive removesuffix("@local") leaves the full
+        # email, which has no ``users`` row, so the admin could never change its
+        # password here (Finding 8).
         session_email: str = str(principal.get("email", ""))
-        username = session_email.removesuffix("@local") if session_email.endswith("@local") else session_email
-        if not username:
-            logger.warning("auth.change-password: could not resolve username from session email %r", session_email)
+        forced_user = await users_repo.get_user_by_session_email(pool, session_email=session_email)
+        if forced_user is None:
+            logger.warning("auth.change-password: could not resolve user from session email %r", session_email)
             return _render_error("Session error — please log out and log in again.")
+        username = forced_user.username
 
         # SECURITY (Finding 6): this forced-flow endpoint sets a password WITHOUT
         # the current one — acceptable only while the account is actually in the
         # must-change state (first login on a bootstrap/temp password). For any
         # other session, route to /me/password, which requires the current
         # password, so a hijacked or idle session cannot silently rotate it.
-        forced_user = await users_repo.get_user_by_username(pool, username=username)
-        if forced_user is None or not forced_user.must_change_password:
+        if not forced_user.must_change_password:
             logger.info(
                 "auth.change-password: POST for username=%r without must_change_password set — "
                 "redirecting to /me/password (current password required there)",
@@ -618,16 +620,19 @@ def build_auth_router(
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             )
 
-        # Resolve the username from the session — same @local-strip logic as
-        # the forced-flow endpoint above.
+        # Resolve the user from the session via the canonical resolver — handles
+        # both ``<username>@local`` and a real email (e.g. the seeded admin),
+        # which a naive removesuffix("@local") would mangle so the admin could
+        # never self-service change its password (Finding 8).
         session_email: str = str(principal.get("email", ""))
-        username = session_email.removesuffix("@local") if session_email.endswith("@local") else session_email
-        if not username:
+        session_user = await users_repo.get_user_by_session_email(pool, session_email=session_email)
+        if session_user is None:
             logger.warning(
-                "me.password: could not resolve username from session email %r",
+                "me.password: could not resolve user from session email %r",
                 session_email,
             )
             return _render_error("Session error — please log out and log in again.")
+        username = session_user.username
 
         # Validate the *current* password first. This is the key difference
         # from the forced /auth/change-password endpoint. verify_credentials

--- a/whilly/api/must_change_gate.py
+++ b/whilly/api/must_change_gate.py
@@ -63,7 +63,7 @@ from starlette.types import ASGIApp
 
 from whilly.api import auth_tokens, sessions
 from whilly.api.csrf import COOKIE_NAME, _HOST_PREFIX_COOKIE_NAME
-from whilly.api.users_repo import get_user_by_username
+from whilly.api.users_repo import get_user_by_session_email
 
 logger = logging.getLogger(__name__)
 
@@ -153,24 +153,6 @@ def _extract_session_id(request: Request, *, secret: bytes, cookie_name: str) ->
     return sid
 
 
-def _session_email_to_username(session_email: str) -> str:
-    """Recover the username from a ``sessions.email`` value.
-
-    The username+password login path synthesises ``<username>@local`` as
-    the ``sessions.email`` value (see
-    :mod:`whilly.api.auth_routes.submit_login`); the magic-link path
-    stores a real email. The username PK CHECK constraint
-    (``^[a-z0-9][a-z0-9_-]{0,63}$``) means a real email never round-trips
-    through :func:`get_user_by_username` — those users have no row in
-    ``users`` at all, so the lookup returns ``None`` and the gate
-    fail-opens. The synthetic case is the one that matters: strip
-    ``@local`` and recover the original username.
-    """
-    if session_email.endswith("@local"):
-        return session_email.removesuffix("@local")
-    return session_email
-
-
 class MustChangePasswordGateMiddleware(BaseHTTPMiddleware):
     """Redirect every cookie-authenticated request to the change-password
     form while the signed-in user has ``must_change_password=True``.
@@ -243,19 +225,25 @@ class MustChangePasswordGateMiddleware(BaseHTTPMiddleware):
             return False
         if session is None:
             return False
-        username = _session_email_to_username(session.email)
+        # Resolve the user via the single canonical resolver, which handles both
+        # the synthetic ``<username>@local`` and a real email (e.g. the seeded
+        # admin ``admin@whilly.local``, whose email does NOT round-trip to a
+        # username). Resolving real emails is what stops the gate silently
+        # bypassing must-change for that account; a magic-link user with no
+        # ``users`` row still resolves to None → fail-open (correct).
         try:
-            user = await get_user_by_username(self._pool, username=username)
+            user = await get_user_by_session_email(self._pool, session_email=session.email)
         except Exception:  # noqa: BLE001 — gate must never crash the request
             logger.warning(
-                "must_change_gate: get_user_by_username raised for %r — fail-open",
-                username,
+                "must_change_gate: user lookup raised for session email %r — fail-open",
+                session.email,
                 exc_info=True,
             )
             return False
         if user is None:
-            # Magic-link user with no ``users`` row, or stale session whose
-            # user has been deleted. Pass through; downstream handlers cope.
+            # Magic-link user with no ``users`` row, ambiguous email, or stale
+            # session whose user has been deleted. Pass through; downstream
+            # handlers cope.
             return False
         return bool(user.must_change_password)
 

--- a/whilly/api/users_repo.py
+++ b/whilly/api/users_repo.py
@@ -76,6 +76,65 @@ async def get_user_by_username(pool: asyncpg.Pool, *, username: str) -> User | N
         )
 
 
+async def get_user_by_email(pool: asyncpg.Pool, *, email: str) -> User | None:
+    """Return the ``User`` whose ``email`` matches exactly, or ``None``.
+
+    ``users.email`` is nullable and NOT unique, so this is defensive: it uses
+    ``LIMIT 2`` and returns ``None`` unless there is exactly one match (zero or
+    ambiguous → ``None``). Used by the must-change gate to resolve a session
+    whose ``email`` is a real address that does not round-trip to a username
+    (e.g. the seeded admin ``admin@whilly.local``); without it the gate would
+    fail-open and silently stop enforcing must-change for that account.
+    """
+    if not isinstance(email, str) or not email.strip():
+        return None
+    normalised = email.strip()
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            """
+            SELECT username, email, role, created_at, last_login_at, must_change_password
+            FROM users WHERE email = $1
+            LIMIT 2
+            """,
+            normalised,
+        )
+    if len(rows) != 1:
+        return None
+    row = rows[0]
+    return User(
+        username=row["username"],
+        email=row["email"],
+        role=row["role"],
+        created_at=row["created_at"],
+        last_login_at=row["last_login_at"],
+        must_change_password=bool(row["must_change_password"]),
+    )
+
+
+async def get_user_by_session_email(pool: asyncpg.Pool, *, session_email: str) -> User | None:
+    """Resolve the ``User`` from a ``sessions.email`` value, or ``None``.
+
+    The username+password login stores the synthetic ``<username>@local`` as the
+    session email; the magic-link path and a password user with a real email set
+    (e.g. the seeded admin ``admin@whilly.local``) store a real address. The
+    single canonical resolver for "who is this session?":
+
+    * ``<username>@local`` → strip and look up by username;
+    * any other value      → look up by email (``None`` if no/ambiguous row,
+                              which is the correct fail-open for magic-link-only
+                              users that have no ``users`` row).
+
+    Centralising this is what stopped several auth call sites (must-change gate,
+    both change-password endpoints) from naively ``removesuffix("@local")`` —
+    which silently broke for every user whose email was not ``<username>@local``.
+    """
+    if not isinstance(session_email, str) or not session_email:
+        return None
+    if session_email.endswith("@local"):
+        return await get_user_by_username(pool, username=session_email.removesuffix("@local"))
+    return await get_user_by_email(pool, email=session_email)
+
+
 async def verify_credentials(pool: asyncpg.Pool, *, username: str, password: str) -> User | None:
     """Validate ``username``/``password`` and return the ``User`` on success.
 
@@ -425,6 +484,8 @@ __all__ = [
     "User",
     "create_user",
     "delete_user",
+    "get_user_by_email",
+    "get_user_by_session_email",
     "get_user_by_username",
     "is_account_locked",
     "list_users",


### PR DESCRIPTION
**Found while making the post-auth smoke test pass — and it's a Medium product bug, not a test flake.**

## The bug
Several auth sites recovered the username from `sessions.email` via `removesuffix("@local")`. That works for the synthetic `<username>@local`, but the **seeded admin's email is the real `admin@whilly.local`** (migration 020) — the strip is a no-op, leaving a value with no `users` row. Consequences:

- **Must-change gate fail-opened** → the default `admin/admin` was never actually forced to change its password (it could navigate past the one-time login redirect to any page).
- **Both change-password endpoints broke** for the admin (`set_password` / `verify_credentials` got a non-existent username) — the admin literally **could not change its password** through either flow.

`submit_login` was fine (it holds the `User` object directly); only the email→username *reconstruction* sites were affected.

## Fix
One canonical resolver `users_repo.get_user_by_session_email`:
- `<username>@local` → strip + `get_user_by_username`;
- any other value → `get_user_by_email` (defensive `LIMIT 2`, exactly-one-match else `None`; a magic-link-only user with no row → `None` → gate fail-open, which is correct).

Routed through it: the **must-change gate**, **`POST /auth/change-password`**, **`POST /me/password`**. Removed the dead `_session_email_to_username` helper (it encoded the buggy assumption).

## Tests
- Unit: `must_change_gate` / `change-password-gate` / `me-password` updated to mock the resolver.
- Integration: new `test_user_email_resolution.py` (against the **real seeded admin**); **`test_post_auth_smoke.py` now passes** end-to-end (it also needed an explicit `Origin` on its change-password POST — a *test* gap, not a product issue: a browser sends `Origin` on a same-origin form POST and the CSRF middleware is correct).

Local: `2380 passed, 3 skipped`; ruff + import-linter (2/2) + mypy core green. Decision in ADR-001 §P1.12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)