### PR TITLE
fix(security): flatten task_id at tmux/verifier path sinks (traversal write)

### DIFF
--- a/tests/unit/test_task_id_validation.py
+++ b/tests/unit/test_task_id_validation.py
@@ -18,7 +18,7 @@ import pytest
 
 from whilly.adapters.filesystem.plan_io import PlanParseError, parse_plan, parse_plan_dict
 from whilly.cli import validate_schema
-from whilly.core.task_id import validate_task_id
+from whilly.core.task_id import safe_task_id_filename, validate_task_id
 from whilly.task_manager import Task as LegacyTask
 
 
@@ -90,6 +90,44 @@ def test_validate_task_id_rejects_empty_string() -> None:
 def test_validate_task_id_rejects_non_string() -> None:
     with pytest.raises(ValueError, match="must be a string"):
         validate_task_id(42)
+
+
+# ── safe_task_id_filename: path/session sink hardening ───────────────────────
+#
+# validate_task_id permits '/' and ':' (hierarchical / namespaced ids), so the
+# file-path + tmux-session sinks must flatten them — otherwise a leading-slash id
+# escapes the log dir (arbitrary write) and 'a/b' references a missing subdir.
+
+
+@pytest.mark.parametrize(
+    ("task_id", "expected"),
+    [
+        ("EORD-9509", "EORD-9509"),  # real ids round-trip unchanged (no-op)
+        ("TASK-001", "TASK-001"),
+        ("epic.subepic/leaf", "epic.subepic_leaf"),  # hierarchical → flat
+        ("0123:abc", "0123_abc"),  # ':' confuses tmux target syntax
+        ("/etc/cron.d/evil", "etc_cron.d_evil"),  # absolute → no leading sep, no '/'
+        ("a/b/c", "a_b_c"),
+    ],
+)
+def test_safe_task_id_filename_flattens(task_id: str, expected: str) -> None:
+    assert safe_task_id_filename(task_id) == expected
+
+
+@pytest.mark.parametrize("task_id", ["/etc/cron.d/evil", "a/b/c", "epic.subepic/leaf", "0123:abc", "../x", ".."])
+def test_safe_task_id_filename_never_escapes_base(task_id: str) -> None:
+    base = Path("/var/whilly_logs")
+    # The result must be a single path component that stays strictly under base.
+    safe = safe_task_id_filename(task_id)
+    assert "/" not in safe
+    resolved = (base / f"{safe}.log").resolve()
+    assert str(resolved).startswith(str(base.resolve()) + "/")
+
+
+def test_safe_task_id_filename_falls_back_on_empty_result() -> None:
+    # An id that is all separators flattens to empty → deterministic fallback.
+    assert safe_task_id_filename("..") == "task"
+    assert safe_task_id_filename("///") == "task"
 
 
 # ── legacy Task.from_dict (whilly/task_manager.py) ────────────────────────

--- a/tests/unit/test_tmux_runner_quoting.py
+++ b/tests/unit/test_tmux_runner_quoting.py
@@ -218,3 +218,48 @@ def test_backend_name_with_metacharacter_does_not_execute(tmp_path: Path) -> Non
     )
 
     assert not canary.exists(), "canary file created — backend.name metacharacters executed despite shlex.quote"
+
+
+def test_slashed_task_id_stays_inside_log_dir(tmp_path: Path) -> None:
+    """A task id containing '/' must be flattened so its prompt/log files land
+    inside log_dir and the tmux session name carries no path separator.
+
+    Without the sink-side ``safe_task_id_filename`` flatten, ``log_dir /
+    f"{task_id}.log"`` for a hierarchical id like ``a/b/c`` references a missing
+    subdir (write crashes), and a leading-slash id escapes log_dir entirely.
+    """
+    from whilly import tmux_runner
+
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+
+    captured: list[list[str]] = []
+
+    def fake_run(cmd, *args, **kwargs):
+        captured.append(list(cmd))
+        result = MagicMock()
+        result.returncode = 0
+        return result
+
+    with (
+        patch.object(tmux_runner, "TMUX", "/usr/bin/tmux"),
+        patch.object(tmux_runner.subprocess, "run", side_effect=fake_run),
+    ):
+        agent = tmux_runner.launch_agent(
+            task_id="a/b/c",
+            prompt="hi",
+            model="m",
+            log_dir=log_dir,
+            cwd=None,
+            backend=_FakeBackend(),
+        )
+
+    # Session name flattened — no '/' that would confuse tmux targeting.
+    assert agent.session_name == "whilly-a_b_c"
+    new_session = [c for c in captured if len(c) >= 2 and c[1] == "new-session"][-1]
+    assert new_session[4] == "whilly-a_b_c"
+    # The prompt + log files were written INSIDE log_dir, flattened — not into a
+    # (non-existent) a/b/ subdir and not anywhere outside log_dir.
+    assert (log_dir / "a_b_c_prompt.txt").exists()
+    assert agent.log_file == log_dir / "a_b_c.log"
+    assert not (log_dir / "a").exists()  # no subdir was created/escaped

--- a/whilly/core/task_id.py
+++ b/whilly/core/task_id.py
@@ -21,10 +21,16 @@ from __future__ import annotations
 
 import re
 
-__all__ = ["VALID_TASK_ID_RE", "validate_task_id"]
+__all__ = ["VALID_TASK_ID_RE", "safe_task_id_filename", "validate_task_id"]
 
 
 VALID_TASK_ID_RE = re.compile(r"^[A-Za-z0-9._:/-]+$")
+
+#: Characters that are unsafe in a *filesystem path component* or a *tmux session
+#: target*. ``validate_task_id`` deliberately permits ``/`` (hierarchical ids like
+#: ``epic.subepic/leaf``) and ``:`` (namespaced ids like ``0123:abc``), but those
+#: must NOT survive into a filename or session name — see :func:`safe_task_id_filename`.
+_UNSAFE_FILENAME_RE = re.compile(r"[^A-Za-z0-9_.-]+")
 
 
 def validate_task_id(task_id: object) -> str:
@@ -52,3 +58,30 @@ def validate_task_id(task_id: object) -> str:
             f"task id {task_id!r} contains forbidden characters; must match ^[A-Za-z0-9._:/-]+$",
         )
     return task_id
+
+
+def safe_task_id_filename(task_id: str) -> str:
+    """Flatten a task id into a single path/session-safe component.
+
+    :func:`validate_task_id` blocks shell metacharacters and ``..`` traversal but
+    deliberately permits ``/`` (hierarchical ids, e.g. ``epic.subepic/leaf``) and
+    ``:`` (namespaced ids, e.g. ``0123:abc``). Those are unsafe the moment an id is
+    interpolated into a filename or a tmux target:
+
+    * a leading ``/`` makes ``log_dir / f"{id}.log"`` resolve to an **absolute**
+      path (pathlib joins an absolute right-hand operand by discarding the base),
+      so a crafted id like ``/etc/cron.d/x`` escapes ``log_dir`` entirely — an
+      arbitrary-location write primitive;
+    * any ``/`` makes ``log_dir / f"{id}.log"`` reference a non-existent subdir,
+      so even the *legitimate* hierarchical ``epic.subepic/leaf`` crashes the
+      writer; and
+    * ``:`` confuses tmux's ``session:window.pane`` target syntax.
+
+    Replace every character outside ``[A-Za-z0-9_.-]`` with ``_`` and strip
+    leading/trailing ``._`` (so a leading slash can't leave a leading separator).
+    Mirrors :func:`whilly.llm_ops._safe_part` and the worktree slugifier so the
+    whole codebase flattens ids identically. Self-contained — safe even if the id
+    was never run through :func:`validate_task_id`.
+    """
+    safe = _UNSAFE_FILENAME_RE.sub("_", str(task_id)).strip("._")
+    return safe or "task"

--- a/whilly/tmux_runner.py
+++ b/whilly/tmux_runner.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from whilly.agents.base import spawn_with_eagain_retry
+from whilly.core.task_id import safe_task_id_filename
 
 log = logging.getLogger("whilly")
 
@@ -101,12 +102,18 @@ def launch_agent(
         backend = active_backend_from_env()
 
     log_dir.mkdir(parents=True, exist_ok=True)
-    log_file = log_dir / f"{task_id}.log"
-    session_name = f"whilly-{task_id}"
+    # task.id may legitimately contain '/' or ':' (hierarchical / namespaced ids);
+    # flatten to a safe single component before using it as a filename or tmux
+    # target so a crafted id like '/etc/cron.d/x' cannot escape log_dir, and so
+    # 'epic.subepic/leaf' does not reference a non-existent subdir. See
+    # whilly.core.task_id.safe_task_id_filename.
+    safe_id = safe_task_id_filename(task_id)
+    log_file = log_dir / f"{safe_id}.log"
+    session_name = f"whilly-{safe_id}"
 
     _tmux_run([TMUX, "kill-session", "-t", session_name], capture_output=True)
 
-    prompt_file = log_dir / f"{task_id}_prompt.txt"
+    prompt_file = log_dir / f"{safe_id}_prompt.txt"
     prompt_file.write_text(prompt)
 
     log_file_q = shlex.quote(str(log_file))

--- a/whilly/verifier.py
+++ b/whilly/verifier.py
@@ -14,6 +14,8 @@ import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
+from whilly.core.task_id import safe_task_id_filename
+
 log = logging.getLogger("whilly.verifier")
 
 
@@ -237,7 +239,9 @@ def verify_task(
 
     if log_dir:
         log_dir.mkdir(parents=True, exist_ok=True)
-        log_file = log_dir / f"{task_id}_verify.log"
+        # Flatten the id so a crafted '/abs' or hierarchical 'a/b' id cannot
+        # escape / miss log_dir (see whilly.core.task_id.safe_task_id_filename).
+        log_file = log_dir / f"{safe_task_id_filename(task_id)}_verify.log"
         with open(log_file, "w") as f:
             f.write(f"Task: {task_id}\nPassed: {passed}\n\n")
             f.write(f"=== LINT (ok={lint_ok}) ===\n{lint_out}\n\n")


### PR DESCRIPTION
Agent-exec / prompt-injection review.

## Surface verdict
- **Prompt injection: already mitigated.** External text (Jira / GitHub issues / PRD gen / decision gate / …) is guard-wrapped via `whilly.security.prompt_sanitizer` across **12 sites**; `tmux_runner` passes the prompt to the CLI via a **file + `"$(cat …)"`** command substitution, so task content never enters the shell source (and command-substitution output isn't re-evaluated). No `shell=True` / `os.system` anywhere; all subprocess calls use argv lists.
- **Worker-auth (prior turn): clean.** **Operator-auth: 8 findings fixed.**

## The one real gap (this PR)
`validate_task_id` deliberately permits `/` (hierarchical ids like `epic.subepic/leaf`) and `:` (namespaced `a:b`), but **`tmux_runner` + `verifier` interpolated the raw id into write paths** (`log_dir / f"{task_id}.log"`, `f"{task_id}_prompt.txt"`, `f"{task_id}_verify.log"`) and the tmux session name:
- a leading-slash id (`/etc/cron.d/x`) makes pathlib discard the base → **escapes `log_dir`** → arbitrary-location write of a `*.log`/`*_prompt.txt` file;
- even the legitimate hierarchical id crashes the writer (missing subdir);
- `:` confuses tmux's `session:window` target.

`llm_ops._safe_part` and `worktree_runner` already flatten ids — these two sinks didn't.

## Fix
Shared `whilly.core.task_id.safe_task_id_filename` (`[^A-Za-z0-9_.-]+ → _`, strip `._`, fallback) applied at `tmux_runner` (log/prompt/session) and `verifier`. **No-op for every real id** (all 208 across the plan files are slash-free) — behaviour unchanged; closes the traversal write and makes hierarchical ids actually work.

## Tests (+~11 unit, CI-gated)
`safe_task_id_filename` flatten / never-escapes-base / fallback; a `tmux_runner` test proving `a/b/c` lands inside `log_dir` with a separator-free session name.

Local: `2394 passed, 3 skipped`; ruff + import-linter (2/2) + mypy core green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)