### PR TITLE
fix: resolve OpenSpec spec-quality audit findings (1 HIGH, 3 MEDIUM, 2 LOW)

### DIFF
--- a/openspec/changes/archive/2026-06-18-fix-agent-dispatch-tmux-drift/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-18-fix-agent-dispatch-tmux-drift/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-18

--- a/openspec/changes/archive/2026-06-18-fix-agent-dispatch-tmux-drift/README.md
+++ b/openspec/changes/archive/2026-06-18-fix-agent-dispatch-tmux-drift/README.md
@@ -1,0 +1,3 @@
+# fix-agent-dispatch-tmux-drift
+
+Correct agent-dispatch spec: tmux runner-selection is legacy/unwired; live path is subprocess-only

--- a/openspec/changes/archive/2026-06-18-fix-agent-dispatch-tmux-drift/proposal.md
+++ b/openspec/changes/archive/2026-06-18-fix-agent-dispatch-tmux-drift/proposal.md
@@ -1,0 +1,39 @@
+# Proposal: Correct agent-dispatch tmux runner-selection drift
+
+## Why
+
+A spec-quality audit (32 capability specs vs live code) found one HIGH spec↔code
+drift in `agent-dispatch`: the "Runner selection between tmux and subprocess"
+requirement asserts the system selects the tmux-session runner when tmux is
+available **and** `WHILLY_USE_TMUX` is enabled. The live dispatch path can never
+exhibit this:
+
+- `whilly/cli/run.py` and `whilly/cli/worker.py` wire only the subprocess runner
+  `whilly.adapters.runner.run_task`; there is no tmux branch.
+- No live module imports `tmux_runner.launch_agent` for selection or reads
+  `WHILLY_USE_TMUX`; tmux appears only in signal-handling comments and one
+  docstring.
+- `WHILLY_USE_TMUX` is a documented parsed-but-inert no-op (`whilly/config.py`).
+
+The dependent "One tmux session per task" requirement is internally accurate
+against `tmux_runner.py` but only reachable via the dead selection path.
+
+This is spec-only drift (the code is correct; the spec overstated a guarantee).
+The fix corrects the spec to describe reality, mirroring how `worktree-isolation`
+and `decomposition` already mark their legacy/unwired code.
+
+## What Changes
+
+- **MODIFIED** `agent-dispatch` → "Runner selection between tmux and subprocess":
+  the live path is subprocess-only; tmux runner + `WHILLY_USE_TMUX` are
+  legacy/unwired and SHALL NOT be selected.
+- **MODIFIED** `agent-dispatch` → "One tmux session per task": reframed as the
+  legacy `tmux_runner` contract, explicitly not wired into the live run path.
+
+No `whilly/` behavior change — this aligns the spec with existing behavior.
+
+## Impact
+
+- Specs: `agent-dispatch` (2 requirements reframed).
+- Code: none.
+- Coverage matrix: unchanged (no module remapping).

--- a/openspec/changes/archive/2026-06-18-fix-agent-dispatch-tmux-drift/specs/agent-dispatch/spec.md
+++ b/openspec/changes/archive/2026-06-18-fix-agent-dispatch-tmux-drift/specs/agent-dispatch/spec.md
@@ -1,0 +1,41 @@
+## MODIFIED Requirements
+
+### Requirement: Runner selection between tmux and subprocess
+The system SHALL dispatch every agent in the live run path (`whilly/cli/run.py`
+and `whilly/cli/worker.py`) through the subprocess runner
+(`whilly.adapters.runner.run_task`, the Claude CLI wrapper). The tmux-session
+runner (`tmux_runner.launch_agent`) and the `USE_TMUX` flag (`WHILLY_USE_TMUX`)
+are **legacy and unwired**: no live dispatch path imports the tmux runner for
+runner selection or reads `WHILLY_USE_TMUX`, and `WHILLY_USE_TMUX` is a
+parsed-but-inert no-op (see configuration). The system SHALL NOT select the
+tmux runner in the live path.
+
+#### Scenario: Live dispatch always uses the subprocess runner
+- **WHEN** the local worker (`whilly/cli/run.py`) or remote worker
+  (`whilly/cli/worker.py`) dispatches a task to its runner
+- **THEN** the system SHALL invoke `whilly.adapters.runner.run_task` and SHALL
+  NOT launch a tmux session
+
+#### Scenario: USE_TMUX does not select a tmux runner
+- **WHEN** `WHILLY_USE_TMUX` is set in the environment
+- **THEN** the system SHALL dispatch agents identically to when it is unset,
+  because `WHILLY_USE_TMUX` is a no-op and no live path consults it for runner
+  selection
+
+### Requirement: One tmux session per task
+The legacy `tmux_runner` module SHALL name each tmux agent session
+`whilly-{task_id}` using the flattened safe task id and MUST run exactly one
+agent session per task, killing any pre-existing session of the same name
+before launch. This behavior is **not wired into the live run path** — neither
+the local nor the remote worker invokes `tmux_runner.launch_agent` — and it
+applies only when `tmux_runner.launch_agent` is called directly.
+
+#### Scenario: Session name derived from task id
+- **WHEN** `tmux_runner.launch_agent` is invoked directly for a task
+- **THEN** the session name SHALL be `whilly-` followed by the safe-flattened
+  task id produced by `safe_task_id_filename`
+
+#### Scenario: Stale session replaced before launch
+- **WHEN** a tmux session named `whilly-{task_id}` already exists at launch
+- **THEN** the legacy runner SHALL kill that session before starting the new one
+  so exactly one session per task remains

--- a/openspec/changes/archive/2026-06-18-fix-agent-dispatch-tmux-drift/tasks.md
+++ b/openspec/changes/archive/2026-06-18-fix-agent-dispatch-tmux-drift/tasks.md
@@ -1,0 +1,6 @@
+# Tasks
+
+- [x] Author MODIFIED delta for the two drifted `agent-dispatch` requirements
+- [x] `openspec change validate fix-agent-dispatch-tmux-drift` passes (strict)
+- [ ] Archive into baseline: `openspec archive fix-agent-dispatch-tmux-drift`
+- [ ] Confirm `openspec validate --all --strict` still 32/0 after archive

--- a/openspec/changes/archive/2026-06-18-fix-self-healing-traceback-scenario/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-18-fix-self-healing-traceback-scenario/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-18

--- a/openspec/changes/archive/2026-06-18-fix-self-healing-traceback-scenario/README.md
+++ b/openspec/changes/archive/2026-06-18-fix-self-healing-traceback-scenario/README.md
@@ -1,0 +1,3 @@
+# fix-self-healing-traceback-scenario
+
+Correct recovery-self-healing: global handler prints full traceback only when no auto-fix was applied

--- a/openspec/changes/archive/2026-06-18-fix-self-healing-traceback-scenario/proposal.md
+++ b/openspec/changes/archive/2026-06-18-fix-self-healing-traceback-scenario/proposal.md
@@ -1,0 +1,23 @@
+# Proposal: Correct recovery-self-healing traceback scenario
+
+## Why
+
+A spec-quality audit found a LOW spec↔code inaccuracy in `recovery-self-healing`.
+The "Global exception hook installation" scenario states the handler "SHALL print
+the full formatted traceback afterward" unconditionally. The code
+(`whilly/self_healing.py:238-250`) returns early after a successful `apply_fix`,
+printing a restart notice instead of the traceback. The module is legacy/unwired,
+so impact is nil, but the scenario is inaccurate.
+
+## What Changes
+
+- **MODIFIED** `recovery-self-healing` → "Global exception hook installation":
+  traceback is printed only when no auto-fix was applied; a successful fix prints
+  a restart notice and returns early. Split into two scenarios accordingly.
+
+No `whilly/` behavior change — this aligns the spec with existing behavior.
+
+## Impact
+
+- Specs: `recovery-self-healing` (1 requirement, 1→2 scenarios).
+- Code: none.

--- a/openspec/changes/archive/2026-06-18-fix-self-healing-traceback-scenario/specs/recovery-self-healing/spec.md
+++ b/openspec/changes/archive/2026-06-18-fix-self-healing-traceback-scenario/specs/recovery-self-healing/spec.md
@@ -1,0 +1,19 @@
+## MODIFIED Requirements
+
+### Requirement: Global exception hook installation
+The system SHALL, via `global_exception_handler`, run analyze-then-apply on an
+uncaught exception, and SHALL print the full formatted traceback EXCEPT when
+`apply_fix` succeeds — in which case it SHALL print a restart notice and return
+early without printing the traceback. `enable_self_healing` SHALL install
+`global_exception_handler` as `sys.excepthook`.
+
+#### Scenario: handler prints full traceback when no fix is applied
+- **WHEN** `global_exception_handler` is invoked for an uncaught exception and
+  `apply_fix` returns `False` (or no `CodeError` is classified)
+- **THEN** the system SHALL attempt `analyze_error` and `apply_fix`
+- **AND** SHALL print the full formatted traceback afterward
+
+#### Scenario: handler returns early after a successful auto-fix
+- **WHEN** `global_exception_handler` is invoked and `apply_fix` returns `True`
+- **THEN** the system SHALL print a restart notice and return early
+- **AND** SHALL NOT print the full formatted traceback

--- a/openspec/specs/agent-dispatch/spec.md
+++ b/openspec/specs/agent-dispatch/spec.md
@@ -9,46 +9,46 @@ permission posture of the spawned agent, and the retry/auth handling around a
 single agent invocation. It does NOT cover the workspace/worktree directory
 layout (see worktree-isolation), result parsing (see result-collection), or
 the task state machine (see task-model-fsm).
-
 ## Requirements
-
 ### Requirement: Runner selection between tmux and subprocess
-The system SHALL dispatch an agent via the tmux-session runner when tmux is
-available on the host AND the `USE_TMUX` flag (`WHILLY_USE_TMUX`) is enabled,
-and MUST fall back to the subprocess runner (the `run_task` Claude CLI wrapper)
-in all other cases.
+The system SHALL dispatch every agent in the live run path (`whilly/cli/run.py`
+and `whilly/cli/worker.py`) through the subprocess runner
+(`whilly.adapters.runner.run_task`, the Claude CLI wrapper). The tmux-session
+runner (`tmux_runner.launch_agent`) and the `USE_TMUX` flag (`WHILLY_USE_TMUX`)
+are **legacy and unwired**: no live dispatch path imports the tmux runner for
+runner selection or reads `WHILLY_USE_TMUX`, and `WHILLY_USE_TMUX` is a
+parsed-but-inert no-op (see configuration). The system SHALL NOT select the
+tmux runner in the live path.
 
-#### Scenario: tmux available and USE_TMUX enabled
-- **WHEN** an agent is dispatched and `tmux_runner.tmux_available()` returns
-  true and `WHILLY_USE_TMUX` is enabled
-- **THEN** the system SHALL launch the agent in a tmux session via
-  `tmux_runner.launch_agent`
+#### Scenario: Live dispatch always uses the subprocess runner
+- **WHEN** the local worker (`whilly/cli/run.py`) or remote worker
+  (`whilly/cli/worker.py`) dispatches a task to its runner
+- **THEN** the system SHALL invoke `whilly.adapters.runner.run_task` and SHALL
+  NOT launch a tmux session
 
-#### Scenario: tmux unavailable
-- **WHEN** an agent is dispatched and `tmux_runner.tmux_available()` returns
-  false
-- **THEN** the system SHALL dispatch the agent through the subprocess runner
-  (`whilly.adapters.runner.run_task`) instead of a tmux session
-
-#### Scenario: USE_TMUX disabled
-- **WHEN** an agent is dispatched while `WHILLY_USE_TMUX` is disabled
-- **THEN** the system SHALL NOT create a tmux session and SHALL use the
-  subprocess runner
+#### Scenario: USE_TMUX does not select a tmux runner
+- **WHEN** `WHILLY_USE_TMUX` is set in the environment
+- **THEN** the system SHALL dispatch agents identically to when it is unset,
+  because `WHILLY_USE_TMUX` is a no-op and no live path consults it for runner
+  selection
 
 ### Requirement: One tmux session per task
-The system SHALL name each tmux agent session `whilly-{task_id}` using the
-flattened safe task id, and MUST run exactly one agent session per task,
-killing any pre-existing session of the same name before launch.
+The legacy `tmux_runner` module SHALL name each tmux agent session
+`whilly-{task_id}` using the flattened safe task id and MUST run exactly one
+agent session per task, killing any pre-existing session of the same name
+before launch. This behavior is **not wired into the live run path** — neither
+the local nor the remote worker invokes `tmux_runner.launch_agent` — and it
+applies only when `tmux_runner.launch_agent` is called directly.
 
 #### Scenario: Session name derived from task id
-- **WHEN** `tmux_runner.launch_agent` launches an agent for a task
+- **WHEN** `tmux_runner.launch_agent` is invoked directly for a task
 - **THEN** the session name SHALL be `whilly-` followed by the safe-flattened
   task id produced by `safe_task_id_filename`
 
 #### Scenario: Stale session replaced before launch
 - **WHEN** a tmux session named `whilly-{task_id}` already exists at launch
-- **THEN** the system SHALL kill that session before starting the new one so
-  exactly one session per task remains
+- **THEN** the legacy runner SHALL kill that session before starting the new one
+  so exactly one session per task remains
 
 ### Requirement: Dispatched agent receives the built prompt
 The system SHALL pass each dispatched agent the prompt produced by
@@ -131,3 +131,4 @@ returning them immediately.
   failure
 - **THEN** the system SHALL return that result immediately without consuming
   any retry attempt
+

--- a/openspec/specs/recovery-self-healing/spec.md
+++ b/openspec/specs/recovery-self-healing/spec.md
@@ -11,9 +11,7 @@ mechanism is the visibility-timeout sweep `release_stale_tasks` (with optimistic
 locking) documented in the `state-persistence` capability; this spec marks the two
 modules legacy in the same manner that `state-persistence` marks the v3 StateStore
 legacy, and it does NOT assert progress-file recovery as the live v4 recovery path.
-
 ## Requirements
-
 ### Requirement: File-based done-status recovery
 The system SHALL reconstruct completed task IDs in `recover_task_statuses` by unioning IDs parsed from `progress.txt` lines of the form `[id] DONE` with IDs from per-task `whilly_logs/*.log` files whose content contains `COMPLETION_MARKER` (preferring a valid `{"type":"result"}` JSON line with `is_error` False), SHALL flip matching non-done legacy `TaskManager` tasks to `done`, SHALL persist only when at least one status changed, and SHALL return a change dict mapping each affected task ID to `"<old> → done"`.
 
@@ -61,16 +59,22 @@ The system SHALL, in `SelfHealingHandler.apply_fix`, act only on NameError (logg
 - **THEN** the system SHALL return `False` and SHALL NOT modify any files
 
 ### Requirement: Global exception hook installation
-The system SHALL, via `global_exception_handler`, run analyze-then-apply on an uncaught exception and then print the full traceback, and `enable_self_healing` SHALL install `global_exception_handler` as `sys.excepthook`.
+The system SHALL, via `global_exception_handler`, run analyze-then-apply on an
+uncaught exception, and SHALL print the full formatted traceback EXCEPT when
+`apply_fix` succeeds — in which case it SHALL print a restart notice and return
+early without printing the traceback. `enable_self_healing` SHALL install
+`global_exception_handler` as `sys.excepthook`.
 
-#### Scenario: handler analyzes then prints full traceback
-- **WHEN** `global_exception_handler` is invoked for an uncaught exception
+#### Scenario: handler prints full traceback when no fix is applied
+- **WHEN** `global_exception_handler` is invoked for an uncaught exception and
+  `apply_fix` returns `False` (or no `CodeError` is classified)
 - **THEN** the system SHALL attempt `analyze_error` and `apply_fix`
 - **AND** SHALL print the full formatted traceback afterward
 
-#### Scenario: enable installs the hook
-- **WHEN** `enable_self_healing` is called
-- **THEN** the system SHALL set `sys.excepthook` to `global_exception_handler`
+#### Scenario: handler returns early after a successful auto-fix
+- **WHEN** `global_exception_handler` is invoked and `apply_fix` returns `True`
+- **THEN** the system SHALL print a restart notice and return early
+- **AND** SHALL NOT print the full formatted traceback
 
 ### Requirement: Legacy status and live recovery reference
 The system SHALL treat `whilly/recovery.py` and `whilly/self_healing.py` as legacy modules that are NOT wired into the v4 Postgres worker-claim path (zero callers), and the live stale-task recovery contract SHALL be `release_stale_tasks` (the visibility-timeout sweep with optimistic locking) defined in the `state-persistence` capability.
@@ -82,3 +86,4 @@ The system SHALL treat `whilly/recovery.py` and `whilly/self_healing.py` as lega
 #### Scenario: live recovery emits visibility-timeout release
 - **WHEN** an aged-out CLAIMED or IN_PROGRESS row is recovered in v4
 - **THEN** the authoritative behavior SHALL be the `state-persistence` `release_stale_tasks` sweep that returns the row to PENDING under optimistic locking
+

--- a/tests/test_jira_full_cycle.py
+++ b/tests/test_jira_full_cycle.py
@@ -416,3 +416,41 @@ def test_status_mapping_override(monkeypatch, _jira_env):
     client = JiraBoardClient(JiraAuth.from_config(), status_mapping={"in_progress": "Doing"})
     assert client.status_mapping["in_progress"] == "Doing"
     assert client.status_mapping["done"] == DEFAULT_JIRA_STATUS_MAPPING["done"]
+
+
+def test_board_api_sends_bearer_header_under_bearer_scheme(monkeypatch):
+    """Regression: the mutating board path must honour auth_scheme like the read
+    path does — a bearer/PAT config must NOT be sent as Basic."""
+    from whilly import jira_board as board_mod
+
+    captured: dict = {}
+
+    def fake_urlopen(req, timeout=None):
+        captured["authorization"] = req.get_header("Authorization")
+        return _FakeResponse(b'{"transitions": []}')
+
+    monkeypatch.setattr(board_mod, "urlopen", fake_urlopen)
+    client = JiraBoardClient(
+        JiraAuth(server_url="https://jira.example.test", username="", token="pat-token", auth_scheme="bearer")
+    )
+    client._fetch_transitions("ABC-1")
+    assert captured["authorization"] == "Bearer pat-token"
+
+
+def test_board_paths_honour_configured_api_version(monkeypatch):
+    """Regression: the mutating board path must use [jira].api_version, not a
+    hardcoded v3 (Jira Server/DC commonly run v2)."""
+    from whilly import jira_board as board_mod
+
+    captured: dict = {}
+
+    def fake_urlopen(req, timeout=None):
+        captured["url"] = req.full_url
+        return _FakeResponse(b'{"transitions": []}')
+
+    monkeypatch.setattr(board_mod, "urlopen", fake_urlopen)
+    client = JiraBoardClient(
+        JiraAuth(server_url="https://jira.example.test", username="qa", token="token", api_version="2")
+    )
+    client._fetch_transitions("ABC-1")
+    assert captured["url"] == "https://jira.example.test/rest/api/2/issue/ABC-1/transitions"

--- a/tests/test_workflow_github.py
+++ b/tests/test_workflow_github.py
@@ -548,3 +548,46 @@ class TestAddStatus:
         sent_names = [opt["name"] for opt in sent]
         assert sent_names == ["Todo", "A", "B"]
         assert all("id" not in opt for opt in sent)
+
+
+# ── gh subprocess env propagation (spec: every gh subprocess uses gh_subprocess_env) ──
+
+
+class TestGraphqlUsesGhSubprocessEnv:
+    """Regression: `_graphql` must build its subprocess env via
+    `gh_subprocess_env`, so a stale ambient GITHUB_TOKEN is overridden by
+    WHILLY_GH_TOKEN (the github-integration spec asserts this holds for every
+    gh CLI subprocess; the GraphQL path used to bypass it)."""
+
+    def _status_response(self):
+        return {
+            "data": {
+                "user": {
+                    "projectV2": {
+                        "id": "PVT_xxx",
+                        "title": "Backlog",
+                        "fields": {"nodes": [{"id": "PVTSSF", "name": "Status", "options": []}]},
+                    }
+                }
+            }
+        }
+
+    def test_env_overrides_stale_github_token(self):
+        import os
+
+        board = GitHubProjectBoard(url="https://github.com/users/x/projects/4", gh_bin="/usr/bin/gh")
+        fake_run, _ = _fake_run([self._status_response()])
+        captured = {}
+
+        def run_capture(cmd, *args, **kwargs):
+            captured["env"] = kwargs.get("env")
+            return fake_run(cmd, *args, **kwargs)
+
+        env_patch = {"GITHUB_TOKEN": "stale-ambient", "WHILLY_GH_TOKEN": "whilly-good"}
+        with patch.dict(os.environ, env_patch, clear=False):
+            with patch("whilly.workflow.github.subprocess.run", side_effect=run_capture):
+                board.list_statuses()
+
+        assert captured["env"] is not None, "_graphql must pass an explicit env (gh_subprocess_env)"
+        assert captured["env"]["GITHUB_TOKEN"] == "whilly-good"
+        assert "GH_TOKEN" not in captured["env"]

--- a/whilly/cli/init.py
+++ b/whilly/cli/init.py
@@ -9,7 +9,7 @@ the v4 Postgres-backed plan storage:
    ``docs/PRD-<slug>.md`` either way.
 3. **Plan import** — ``prd_generator.generate_tasks_dict`` builds the
    payload in-memory, ``plan_io.parse_plan_dict`` validates it, and
-   ``cli.plan._insert_plan_and_tasks`` does the batched INSERT — same
+   ``cli.plan._async_import`` does the transactional INSERT — the same
    helper that ``whilly plan import`` uses, so the v4 import surface
    stays single-sourced.
 

--- a/whilly/jira_board.py
+++ b/whilly/jira_board.py
@@ -131,14 +131,23 @@ class JiraBoardClient:
 
     # ── Internals ────────────────────────────────────────────────────────────
 
+    def _rest_path(self, resource: str) -> str:
+        """Build a Jira REST path honouring the configured API version.
+
+        Mirrors the read path's ``whilly.sources.jira._jira_rest_path`` so the
+        mutating board-sync path applies ``[jira].api_version`` instead of
+        hardcoding v3 (Jira Server/DC commonly run the v2 API).
+        """
+        return f"/rest/api/{self.auth.api_version}/{resource.lstrip('/')}"
+
     def _fetch_transitions(self, key: str) -> list[dict]:
-        data = self._api("GET", f"/rest/api/3/issue/{key}/transitions")
+        data = self._api("GET", self._rest_path(f"issue/{key}/transitions"))
         return list(data.get("transitions") or [])
 
     def _post_transition(self, key: str, transition_id: str) -> None:
         self._api(
             "POST",
-            f"/rest/api/3/issue/{key}/transitions",
+            self._rest_path(f"issue/{key}/transitions"),
             payload={"transition": {"id": transition_id}},
             expect_empty=True,
         )
@@ -153,13 +162,19 @@ class JiraBoardClient:
         expect_empty: bool = False,
     ) -> dict:
         url = f"{self.auth.server_url}{path}"
-        header = base64.b64encode(f"{self.auth.username}:{self.auth.token}".encode("utf-8")).decode("ascii")
+        # Honour the configured auth scheme, mirroring the read path
+        # (whilly.sources.jira): a bearer/PAT config must NOT be sent as Basic.
+        if self.auth.auth_scheme == "bearer":
+            authorization = f"Bearer {self.auth.token}"
+        else:
+            header = base64.b64encode(f"{self.auth.username}:{self.auth.token}".encode("utf-8")).decode("ascii")
+            authorization = f"Basic {header}"
         data = json.dumps(payload).encode("utf-8") if payload is not None else None
         req = Request(
             url,
             data=data,
             headers={
-                "Authorization": f"Basic {header}",
+                "Authorization": authorization,
                 "Accept": "application/json",
                 **({"Content-Type": "application/json"} if data else {}),
             },

--- a/whilly/sinks/gitlab_mr.py
+++ b/whilly/sinks/gitlab_mr.py
@@ -212,7 +212,9 @@ def open_mr_for_task(
 
     Steps:
     1. Resolve branch name (default ``whilly/{task.id}``).
-    2. ``git push origin HEAD:{branch} --force-with-lease``
+    2. ``git push origin HEAD:{branch} --force`` (plain ``--force``; see the
+       inline comment at the push site for why ``--force-with-lease`` is wrong
+       on a fresh worktree)
     3. ``glab mr create --target-branch {base} --source-branch {branch}
          --title ... --description-file ...``
 

--- a/whilly/workflow/github.py
+++ b/whilly/workflow/github.py
@@ -32,6 +32,7 @@ import subprocess
 from dataclasses import dataclass
 from typing import Any
 
+from whilly.gh_utils import gh_subprocess_env
 from whilly.workflow.base import BoardStatus
 
 log = logging.getLogger("whilly.workflow.github")
@@ -255,6 +256,7 @@ class GitHubProjectBoard:
                 capture_output=True,
                 text=True,
                 check=False,
+                env=gh_subprocess_env(),
             )
         else:
             cmd = [self._gh_path(), "api", "graphql", "-f", f"query={query}"]
@@ -263,7 +265,7 @@ class GitHubProjectBoard:
                     cmd.extend(["-F", f"{key}={val}"])
                 else:
                     cmd.extend(["-f", f"{key}={val}"])
-            proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+            proc = subprocess.run(cmd, capture_output=True, text=True, check=False, env=gh_subprocess_env())
 
         if proc.returncode != 0:
             raise RuntimeError(f"gh api graphql failed: {proc.stderr.strip() or proc.stdout.strip()}")


### PR DESCRIPTION
## Summary

Follow-up to the v1.4 drift-guard: a spec-quality audit of all **32 OpenSpec capability specs vs live code** found drift the mechanical CI gate cannot catch (semantic fidelity, not coverage/validity). This PR resolves the actionable findings. **Stacked on `feat/spec-drift-guard-v1.4` (#321)** — review/merge that first.

Audit result: 25/32 specs clean; 1 HIGH, 4 MEDIUM, 6 LOW. `auth-security` and the full control-plane verified exactly.

## Code bugs (write paths drifted from read paths — now conform to existing spec)

- **github** `GitHubProjectBoard._graphql`: now builds its subprocess env via `gh_subprocess_env()` (both `gh api graphql` calls). A stale ambient `GITHUB_TOKEN` is now overridden by `WHILLY_GH_TOKEN` — the exact failure mode hit creating #321.
- **jira_board** `JiraBoardClient`: now honours `auth.api_version` (was hardcoded `/rest/api/3/`) and `auth.auth_scheme` (was Basic-only). Bearer/PAT configs and Jira Server/DC v2 deployments now work on the mutating board-sync path.
- 3 new regression tests pin the above. No spec delta needed — these conform code to guarantees the specs already assert.

## Spec corrections (opsx propose→archive; no `whilly/` behavior change)

- **agent-dispatch (HIGH):** runner-selection requirement described a dead tmux path (`WHILLY_USE_TMUX` is a no-op; live path is subprocess-only). Corrected to subprocess-only; tmux runner marked legacy/unwired. Archived: `2026-06-18-fix-agent-dispatch-tmux-drift`.
- **recovery-self-healing (LOW):** global handler prints the full traceback only when no auto-fix was applied (successful fix returns early). Archived: `2026-06-18-fix-self-healing-traceback-scenario`.

## Pure-docs LOW fixes (exempt from delta)

- `gitlab_mr.py` docstring `--force-with-lease` → `--force` (matches code + inline rationale).
- `cli/init.py` docstring: inserter uses `parse_plan_dict` + `_async_import`, not the non-existent `_insert_plan_and_tasks`.

## Verification

- `openspec validate --all --strict` → **32/0**
- coverage audit → **275/275**, 0 unmapped
- github + jira tests → 68 pass + 3 new; ruff clean
- Full-batch failures confirmed pre-existing (identical with/without this diff via stash comparison) — DB-dependent integration tests + order-dependent state leakage

Remaining marginal LOWs (terse but accurate spec wording) reviewed and accepted without churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)